### PR TITLE
[OpenClaw v4] #29 自主授權邊界

### DIFF
--- a/src/openclaw/authority.py
+++ b/src/openclaw/authority.py
@@ -1,0 +1,259 @@
+"""Authority Boundary Engine (v4 #29).
+
+Implements Level 0-3 authorization boundary with Level 3 forbidden categories.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import json
+from datetime import datetime
+from typing import Dict, Any, Optional, List
+from enum import IntEnum
+
+
+class AuthorityLevel(IntEnum):
+    """Authorization levels (0-3)."""
+    LEVEL_0 = 0  # Observe only, no actions
+    LEVEL_1 = 1  # Log only, no real actions
+    LEVEL_2 = 2  # Can propose, requires human approval
+    LEVEL_3 = 3  # Can auto-approve non-sensitive categories
+
+
+# Level 3 forbidden categories (must have human approval)
+# Aligns with proposal_engine.LEVEL3_FORBIDDEN_CATEGORIES
+LEVEL3_FORBIDDEN_CATEGORIES = {
+    "stop_loss_logic",
+    "position_sizing",
+    "symbol_universe",
+    "live_mode_switch",
+    "monthly_drawdown_limit",
+    "risk_parameters",
+}
+
+
+class AuthorityEngine:
+    """Manages authorization boundaries."""
+    
+    def __init__(self, db_path: Optional[str] = None):
+        """Initialize with optional database path."""
+        self.db_path = db_path or "data/sqlite/trades.db"
+        
+    def _get_conn(self) -> sqlite3.Connection:
+        """Get database connection."""
+        return sqlite3.connect(self.db_path)
+    
+    def get_current_level(self) -> AuthorityLevel:
+        """Get current authority level from database."""
+        conn = self._get_conn()
+        try:
+            # Check if authority_policy table exists
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='authority_policy'"
+            )
+            if cursor.fetchone() is None:
+                # Table doesn't exist, default to LEVEL_2
+                return AuthorityLevel.LEVEL_2
+            
+            # Get current level
+            row = conn.execute(
+                "SELECT level, effective_from FROM authority_policy WHERE id = 1"
+            ).fetchone()
+            
+            if row is None:
+                # No policy set, default to LEVEL_2
+                return AuthorityLevel.LEVEL_2
+            
+            level, effective_from = row
+            try:
+                return AuthorityLevel(int(level))
+            except (ValueError, TypeError):
+                return AuthorityLevel.LEVEL_2
+        finally:
+            conn.close()
+    
+    def set_level(self, level: AuthorityLevel, changed_by: str, reason: str) -> bool:
+        """Set authority level (requires audit log)."""
+        conn = self._get_conn()
+        try:
+            # Ensure table exists
+            self._ensure_table_exists(conn)
+            
+            # Update level
+            now = datetime.utcnow().isoformat()
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO authority_policy (id, level, changed_by, reason, effective_from, updated_at)
+                VALUES (1, ?, ?, ?, ?, ?)
+                """,
+                (level.value, changed_by, reason, now, now)
+            )
+            
+            # Create audit log
+            conn.execute(
+                """
+                INSERT INTO authority_audit_log (old_level, new_level, changed_by, reason, changed_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (self.get_current_level().value, level.value, changed_by, reason, now)
+            )
+            
+            conn.commit()
+            return True
+        except Exception as e:
+            print(f"Error setting authority level: {e}")
+            return False
+        finally:
+            conn.close()
+    
+    def can_propose(self) -> bool:
+        """Check if system can propose changes."""
+        level = self.get_current_level()
+        return level >= AuthorityLevel.LEVEL_2
+    
+    def can_auto_approve(self, rule_category: str) -> bool:
+        """
+        Check if system can auto-approve a proposal.
+        
+        Requirements:
+        1. Level must be LEVEL_3
+        2. Rule category must NOT be in LEVEL3_FORBIDDEN_CATEGORIES
+        """
+        level = self.get_current_level()
+        
+        if level != AuthorityLevel.LEVEL_3:
+            return False
+        
+        if rule_category in LEVEL3_FORBIDDEN_CATEGORIES:
+            return False
+        
+        return True
+    
+    def check_proposal_authorization(self, proposal_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Check authorization for a proposal.
+        
+        Returns:
+            {
+                "allowed": bool,
+                "level": int,
+                "requires_human_approval": bool,
+                "reason_code": str,
+                "reason": str
+            }
+        """
+        current_level = self.get_current_level()
+        
+        # Level 0 or 1 cannot propose
+        if current_level <= AuthorityLevel.LEVEL_1:
+            return {
+                "allowed": False,
+                "level": current_level.value,
+                "requires_human_approval": True,
+                "reason_code": "AUTH_LEVEL_TOO_LOW",
+                "reason": f"Current level {current_level.value} cannot propose changes"
+            }
+        
+        # Extract rule category
+        rule_category = proposal_data.get("rule_category", "")
+        
+        # Check if auto-approval is possible
+        if self.can_auto_approve(rule_category):
+            return {
+                "allowed": True,
+                "level": current_level.value,
+                "requires_human_approval": False,
+                "reason_code": "AUTH_AUTO_APPROVE_ALLOWED",
+                "reason": f"Level {current_level.value} can auto-approve non-sensitive category"
+            }
+        
+        # Level 2 or Level 3 with forbidden category requires human approval
+        return {
+            "allowed": True,
+            "level": current_level.value,
+            "requires_human_approval": True,
+            "reason_code": "AUTH_MANUAL_REQUIRED",
+            "reason": f"Category '{rule_category}' requires human approval"
+        }
+    
+    def get_audit_log(self, limit: int = 50) -> List[Dict[str, Any]]:
+        """Get authority change audit log."""
+        conn = self._get_conn()
+        try:
+            # Check if audit table exists
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='authority_audit_log'"
+            )
+            if cursor.fetchone() is None:
+                return []
+            
+            rows = conn.execute(
+                """
+                SELECT old_level, new_level, changed_by, reason, changed_at
+                FROM authority_audit_log
+                ORDER BY changed_at DESC
+                LIMIT ?
+                """,
+                (limit,)
+            ).fetchall()
+            
+            return [
+                {
+                    "old_level": row[0],
+                    "new_level": row[1],
+                    "changed_by": row[2],
+                    "reason": row[3],
+                    "changed_at": row[4]
+                }
+                for row in rows
+            ]
+        finally:
+            conn.close()
+    
+    def _ensure_table_exists(self, conn: sqlite3.Connection) -> None:
+        """Ensure authority tables exist."""
+        # Create authority_policy table
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS authority_policy (
+                id INTEGER PRIMARY KEY,
+                level INTEGER NOT NULL,
+                changed_by TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                effective_from TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        """)
+        
+        # Create authority_audit_log table
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS authority_audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                old_level INTEGER NOT NULL,
+                new_level INTEGER NOT NULL,
+                changed_by TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                changed_at TEXT NOT NULL
+            )
+        """)
+        
+        conn.commit()
+
+
+# Backward compatibility function for proposal_engine.py
+def get_authority_level(conn: sqlite3.Connection) -> int:
+    """Backward compatibility function for existing code."""
+    engine = AuthorityEngine()
+    return engine.get_current_level().value
+
+
+if __name__ == "__main__":
+    print("Authority Boundary Engine (v4 #29)")
+    print("Supports Level 0-3 authorization with Level 3 guardrails")
+    
+    # Test
+    engine = AuthorityEngine()
+    level = engine.get_current_level()
+    print(f"Current level: {level} ({level.value})")
+    print(f"Can propose: {engine.can_propose()}")
+    print(f"Can auto-approve 'entry_parameters': {engine.can_auto_approve('entry_parameters')}")
+    print(f"Can auto-approve 'stop_loss_logic': {engine.can_auto_approve('stop_loss_logic')}")

--- a/tests/test_v4_29_authority_boundary.py
+++ b/tests/test_v4_29_authority_boundary.py
@@ -1,0 +1,220 @@
+"""Test Authority Boundary (v4 #29)."""
+
+import pytest
+import sqlite3
+import tempfile
+import os
+from datetime import datetime, timedelta
+
+
+def test_authority_level_enum():
+    """Test AuthorityLevel enum values."""
+    from openclaw.authority import AuthorityLevel
+    
+    assert AuthorityLevel.LEVEL_0.value == 0
+    assert AuthorityLevel.LEVEL_1.value == 1
+    assert AuthorityLevel.LEVEL_2.value == 2
+    assert AuthorityLevel.LEVEL_3.value == 3
+
+
+def test_level3_forbidden_categories():
+    """Test Level 3 forbidden categories match proposal engine."""
+    from openclaw.authority import LEVEL3_FORBIDDEN_CATEGORIES
+    
+    forbidden = {"stop_loss_logic", "position_sizing", "symbol_universe", 
+                 "live_mode_switch", "monthly_drawdown_limit", "risk_parameters"}
+    assert LEVEL3_FORBIDDEN_CATEGORIES == forbidden
+
+
+def test_engine_init():
+    """Test authority engine initialization."""
+    from openclaw.authority import AuthorityEngine
+    
+    engine = AuthorityEngine()
+    assert engine.db_path == "data/sqlite/trades.db"
+    
+    # Test with custom path
+    engine2 = AuthorityEngine(":memory:")
+    assert engine2.db_path == ":memory:"
+
+
+def test_get_current_level_default():
+    """Test getting default authority level when no table exists."""
+    from openclaw.authority import AuthorityEngine, AuthorityLevel
+    
+    # Use temporary file
+    with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+        db_path = f.name
+    
+    try:
+        engine = AuthorityEngine(db_path)
+        level = engine.get_current_level()
+        
+        # Default should be LEVEL_2
+        assert level == AuthorityLevel.LEVEL_2
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_set_and_get_level():
+    """Test setting and getting authority level."""
+    from openclaw.authority import AuthorityEngine, AuthorityLevel
+    
+    # Use temporary file
+    with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+        db_path = f.name
+    
+    try:
+        engine = AuthorityEngine(db_path)
+        
+        # Initial default
+        level = engine.get_current_level()
+        assert level == AuthorityLevel.LEVEL_2
+        
+        # Set to LEVEL_3
+        success = engine.set_level(
+            level=AuthorityLevel.LEVEL_3,
+            changed_by="pm",
+            reason="Testing level upgrade"
+        )
+        
+        assert success is True
+        
+        # Verify new level
+        new_level = engine.get_current_level()
+        assert new_level == AuthorityLevel.LEVEL_3
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+def test_can_propose():
+    """Test can_propose method."""
+    from openclaw.authority import AuthorityEngine, AuthorityLevel
+    
+    engine = AuthorityEngine(":memory:")
+    
+    # Mock different levels
+    def mock_level(level):
+        engine.get_current_level = lambda: level
+        return engine
+    
+    # Level 0 cannot propose
+    engine_l0 = mock_level(AuthorityLevel.LEVEL_0)
+    assert engine_l0.can_propose() is False
+    
+    # Level 1 cannot propose
+    engine_l1 = mock_level(AuthorityLevel.LEVEL_1)
+    assert engine_l1.can_propose() is False
+    
+    # Level 2 can propose
+    engine_l2 = mock_level(AuthorityLevel.LEVEL_2)
+    assert engine_l2.can_propose() is True
+    
+    # Level 3 can propose
+    engine_l3 = mock_level(AuthorityLevel.LEVEL_3)
+    assert engine_l3.can_propose() is True
+
+
+def test_can_auto_approve():
+    """Test can_auto_approve method."""
+    from openclaw.authority import AuthorityEngine, AuthorityLevel
+    
+    engine = AuthorityEngine(":memory:")
+    
+    # Mock different levels
+    def mock_level(level):
+        engine.get_current_level = lambda: level
+        return engine
+    
+    # Level 2 cannot auto-approve even non-sensitive
+    engine_l2 = mock_level(AuthorityLevel.LEVEL_2)
+    assert engine_l2.can_auto_approve("entry_parameters") is False
+    assert engine_l2.can_auto_approve("stop_loss_logic") is False
+    
+    # Level 3 can auto-approve non-sensitive
+    engine_l3 = mock_level(AuthorityLevel.LEVEL_3)
+    assert engine_l3.can_auto_approve("entry_parameters") is True
+    
+    # Level 3 cannot auto-approve forbidden categories
+    assert engine_l3.can_auto_approve("stop_loss_logic") is False
+    assert engine_l3.can_auto_approve("position_sizing") is False
+
+
+def test_check_proposal_authorization():
+    """Test proposal authorization checks."""
+    from openclaw.authority import AuthorityEngine, AuthorityLevel
+    
+    engine = AuthorityEngine(":memory:")
+    
+    # Mock level 2
+    engine.get_current_level = lambda: AuthorityLevel.LEVEL_2
+    
+    # Level 2 with non-sensitive category
+    result = engine.check_proposal_authorization({
+        "rule_category": "entry_parameters"
+    })
+    
+    assert result["allowed"] is True
+    assert result["level"] == 2
+    assert result["requires_human_approval"] is True
+    assert result["reason_code"] == "AUTH_MANUAL_REQUIRED"
+    
+    # Mock level 3
+    engine.get_current_level = lambda: AuthorityLevel.LEVEL_3
+    
+    # Level 3 with non-sensitive category
+    result = engine.check_proposal_authorization({
+        "rule_category": "entry_parameters"
+    })
+    
+    assert result["allowed"] is True
+    assert result["level"] == 3
+    assert result["requires_human_approval"] is False
+    assert result["reason_code"] == "AUTH_AUTO_APPROVE_ALLOWED"
+    
+    # Level 3 with forbidden category
+    result = engine.check_proposal_authorization({
+        "rule_category": "stop_loss_logic"
+    })
+    
+    assert result["allowed"] is True
+    assert result["level"] == 3
+    assert result["requires_human_approval"] is True
+    assert result["reason_code"] == "AUTH_MANUAL_REQUIRED"
+
+
+def test_get_audit_log():
+    """Test getting authority audit log."""
+    from openclaw.authority import AuthorityEngine, AuthorityLevel
+    
+    # Use temporary file
+    with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+        db_path = f.name
+    
+    try:
+        engine = AuthorityEngine(db_path)
+        
+        # Initially empty
+        log = engine.get_audit_log()
+        assert log == []
+        
+        # Set level a few times
+        engine.set_level(AuthorityLevel.LEVEL_3, "pm", "Upgrade for testing")
+        engine.set_level(AuthorityLevel.LEVEL_2, "critic", "Downgrade due to risk")
+        
+        # Get audit log
+        log = engine.get_audit_log()
+        
+        assert len(log) == 2
+        assert log[0]["new_level"] == 2  # Most recent first
+        assert log[0]["changed_by"] == "critic"
+        assert log[1]["new_level"] == 3
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 實作內容
- 實作 Level 0-3 授權等級：
  - Level 0：僅觀察，無任何操作權
  - Level 1：僅記錄日誌，無實際操作
  - Level 2：可提交提案 (Proposals)，需人工核准
  - Level 3：可自動核准「非敏感類別」提案
- 定義 Level 3 禁區（與 proposal_engine 對齊）：
  - stop_loss_logic, position_sizing, symbol_universe, live_mode_switch, monthly_drawdown_limit, risk_parameters
- 實作授權檢查引擎：
  - 提案授權判斷（can_propose, can_auto_approve）
  - 審計日誌記錄所有等級變更
- 向後相容：提供 get_authority_level() 函數供現有代碼使用

## 對應 v4 條目
#29 自主授權邊界（Level 0/1/2/3 + Level 3 禁區）

## 測試結果
✅ 9/9 tests passed

## 驗收標準
- [x] 不同 Level 下的權限判斷正確
- [x] Level 3 禁區項目被正確攔截並要求人工核准
- [x] 權限變更審計日誌完整
- [x] 與 proposal_engine 整合（禁區對齊）

## Ref
- Issue #13
- gap_matrix.md: #29