### PR TITLE
[v4 #12] API 金鑰安全 (Keychain) + IP 白名單

### DIFF
--- a/src/openclaw/main.py
+++ b/src/openclaw/main.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+
+from openclaw.audit_store import insert_incident, insert_risk_check
+from openclaw.broker import BrokerAdapter, BrokerOrderStatus, SimBrokerAdapter
+from openclaw.drawdown_guard import DrawdownPolicy, evaluate_drawdown_guard, evaluate_strategy_health_guard
+from openclaw.order_store import insert_order_event, transition_with_event
+from openclaw.orders import summarize_fill_status
+from openclaw.risk_engine import Decision, MarketState, PortfolioState, SystemState, evaluate_and_build_order
+from openclaw.risk_store import LimitQuery, load_limits
+
+
+def utc_now_iso() -> str:
+    return dt.datetime.now(tz=dt.timezone.utc).isoformat()
+
+
+@dataclass
+class ExecutionResult:
+    ok: bool
+    order_id: str
+    error_code: str = ""
+    error_message: str = ""
+
+
+def persist_order(
+    conn: sqlite3.Connection,
+    *,
+    order_id: str,
+    decision_id: str,
+    broker_order_id: str,
+    symbol: str,
+    side: str,
+    qty: int,
+    price: float,
+    strategy_version: str,
+    status: str = "submitted",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO orders (
+          order_id, decision_id, broker_order_id, ts_submit, symbol, side, qty, price,
+          order_type, tif, status, strategy_version
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            order_id,
+            decision_id,
+            broker_order_id,
+            utc_now_iso(),
+            symbol,
+            side,
+            qty,
+            price,
+            "limit",
+            "IOC",
+            status,
+            strategy_version,
+        ),
+    )
+
+
+def persist_decision(
+    conn: sqlite3.Connection,
+    *,
+    decision: Decision,
+    strategy_version: str,
+    reason: dict | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO decisions (
+          decision_id, ts, symbol, strategy_id, strategy_version, signal_side, signal_score, signal_ttl_ms, llm_ref, reason_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            decision.decision_id,
+            utc_now_iso(),
+            decision.symbol,
+            decision.strategy_id,
+            strategy_version,
+            decision.signal_side,
+            decision.signal_score,
+            decision.signal_ttl_ms,
+            None,
+            json.dumps(reason or {"source": "main_demo"}, ensure_ascii=True),
+        ),
+    )
+
+
+def persist_fill(
+    conn: sqlite3.Connection,
+    *,
+    fill_id: str,
+    order_id: str,
+    qty: int,
+    price: float,
+    fee: float,
+    tax: float,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO fills (fill_id, order_id, ts_fill, qty, price, fee, tax)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (fill_id, order_id, utc_now_iso(), qty, price, fee, tax),
+    )
+
+
+def execute_approved_order(
+    conn: sqlite3.Connection,
+    *,
+    broker: BrokerAdapter,
+    decision: Decision,
+    strategy_version: str,
+    symbol: str,
+    side: str,
+    qty: int,
+    price: float,
+    candidate,
+    poll_interval_sec: float = 0.5,
+    poll_timeout_sec: float = 5.0,
+) -> ExecutionResult:
+    order_id = str(uuid.uuid4())
+
+    # v4 #12: IP allowlist gate for sensitive broker APIs (configurable via env)
+    from openclaw.network_allowlist import enforce_network_security
+
+    enforce_network_security(conn=conn)
+
+    submission = broker.submit_order(order_id, candidate)
+    if submission.status != "submitted":
+        # Persist rejected order for audit; do not lose broker failure context.
+        persist_order(
+            conn,
+            order_id=order_id,
+            decision_id=decision.decision_id,
+            broker_order_id=submission.broker_order_id or "",
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            price=price,
+            strategy_version=strategy_version,
+            status="rejected",
+        )
+        reason_code = submission.reason_code or "EXEC_BROKER_REJECTED"
+        insert_order_event(
+            conn,
+            order_id=order_id,
+            event_type="rejected",
+            from_status=None,
+            to_status="rejected",
+            source="broker",
+            reason_code=reason_code,
+            payload={"reason": submission.reason},
+        )
+        return ExecutionResult(
+            ok=False,
+            order_id=order_id,
+            error_code=reason_code,
+            error_message=submission.reason or "broker rejected order",
+        )
+
+    persist_order(
+        conn,
+        order_id=order_id,
+        decision_id=decision.decision_id,
+        broker_order_id=submission.broker_order_id,
+        symbol=symbol,
+        side=side,
+        qty=qty,
+        price=price,
+        strategy_version=strategy_version,
+        status="submitted",
+    )
+    insert_order_event(
+        conn,
+        order_id=order_id,
+        event_type="submitted",
+        from_status=None,
+        to_status="submitted",
+        source="execution",
+        reason_code=None,
+        payload={"broker_order_id": submission.broker_order_id},
+    )
+
+    deadline = time.time() + poll_timeout_sec
+    last_filled_qty = 0
+    while time.time() < deadline:
+        status = broker.poll_order_status(submission.broker_order_id)
+        if status is None:
+            time.sleep(poll_interval_sec)
+            continue
+        last_filled_qty = _apply_broker_status(
+            conn=conn,
+            order_id=order_id,
+            broker_status=status,
+            last_filled_qty=last_filled_qty,
+        )
+        if status.status in {"filled", "cancelled", "rejected", "expired"}:
+            return ExecutionResult(ok=True, order_id=order_id)
+        time.sleep(poll_interval_sec)
+
+    insert_order_event(
+        conn,
+        order_id=order_id,
+        event_type="cancel_requested",
+        from_status=None,
+        to_status=None,
+        source="execution",
+        reason_code="EXEC_TIMEOUT_CANCEL",
+        payload={"poll_timeout_sec": poll_timeout_sec},
+    )
+    cancel_result = broker.cancel_order(submission.broker_order_id)
+    if cancel_result.status == "submitted":
+        transition_with_event(
+            conn,
+            order_id=order_id,
+            next_status="cancelled",
+            source="broker",
+            reason_code="EXEC_TIMEOUT_CANCEL",
+            payload={"broker_order_id": submission.broker_order_id},
+        )
+    else:
+        reason_code = cancel_result.reason_code or "EXEC_CANCEL_FAILED"
+        insert_order_event(
+            conn,
+            order_id=order_id,
+            event_type="cancel_failed",
+            from_status=None,
+            to_status=None,
+            source="broker",
+            reason_code=reason_code,
+            payload={"reason": cancel_result.reason},
+        )
+        return ExecutionResult(
+            ok=False,
+            order_id=order_id,
+            error_code=reason_code,
+            error_message=cancel_result.reason or "cancel failed",
+        )
+    return ExecutionResult(ok=True, order_id=order_id)
+
+
+def _apply_broker_status(
+    conn: sqlite3.Connection,
+    *,
+    order_id: str,
+    broker_status: BrokerOrderStatus,
+    last_filled_qty: int,
+) -> int:
+    new_filled_qty = max(last_filled_qty, int(broker_status.filled_qty))
+    delta = new_filled_qty - last_filled_qty
+    if delta > 0:
+        fill_id = str(uuid.uuid4())
+        persist_fill(
+            conn,
+            fill_id=fill_id,
+            order_id=order_id,
+            qty=delta,
+            price=broker_status.avg_fill_price,
+            fee=broker_status.fee,
+            tax=broker_status.tax,
+        )
+        insert_order_event(
+            conn,
+            order_id=order_id,
+            event_type="fill",
+            from_status=None,
+            to_status=None,
+            source="broker",
+            reason_code=None,
+            payload={
+                "fill_id": fill_id,
+                "delta_qty": delta,
+                "cum_filled_qty": new_filled_qty,
+                "avg_fill_price": broker_status.avg_fill_price,
+            },
+        )
+
+    next_status = summarize_fill_status(conn, order_id)
+    broker_terminal = broker_status.status in {"cancelled", "rejected", "expired"}
+    if broker_terminal:
+        next_status = broker_status.status
+    transition_with_event(
+        conn,
+        order_id=order_id,
+        next_status=next_status,
+        source="broker",
+        reason_code=broker_status.reason_code or None,
+        payload={"broker_status": broker_status.status, "reason": broker_status.reason},
+    )
+    return new_filled_qty
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OpenClaw v1.1 risk gate demo.")
+    parser.add_argument("--db", default="trades.db", help="Path to trades.db")
+    args = parser.parse_args()
+
+    conn = sqlite3.connect(args.db)
+    broker: BrokerAdapter = SimBrokerAdapter()
+
+    decision = Decision(
+        decision_id="demo-decision-001",
+        ts_ms=int(dt.datetime.now(tz=dt.timezone.utc).timestamp() * 1000),
+        symbol="2330",
+        strategy_id="breakout",
+        signal_side="buy",
+        signal_score=0.78,
+    )
+    strategy_version = "strat_demo_v1_1"
+    market = MarketState(best_bid=999.0, best_ask=1000.0, volume_1m=3000, feed_delay_ms=40)
+    portfolio = PortfolioState(nav=1_000_000.0, cash=700_000.0, realized_pnl_today=0.0, unrealized_pnl=-2_000.0)
+    system = SystemState(
+        now_ms=int(dt.datetime.now(tz=dt.timezone.utc).timestamp() * 1000),
+        trading_locked=False,
+        broker_connected=True,
+        db_write_p99_ms=20,
+        orders_last_60s=0,
+        reduce_only_mode=False,
+    )
+
+    limits = load_limits(conn, LimitQuery(symbol=decision.symbol, strategy_id=decision.strategy_id))
+
+    dd_policy = DrawdownPolicy()
+    dd_result = evaluate_drawdown_guard(conn, dd_policy)
+    st_result = evaluate_strategy_health_guard(conn, dd_policy, decision.strategy_id)
+    if dd_result.risk_mode == "suspended" or st_result.risk_mode == "suspended":
+        system.trading_locked = True
+    elif dd_result.risk_mode == "reduce_only" or st_result.risk_mode == "reduce_only":
+        system.reduce_only_mode = True
+
+    result = evaluate_and_build_order(decision, market, portfolio, limits, system)
+
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        persist_decision(conn, decision=decision, strategy_version=strategy_version)
+
+        insert_risk_check(
+            conn,
+            decision_id=decision.decision_id,
+            ts=utc_now_iso(),
+            passed=result.approved,
+            reject_code=result.reject_code,
+            metrics={
+                **result.metrics,
+                "drawdown_mode": dd_result.risk_mode,
+                "drawdown_reason": dd_result.reason_code,
+                "strategy_health_mode": st_result.risk_mode,
+                "strategy_health_reason": st_result.reason_code,
+            },
+            auto_commit=False,
+        )
+
+        if not result.approved:
+            insert_incident(
+                conn,
+                ts=utc_now_iso(),
+                severity="warn",
+                source="risk",
+                code=result.reject_code or "RISK_UNKNOWN",
+                detail={"decision_id": decision.decision_id, "metrics": result.metrics},
+                auto_commit=False,
+            )
+            conn.commit()
+            print(f"REJECTED: {result.reject_code}")
+            return
+
+        execution_result = execute_approved_order(
+            conn,
+            broker=broker,
+            decision=decision,
+            strategy_version=strategy_version,
+            symbol=result.order.symbol,
+            side=result.order.side,
+            qty=result.order.qty,
+            price=result.order.price,
+            candidate=result.order,
+        )
+        if not execution_result.ok:
+            insert_incident(
+                conn,
+                ts=utc_now_iso(),
+                severity="critical",
+                source="execution",
+                code=execution_result.error_code or "EXECUTION_TXN_FAILED",
+                detail={
+                    "decision_id": decision.decision_id,
+                    "order_id": execution_result.order_id,
+                    "error": execution_result.error_message,
+                },
+                auto_commit=False,
+            )
+            conn.commit()
+            print(f"FAILED: {execution_result.error_code}: {execution_result.error_message}")
+            return
+        conn.commit()
+        print(f"APPROVED: order_submitted={execution_result.order_id}")
+    except Exception as exc:
+        conn.rollback()
+        error_text = str(exc)
+        incident_code = "EXECUTION_TXN_FAILED"
+        if ":" in error_text:
+            maybe_code = error_text.split(":", 1)[0].strip()
+            if maybe_code.isupper() and "_" in maybe_code:
+                incident_code = maybe_code
+        insert_incident(
+            conn,
+            ts=utc_now_iso(),
+            severity="critical",
+            source="execution",
+            code=incident_code,
+            detail={"decision_id": decision.decision_id, "error": str(exc)},
+            auto_commit=True,
+        )
+        print(f"FAILED: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openclaw/network_allowlist.py
+++ b/src/openclaw/network_allowlist.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import ipaddress
+import os
+import sqlite3
+import urllib.request
+from datetime import datetime, timezone
+from typing import List, Optional
+
+
+class NetworkSecurityError(RuntimeError):
+    """Raised when current IP is not allowed for sensitive API calls."""
+
+
+def check_ip_whitelist(current_ip: str, whitelist: List[str]) -> bool:
+    """Return True if current_ip is within any whitelist entry.
+
+    Whitelist entries may be:
+    - single IP (e.g. "203.0.113.10")
+    - CIDR (e.g. "203.0.113.0/24")
+
+    Empty/blank items are ignored.
+    """
+
+    ip = ipaddress.ip_address(current_ip.strip())
+    for raw in whitelist:
+        item = (raw or "").strip()
+        if not item:
+            continue
+        try:
+            if "/" in item:
+                net = ipaddress.ip_network(item, strict=False)
+                if ip in net:
+                    return True
+            else:
+                if ip == ipaddress.ip_address(item):
+                    return True
+        except ValueError:
+            # invalid whitelist entry -> treat as non-match
+            continue
+    return False
+
+
+def _parse_allowlist(raw: str | None) -> List[str]:
+    if not raw:
+        return []
+    # allow commas, spaces, newlines
+    parts: List[str] = []
+    for chunk in raw.replace("\n", ",").split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        parts.extend([p for p in chunk.split() if p.strip()])
+    return parts
+
+
+def get_current_public_ip(*, timeout_sec: float = 3.0) -> str:
+    """Best-effort fetch public IP.
+
+    Supports test override via env OPENCLAW_CURRENT_IP.
+    """
+
+    override = os.getenv("OPENCLAW_CURRENT_IP", "").strip()
+    if override:
+        return override
+
+    urls = [
+        "https://api.ipify.org",
+        "https://ifconfig.me/ip",
+    ]
+    last_exc: Optional[Exception] = None
+    for url in urls:
+        try:
+            with urllib.request.urlopen(url, timeout=timeout_sec) as resp:
+                txt = resp.read().decode("utf-8", errors="ignore").strip()
+                ipaddress.ip_address(txt)
+                return txt
+        except Exception as exc:  # pragma: no cover
+            last_exc = exc
+            continue
+    raise NetworkSecurityError(f"SEC_NETWORK_IP_LOOKUP_FAILED: {last_exc}")
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _insert_incident_best_effort(
+    *,
+    conn: sqlite3.Connection,
+    code: str,
+    detail_json: str,
+    severity: str = "critical",
+    source: str = "network_security",
+) -> None:
+    try:
+        if not _table_exists(conn, "incidents"):
+            return
+        conn.execute(
+            """
+            INSERT INTO incidents(incident_id, ts, severity, source, code, detail_json, resolved)
+            VALUES (lower(hex(randomblob(16))), ?, ?, ?, ?, ?, 0)
+            """,
+            (
+                datetime.now(tz=timezone.utc).isoformat(),
+                severity,
+                source,
+                code,
+                detail_json,
+            ),
+        )
+        conn.commit()
+    except Exception:
+        return
+
+
+def enforce_network_security(
+    *,
+    current_ip: str | None = None,
+    whitelist: Optional[List[str]] = None,
+    conn: Optional[sqlite3.Connection] = None,
+    db_path: Optional[str] = None,
+) -> str:
+    """Enforce IP allowlist for sensitive API calls.
+
+    - If allowlist is empty -> no-op.
+    - If allowlist is set and current IP not allowed -> log incident (best-effort) then raise.
+
+    Allowlist sources:
+    - explicit whitelist argument
+    - env OPENCLAW_IP_ALLOWLIST
+
+    Current IP sources:
+    - explicit current_ip argument
+    - env OPENCLAW_CURRENT_IP (test override)
+    - public IP lookup
+
+    Returns resolved current IP.
+    """
+
+    allow = whitelist if whitelist is not None else _parse_allowlist(os.getenv("OPENCLAW_IP_ALLOWLIST"))
+    if not allow:
+        return current_ip or get_current_public_ip()
+
+    ip = current_ip or get_current_public_ip()
+    if check_ip_whitelist(ip, allow):
+        return ip
+
+    detail = {"current_ip": ip, "allowlist": allow}
+
+    close_after = False
+    try:
+        if conn is None:
+            resolved_db_path = db_path or os.getenv("OPENCLAW_DB_PATH") or "data/sqlite/trades.db"
+            conn = sqlite3.connect(resolved_db_path)
+            close_after = True
+        _insert_incident_best_effort(
+            conn=conn,
+            code="SEC_NETWORK_IP_DENIED",
+            detail_json=str(detail),
+            severity="critical",
+            source="network_security",
+        )
+    finally:
+        if conn is not None and close_after:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    raise NetworkSecurityError(f"SEC_NETWORK_IP_DENIED: current_ip={ip}")

--- a/src/openclaw/secrets.py
+++ b/src/openclaw/secrets.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+try:  # optional dependency
+    import keyring  # type: ignore
+except Exception:  # pragma: no cover
+    keyring = None
+
+
+def _project_root() -> Path:
+    # .../src/openclaw/secrets.py -> parents[0]=openclaw, [1]=src, [2]=project root
+    return Path(__file__).resolve().parents[2]
+
+
+def _parse_dotenv_value(raw: str) -> str:
+    v = raw.strip()
+    if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+        v = v[1:-1]
+    return v
+
+
+def _get_from_dotenv(key: str, *, dotenv_path: Optional[str] = None) -> str:
+    p = dotenv_path or os.getenv("OPENCLAW_DOTENV_PATH") or ".env"
+    path = Path(p)
+    if not path.is_absolute():
+        # resolve relative to project root first
+        candidate = _project_root() / path
+        if candidate.exists():
+            path = candidate
+        else:
+            path = Path.cwd() / path
+
+    if not path.exists() or not path.is_file():
+        return ""
+
+    try:
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            s = line.strip()
+            if not s or s.startswith("#"):
+                continue
+            if s.startswith("export "):
+                s = s[len("export ") :].strip()
+            if "=" not in s:
+                continue
+            k, v = s.split("=", 1)
+            if k.strip() == key:
+                return _parse_dotenv_value(v)
+    except Exception:
+        return ""
+
+    return ""
+
+
+def _get_from_keychain(
+    key: str, *, keychain_service: Optional[str] = None, keychain_account: Optional[str] = None
+) -> str:
+    service = keychain_service or os.getenv("OPENCLAW_KEYCHAIN_SERVICE") or "openclaw"
+    account = keychain_account or os.getenv("OPENCLAW_KEYCHAIN_ACCOUNT") or key
+
+    # Prefer keyring (supports macOS Keychain via backend)
+    if keyring is not None:
+        try:
+            v = keyring.get_password(service, account)  # type: ignore[attr-defined]
+            if v:
+                return str(v).strip()
+        except Exception:
+            pass
+
+    # Fallback to `security` CLI (macOS)
+    try:
+        out = subprocess.check_output(
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                service,
+                "-a",
+                account,
+                "-w",
+            ],
+            text=True,
+        )
+        v = out.strip()
+        if v:
+            return v
+    except Exception:
+        pass
+
+    return ""
+
+
+def get_secret(
+    key: str,
+    *,
+    dotenv_path: Optional[str] = None,
+    keychain_service: Optional[str] = None,
+    keychain_account: Optional[str] = None,
+) -> str:
+    """Resolve secret in priority order:
+
+    1) Environment Variable
+    2) .env file
+    3) macOS Keychain (via keyring, fallback to `security` CLI)
+
+    Raises RuntimeError if not found.
+    """
+
+    value = os.getenv(key, "").strip()
+    if value:
+        return value
+
+    value = _get_from_dotenv(key, dotenv_path=dotenv_path).strip()
+    if value:
+        return value
+
+    value = _get_from_keychain(
+        key,
+        keychain_service=keychain_service,
+        keychain_account=keychain_account,
+    ).strip()
+    if value:
+        return value
+
+    service = keychain_service or os.getenv("OPENCLAW_KEYCHAIN_SERVICE") or "openclaw"
+    account = keychain_account or os.getenv("OPENCLAW_KEYCHAIN_ACCOUNT") or key
+    raise RuntimeError(
+        f"missing secret: {key}; set env var, .env, or macOS keychain ({service}/{account})"
+    )

--- a/tests/test_v4_12_security.py
+++ b/tests/test_v4_12_security.py
@@ -1,0 +1,89 @@
+"""Test API key security + IP allowlist (v4 #12)."""
+
+import os
+import pytest
+
+from openclaw.secrets import get_secret
+from openclaw.network_allowlist import check_ip_whitelist, enforce_network_security, NetworkSecurityError
+
+
+def test_get_secret_env_overrides_dotenv_and_keychain(monkeypatch, tmp_path):
+    key = "TEST_SECRET_KEY"
+
+    dotenv = tmp_path / ".env"
+    dotenv.write_text(f"{key}=from_dotenv\n", encoding="utf-8")
+    monkeypatch.setenv("OPENCLAW_DOTENV_PATH", str(dotenv))
+
+    class DummyKeyring:
+        @staticmethod
+        def get_password(service, account):
+            return "from_keychain"
+
+    import openclaw.secrets as secrets_mod
+
+    monkeypatch.setattr(secrets_mod, "keyring", DummyKeyring)
+    monkeypatch.setenv(key, "from_env")
+
+    assert get_secret(key) == "from_env"
+
+
+def test_get_secret_dotenv_fallback(monkeypatch, tmp_path):
+    key = "TEST_SECRET_KEY_2"
+    monkeypatch.delenv(key, raising=False)
+
+    dotenv = tmp_path / ".env"
+    dotenv.write_text(f"{key}='from_dotenv'\n", encoding="utf-8")
+    monkeypatch.setenv("OPENCLAW_DOTENV_PATH", str(dotenv))
+
+    import openclaw.secrets as secrets_mod
+
+    class DummyKeyring:
+        @staticmethod
+        def get_password(service, account):
+            return "from_keychain"
+
+    monkeypatch.setattr(secrets_mod, "keyring", DummyKeyring)
+
+    assert get_secret(key) == "from_dotenv"
+
+
+def test_get_secret_keychain_fallback(monkeypatch, tmp_path):
+    key = "TEST_SECRET_KEY_3"
+    monkeypatch.delenv(key, raising=False)
+
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("# empty\n", encoding="utf-8")
+    monkeypatch.setenv("OPENCLAW_DOTENV_PATH", str(dotenv))
+
+    import openclaw.secrets as secrets_mod
+
+    class DummyKeyring:
+        @staticmethod
+        def get_password(service, account):
+            assert account == key
+            return "from_keychain"
+
+    monkeypatch.setattr(secrets_mod, "keyring", DummyKeyring)
+
+    assert get_secret(key) == "from_keychain"
+
+
+def test_check_ip_whitelist_single_and_cidr():
+    assert check_ip_whitelist("203.0.113.10", ["203.0.113.10"]) is True
+    assert check_ip_whitelist("203.0.113.10", ["203.0.113.11"]) is False
+    assert check_ip_whitelist("203.0.113.10", ["203.0.113.0/24"]) is True
+    assert check_ip_whitelist("203.0.113.10", ["203.0.112.0/24"]) is False
+
+
+def test_check_ip_whitelist_ignores_invalid_entries():
+    assert check_ip_whitelist("203.0.113.10", ["not-a-cidr", "203.0.113.0/24"]) is True
+
+
+def test_enforce_network_security_raises_when_denied():
+    with pytest.raises(NetworkSecurityError):
+        enforce_network_security(current_ip="203.0.113.10", whitelist=["203.0.113.0/28"])
+
+
+def test_enforce_network_security_passes_when_allowed():
+    ip = enforce_network_security(current_ip="203.0.113.10", whitelist=["203.0.113.0/24"])
+    assert ip == "203.0.113.10"


### PR DESCRIPTION
## 內容\n- secrets.get_secret(): Env -> .env -> macOS Keychain (keyring + security CLI fallback)\n- 新增 network_allowlist: CIDR/單 IP 匹配 + enforce_network_security() (含 incident best-effort 記錄)\n- 在敏感 broker 呼叫前加上 allowlist gate\n- 新增單元測試 tests/test_v4_12_security.py\n\n## 設定\n- OPENCLAW_IP_ALLOWLIST="203.0.113.0/24,198.51.100.10"\n- OPENCLAW_CURRENT_IP (測試 override)\n- OPENCLAW_DOTENV_PATH / OPENCLAW_KEYCHAIN_SERVICE / OPENCLAW_KEYCHAIN_ACCOUNT\n