### PR TITLE
Phase 2.3 Batch D: TW session rules + order slicing + take profit (TaskHub #17 #19 #21)

### DIFF
--- a/config/sentinel_policy_v1.json
+++ b/config/sentinel_policy_v1.json
@@ -53,5 +53,29 @@
       "incident_log"
     ],
     "telegram_chat_id": "-1003772422881"
+  },
+  "tw_session_rules": {
+    "timezone": "Asia/Taipei",
+    "preopen_auction": {
+      "max_orders_per_min": 0.5,
+      "max_slippage_bps": 0.8,
+      "max_price_deviation_pct": 0.8,
+      "max_qty_to_1m_volume_ratio": 0.7,
+      "max_loss_per_trade_pct_nav": 0.7
+    },
+    "regular": {
+      "max_orders_per_min": 1.0,
+      "max_slippage_bps": 1.0,
+      "max_price_deviation_pct": 1.0,
+      "max_qty_to_1m_volume_ratio": 1.0,
+      "max_loss_per_trade_pct_nav": 1.0
+    },
+    "afterhours_auction": {
+      "max_orders_per_min": 0.6,
+      "max_slippage_bps": 0.7,
+      "max_price_deviation_pct": 0.8,
+      "max_qty_to_1m_volume_ratio": 0.5,
+      "max_loss_per_trade_pct_nav": 0.7
+    }
   }
 }

--- a/src/openclaw/order_slicing.py
+++ b/src/openclaw/order_slicing.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Literal, Optional, Sequence, Tuple
+
+from openclaw.position_sizing import calculate_position_qty
+from openclaw.risk_engine import OrderCandidate
+
+
+Side = Literal["buy", "sell"]
+SlicingMethod = Literal["twap", "vwap"]
+
+
+@dataclass(frozen=True)
+class OrderBookLevel:
+    price: float
+    qty: int
+
+
+@dataclass(frozen=True)
+class OrderBookSnapshot:
+    ts_ms: int
+    bids: Sequence[OrderBookLevel]
+    asks: Sequence[OrderBookLevel]
+
+
+@dataclass(frozen=True)
+class DepthCheck:
+    ok: bool
+    available_qty: int
+    limit_price: float
+    max_slippage_bps: float
+
+
+@dataclass(frozen=True)
+class OrderSlice:
+    scheduled_ts_ms: int
+    qty: int
+
+
+@dataclass(frozen=True)
+class SlicePlan:
+    method: SlicingMethod
+    total_qty: int
+    slices: Sequence[OrderSlice]
+    duration_ms: int
+
+
+def _clip_int(v: int, lo: int, hi: int) -> int:
+    return max(lo, min(int(v), hi))
+
+
+def _sum_qty(levels: Iterable[OrderBookLevel]) -> int:
+    s = 0
+    for lv in levels:
+        try:
+            s += max(0, int(lv.qty))
+        except Exception:
+            continue
+    return int(s)
+
+
+def estimate_available_qty_within_slippage(
+    *,
+    side: Side,
+    book: OrderBookSnapshot,
+    max_slippage_bps: float,
+) -> Tuple[int, float]:
+    """Estimate available quantity within a max slippage band.
+
+    For buy orders we consume asks up to best_ask*(1+slippage).
+    For sell orders we consume bids down to best_bid*(1-slippage).
+
+    Returns: (available_qty, limit_price)
+    """
+
+    if max_slippage_bps < 0:
+        max_slippage_bps = 0.0
+
+    if side == "buy":
+        if not book.asks:
+            return 0, 0.0
+        best = float(book.asks[0].price)
+        limit_price = best * (1.0 + max_slippage_bps / 10_000.0)
+        levels = [lv for lv in book.asks if float(lv.price) <= limit_price]
+        return _sum_qty(levels), float(limit_price)
+
+    # sell
+    if not book.bids:
+        return 0, 0.0
+    best = float(book.bids[0].price)
+    limit_price = best * (1.0 - max_slippage_bps / 10_000.0)
+    levels = [lv for lv in book.bids if float(lv.price) >= limit_price]
+    return _sum_qty(levels), float(limit_price)
+
+
+def check_orderbook_depth(
+    *,
+    side: Side,
+    desired_qty: int,
+    book: OrderBookSnapshot,
+    max_slippage_bps: float,
+    min_depth_multiplier: float = 1.20,
+) -> DepthCheck:
+    """Ensure the orderbook has sufficient depth for slicing/large orders.
+
+    Rule of thumb: available_qty >= desired_qty * min_depth_multiplier.
+    """
+
+    desired_qty = max(0, int(desired_qty))
+    available, limit_price = estimate_available_qty_within_slippage(
+        side=side, book=book, max_slippage_bps=max_slippage_bps
+    )
+    ok = available >= int(desired_qty * float(min_depth_multiplier))
+    return DepthCheck(ok=ok, available_qty=int(available), limit_price=float(limit_price), max_slippage_bps=float(max_slippage_bps))
+
+
+def plan_twap_slices(
+    *,
+    total_qty: int,
+    start_ts_ms: int,
+    duration_ms: int,
+    n_slices: int,
+    min_slice_qty: int = 1,
+    max_slice_qty: Optional[int] = None,
+) -> SlicePlan:
+    """Build a TWAP slice plan (equal qty per interval, remainder distributed)."""
+
+    total_qty = max(0, int(total_qty))
+    n_slices = max(1, int(n_slices))
+    duration_ms = max(0, int(duration_ms))
+
+    if total_qty == 0:
+        return SlicePlan(method="twap", total_qty=0, slices=[], duration_ms=duration_ms)
+
+    base = total_qty // n_slices
+    rem = total_qty % n_slices
+
+    # When total_qty < n_slices, we just emit fewer slices.
+    per_slice: List[int] = []
+    for i in range(n_slices):
+        q = base + (1 if i < rem else 0)
+        if q <= 0:
+            continue
+        per_slice.append(int(q))
+
+    # Apply min/max constraints.
+    # If min constraint makes total exceed, we keep total by trimming later slices.
+    if min_slice_qty > 1:
+        per_slice = [max(int(min_slice_qty), q) for q in per_slice]
+
+    if max_slice_qty is not None:
+        per_slice = [min(int(max_slice_qty), q) for q in per_slice]
+
+    # Normalize back to total_qty.
+    current = sum(per_slice)
+    if current != total_qty:
+        delta = current - total_qty
+        # Reduce from the back first.
+        i = len(per_slice) - 1
+        while delta > 0 and i >= 0:
+            can_reduce = per_slice[i] - 1
+            if can_reduce > 0:
+                r = min(delta, can_reduce)
+                per_slice[i] -= r
+                delta -= r
+            i -= 1
+        # If we couldn't reduce enough, we accept a small over-allocation (safe).
+
+    interval_ms = 0 if len(per_slice) <= 1 else duration_ms // (len(per_slice) - 1)
+
+    slices: List[OrderSlice] = []
+    for i, q in enumerate(per_slice):
+        slices.append(OrderSlice(scheduled_ts_ms=int(start_ts_ms + i * interval_ms), qty=int(q)))
+
+    return SlicePlan(method="twap", total_qty=total_qty, slices=slices, duration_ms=duration_ms)
+
+
+def plan_vwap_slices(
+    *,
+    total_qty: int,
+    start_ts_ms: int,
+    duration_ms: int,
+    volume_profile: Sequence[int],
+    min_slice_qty: int = 1,
+    max_slice_qty: Optional[int] = None,
+) -> SlicePlan:
+    """Build a VWAP slice plan based on a volume profile.
+
+    Parameters
+    ----------
+    volume_profile:
+        A list of positive integers representing expected volume per interval.
+        The number of slices equals len(volume_profile).
+    """
+
+    total_qty = max(0, int(total_qty))
+    duration_ms = max(0, int(duration_ms))
+
+    if total_qty == 0:
+        return SlicePlan(method="vwap", total_qty=0, slices=[], duration_ms=duration_ms)
+
+    if not volume_profile:
+        # fallback to TWAP behavior
+        return plan_twap_slices(
+            total_qty=total_qty,
+            start_ts_ms=start_ts_ms,
+            duration_ms=duration_ms,
+            n_slices=1,
+            min_slice_qty=min_slice_qty,
+            max_slice_qty=max_slice_qty,
+        )
+
+    weights = [max(0, int(v)) for v in volume_profile]
+    s = sum(weights)
+    if s <= 0:
+        weights = [1] * len(volume_profile)
+        s = len(volume_profile)
+
+    raw = [total_qty * w / s for w in weights]
+    per_slice = [int(x) for x in raw]
+
+    # Distribute remainder to biggest fractional parts
+    allocated = sum(per_slice)
+    remainder = total_qty - allocated
+    if remainder > 0:
+        frac = [(raw[i] - per_slice[i], i) for i in range(len(per_slice))]
+        frac.sort(reverse=True)
+        for _, idx in frac[:remainder]:
+            per_slice[idx] += 1
+
+    # Apply constraints.
+    if min_slice_qty > 1:
+        per_slice = [max(int(min_slice_qty), q) for q in per_slice]
+    if max_slice_qty is not None:
+        per_slice = [min(int(max_slice_qty), q) for q in per_slice]
+
+    # Normalize back down to total_qty if needed.
+    current = sum(per_slice)
+    if current > total_qty:
+        delta = current - total_qty
+        # reduce from smallest slices first
+        idxs = sorted(range(len(per_slice)), key=lambda i: per_slice[i])
+        for i in idxs:
+            if delta <= 0:
+                break
+            can_reduce = per_slice[i] - 1
+            if can_reduce > 0:
+                r = min(delta, can_reduce)
+                per_slice[i] -= r
+                delta -= r
+
+    interval_ms = 0 if len(per_slice) <= 1 else duration_ms // (len(per_slice) - 1)
+
+    slices: List[OrderSlice] = []
+    for i, q in enumerate(per_slice):
+        if q <= 0:
+            continue
+        slices.append(OrderSlice(scheduled_ts_ms=int(start_ts_ms + i * interval_ms), qty=int(q)))
+
+    return SlicePlan(method="vwap", total_qty=total_qty, slices=slices, duration_ms=duration_ms)
+
+
+def slice_order_candidate(
+    *,
+    candidate: OrderCandidate,
+    method: SlicingMethod,
+    start_ts_ms: int,
+    duration_ms: int,
+    n_slices: int = 5,
+    volume_profile: Optional[Sequence[int]] = None,
+) -> List[OrderCandidate]:
+    """Slice an OrderCandidate into multiple smaller candidates.
+
+    Price/order_type/tif are copied as-is; qty is split.
+    """
+
+    if candidate.qty <= 0:
+        return []
+
+    if method == "vwap":
+        profile = list(volume_profile) if volume_profile is not None else [1] * int(n_slices)
+        plan = plan_vwap_slices(
+            total_qty=candidate.qty,
+            start_ts_ms=start_ts_ms,
+            duration_ms=duration_ms,
+            volume_profile=profile,
+        )
+    else:
+        plan = plan_twap_slices(
+            total_qty=candidate.qty,
+            start_ts_ms=start_ts_ms,
+            duration_ms=duration_ms,
+            n_slices=int(n_slices),
+        )
+
+    out: List[OrderCandidate] = []
+    for sl in plan.slices:
+        out.append(
+            OrderCandidate(
+                symbol=candidate.symbol,
+                side=candidate.side,
+                qty=int(sl.qty),
+                price=candidate.price,
+                order_type=candidate.order_type,
+                tif=candidate.tif,
+                opens_new_position=candidate.opens_new_position,
+            )
+        )
+    return out
+
+
+def build_sliced_entry_plan_from_risk_inputs(
+    *,
+    nav: float,
+    entry_price: float,
+    stop_price: float,
+    side: Side,
+    limits: Dict[str, float],
+    start_ts_ms: int,
+    duration_ms: int,
+    method: SlicingMethod = "twap",
+    n_slices: int = 5,
+    authority_level: Optional[int] = None,
+    sentinel_policy_path: str = "config/sentinel_policy_v1.json",
+    symbol: str = "UNKNOWN",
+) -> Tuple[int, List[OrderCandidate]]:
+    """Integration helper: position sizing (#5) -> sliced OrderCandidates (#19).
+
+    Returns: (total_qty, sliced_candidates)
+    """
+
+    qty = calculate_position_qty(
+        nav=float(nav),
+        entry_price=float(entry_price),
+        stop_price=float(stop_price),
+        atr=None,
+        atr_stop_multiple=float(limits.get("atr_stop_multiple", 2.0)),
+        base_risk_pct=float(limits.get("max_loss_per_trade_pct_nav", 0.005)),
+        confidence=float(limits.get("confidence", 1.0)),
+        confidence_threshold=float(limits.get("low_confidence_threshold", 0.60)),
+        low_confidence_scale=float(limits.get("low_confidence_scale", 0.50)),
+        volatility_multiplier=float(limits.get("volatility_multiplier", 1.0)),
+        method=str(limits.get("position_sizing_method", "fixed_fractional")),
+        authority_level=authority_level,
+        sentinel_policy_path=sentinel_policy_path,
+    )
+
+    if qty <= 0:
+        return 0, []
+
+    candidate = OrderCandidate(
+        symbol=str(symbol),
+        side=side,
+        qty=int(qty),
+        price=float(entry_price),
+        order_type="limit",
+        tif=str(limits.get("tif", "IOC")),
+        opens_new_position=True,
+    )
+
+    sliced = slice_order_candidate(
+        candidate=candidate,
+        method=method,
+        start_ts_ms=start_ts_ms,
+        duration_ms=duration_ms,
+        n_slices=int(n_slices),
+        volume_profile=None,
+    )
+    return int(qty), sliced

--- a/src/openclaw/take_profit.py
+++ b/src/openclaw/take_profit.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Literal, Optional
+
+
+PositionSide = Literal["long", "short"]
+
+
+@dataclass
+class TakeProfitPolicy:
+    """Three-in-one take profit policy.
+
+    Layers (evaluated in this order):
+      1) Target price take profit (partial)
+      2) Trailing stop (exit remaining)
+      3) Time decay (exit remaining)
+
+    Notes
+    -----
+    - Target price defaults to risk-reward (RR) multiple derived from
+      (entry_price - initial_stop_price).
+    - Trailing stop uses pct of peak/trough by default.
+    """
+
+    target_rr: float = 2.0
+    target_exit_fraction: float = 0.50
+
+    trailing_stop_pct: float = 0.01
+
+    max_hold_ms: int = 90 * 60 * 1000  # 90 minutes
+    time_decay_profit_floor_pct: float = 0.0  # allow time-exit at breakeven
+
+
+@dataclass
+class TakeProfitState:
+    entry_ts_ms: int
+    entry_price: float
+    side: PositionSide
+    qty: int
+    initial_stop_price: float
+
+    remaining_qty: int = field(init=False)
+    target_taken: bool = field(default=False)
+
+    peak_price: float = field(init=False)
+    trough_price: float = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.remaining_qty = int(self.qty)
+        self.peak_price = float(self.entry_price)
+        self.trough_price = float(self.entry_price)
+
+
+@dataclass(frozen=True)
+class TakeProfitDecision:
+    action: Literal["hold", "exit"]
+    qty_to_exit: int = 0
+    reason: str = ""
+    target_price: Optional[float] = None
+    trailing_stop: Optional[float] = None
+    metrics: Dict[str, float] = None  # type: ignore[assignment]
+
+
+def _risk_per_share(state: TakeProfitState) -> float:
+    return abs(float(state.entry_price) - float(state.initial_stop_price))
+
+
+def compute_target_price(state: TakeProfitState, policy: TakeProfitPolicy) -> float:
+    risk = _risk_per_share(state)
+    if risk <= 0:
+        # Fallback: 1% target if we don't have a stop distance.
+        risk = abs(state.entry_price) * 0.01
+
+    if state.side == "long":
+        return float(state.entry_price + risk * float(policy.target_rr))
+    return float(state.entry_price - risk * float(policy.target_rr))
+
+
+def update_trailing_extremes(state: TakeProfitState, last_price: float) -> None:
+    p = float(last_price)
+    state.peak_price = max(float(state.peak_price), p)
+    state.trough_price = min(float(state.trough_price), p)
+
+
+def compute_trailing_stop(state: TakeProfitState, policy: TakeProfitPolicy) -> float:
+    pct = max(0.0, float(policy.trailing_stop_pct))
+    if state.side == "long":
+        return float(state.peak_price * (1.0 - pct))
+    return float(state.trough_price * (1.0 + pct))
+
+
+def _profit_pct(state: TakeProfitState, last_price: float) -> float:
+    lp = float(last_price)
+    if state.entry_price == 0:
+        return 0.0
+
+    if state.side == "long":
+        return (lp - float(state.entry_price)) / abs(float(state.entry_price))
+    return (float(state.entry_price) - lp) / abs(float(state.entry_price))
+
+
+def _crosses_target(state: TakeProfitState, last_price: float, target_price: float) -> bool:
+    lp = float(last_price)
+    if state.side == "long":
+        return lp >= float(target_price)
+    return lp <= float(target_price)
+
+
+def _crosses_trailing_stop(state: TakeProfitState, last_price: float, trailing_stop: float) -> bool:
+    lp = float(last_price)
+    if state.side == "long":
+        return lp <= float(trailing_stop)
+    return lp >= float(trailing_stop)
+
+
+def evaluate_take_profit(
+    *,
+    state: TakeProfitState,
+    last_price: float,
+    now_ms: int,
+    policy: TakeProfitPolicy,
+) -> TakeProfitDecision:
+    """Evaluate take profit rules and (optionally) emit an exit instruction.
+
+    The caller is responsible for turning the decision into actual orders.
+    The state is mutated only for tracking extremes/target-taken bookkeeping.
+    """
+
+    if state.remaining_qty <= 0:
+        return TakeProfitDecision(action="hold", qty_to_exit=0, reason="no_position")
+
+    update_trailing_extremes(state, last_price)
+
+    target_price = compute_target_price(state, policy)
+    trailing_stop = compute_trailing_stop(state, policy)
+
+    # 1) Target price: partial take profit once.
+    if (not state.target_taken) and _crosses_target(state, last_price, target_price):
+        exit_qty = max(1, int(round(state.qty * float(policy.target_exit_fraction))))
+        exit_qty = min(exit_qty, state.remaining_qty)
+        state.remaining_qty -= exit_qty
+        state.target_taken = True
+        return TakeProfitDecision(
+            action="exit",
+            qty_to_exit=int(exit_qty),
+            reason="target_price",
+            target_price=float(target_price),
+            trailing_stop=float(trailing_stop),
+            metrics={"profit_pct": float(_profit_pct(state, last_price))},
+        )
+
+    # 2) Trailing stop: exit all remaining.
+    if _crosses_trailing_stop(state, last_price, trailing_stop):
+        exit_qty = int(state.remaining_qty)
+        state.remaining_qty = 0
+        return TakeProfitDecision(
+            action="exit",
+            qty_to_exit=int(exit_qty),
+            reason="trailing_stop",
+            target_price=float(target_price),
+            trailing_stop=float(trailing_stop),
+            metrics={"profit_pct": float(_profit_pct(state, last_price))},
+        )
+
+    # 3) Time decay: exit if held too long.
+    held_ms = int(now_ms) - int(state.entry_ts_ms)
+    if held_ms >= int(policy.max_hold_ms):
+        pp = float(_profit_pct(state, last_price))
+        if pp >= float(policy.time_decay_profit_floor_pct):
+            exit_qty = int(state.remaining_qty)
+            state.remaining_qty = 0
+            return TakeProfitDecision(
+                action="exit",
+                qty_to_exit=int(exit_qty),
+                reason="time_decay",
+                target_price=float(target_price),
+                trailing_stop=float(trailing_stop),
+                metrics={"profit_pct": pp, "held_ms": float(held_ms)},
+            )
+
+    return TakeProfitDecision(
+        action="hold",
+        qty_to_exit=0,
+        reason="hold",
+        target_price=float(target_price),
+        trailing_stop=float(trailing_stop),
+        metrics={"profit_pct": float(_profit_pct(state, last_price)), "held_ms": float(held_ms)},
+    )

--- a/src/openclaw/tw_session_rules.py
+++ b/src/openclaw/tw_session_rules.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, time
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Mapping, Optional
+
+from zoneinfo import ZoneInfo
+
+
+class TWTradingPhase(str, Enum):
+    """Taiwan equity market session phase (UTC+8).
+
+    Canonical phases for OpenClaw v4 Batch-D:
+      - preopen_auction: 09:00-09:10
+      - regular:         09:10-13:25
+      - afterhours:      13:30-13:40
+      - closed:          otherwise
+
+    We keep the schedule hard-coded to avoid accidental misconfiguration.
+    JSON (sentinel_policy_v1.json) is used only for *risk multipliers*.
+    """
+
+    PREOPEN_AUCTION = "preopen_auction"
+    REGULAR = "regular"
+    AFTERHOURS_AUCTION = "afterhours_auction"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True)
+class TWSessionConfig:
+    tz: str
+
+    # Multipliers applied to flattened risk `limits`.
+    preopen_multipliers: Mapping[str, float]
+    regular_multipliers: Mapping[str, float]
+    afterhours_multipliers: Mapping[str, float]
+
+    @staticmethod
+    def default() -> "TWSessionConfig":
+        # Conservative defaults: auction sessions are thinner & more discontinuous.
+        return TWSessionConfig(
+            tz="Asia/Taipei",
+            preopen_multipliers={
+                "max_orders_per_min": 0.50,
+                "max_slippage_bps": 0.80,
+                "max_price_deviation_pct": 0.80,
+                "max_qty_to_1m_volume_ratio": 0.70,
+                "max_loss_per_trade_pct_nav": 0.70,
+            },
+            regular_multipliers={
+                "max_orders_per_min": 1.00,
+                "max_slippage_bps": 1.00,
+                "max_price_deviation_pct": 1.00,
+                "max_qty_to_1m_volume_ratio": 1.00,
+                "max_loss_per_trade_pct_nav": 1.00,
+            },
+            afterhours_multipliers={
+                "max_orders_per_min": 0.60,
+                "max_slippage_bps": 0.70,
+                "max_price_deviation_pct": 0.80,
+                "max_qty_to_1m_volume_ratio": 0.50,
+                "max_loss_per_trade_pct_nav": 0.70,
+            },
+        )
+
+
+_PREOPEN_START = time(9, 0)
+_PREOPEN_END = time(9, 10)
+_REGULAR_START = time(9, 10)
+_REGULAR_END = time(13, 25)
+_AFTER_START = time(13, 30)
+_AFTER_END = time(13, 40)
+
+
+def _to_local_time_of_day(now_ms: int, tz: ZoneInfo) -> time:
+    dt = datetime.fromtimestamp(now_ms / 1000, tz=tz)
+    return dt.timetz().replace(tzinfo=None)
+
+
+def get_tw_trading_phase(now_ms: int, tz: str = "Asia/Taipei") -> TWTradingPhase:
+    """Return current TW market phase for a given epoch-ms."""
+
+    z = ZoneInfo(tz)
+    tod = _to_local_time_of_day(now_ms, z)
+
+    if _PREOPEN_START <= tod < _PREOPEN_END:
+        return TWTradingPhase.PREOPEN_AUCTION
+    if _REGULAR_START <= tod < _REGULAR_END:
+        return TWTradingPhase.REGULAR
+    if _AFTER_START <= tod < _AFTER_END:
+        return TWTradingPhase.AFTERHOURS_AUCTION
+    return TWTradingPhase.CLOSED
+
+
+def _load_sentinel_tw_session_config(sentinel_policy_path: str) -> Optional[TWSessionConfig]:
+    """Load TW session multipliers from sentinel_policy_v1.json.
+
+    This function is *optional* and must never throw: if the policy file is
+    missing / malformed / has no session config, we fall back to defaults.
+    """
+
+    try:
+        p = Path(sentinel_policy_path)
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    cfg = raw.get("tw_session_rules")
+    if not isinstance(cfg, dict):
+        return None
+
+    def _mp(key: str) -> Optional[Mapping[str, float]]:
+        v = cfg.get(key)
+        if not isinstance(v, dict):
+            return None
+        out: Dict[str, float] = {}
+        for k, vv in v.items():
+            try:
+                out[str(k)] = float(vv)
+            except Exception:
+                continue
+        return out
+
+    preopen = _mp("preopen_auction")
+    regular = _mp("regular")
+    after = _mp("afterhours_auction")
+
+    if preopen is None and regular is None and after is None:
+        return None
+
+    base = TWSessionConfig.default()
+    return TWSessionConfig(
+        tz=str(cfg.get("timezone", base.tz)),
+        preopen_multipliers=preopen or base.preopen_multipliers,
+        regular_multipliers=regular or base.regular_multipliers,
+        afterhours_multipliers=after or base.afterhours_multipliers,
+    )
+
+
+def apply_tw_session_risk_adjustments(
+    limits: Mapping[str, object],
+    *,
+    now_ms: int,
+    sentinel_policy_path: str = "config/sentinel_policy_v1.json",
+) -> Dict[str, object]:
+    """Apply Taiwan-session-aware risk multipliers to a flattened limits dict.
+
+    - Only keys present in both `limits` and multipliers are modified.
+    - CLOSED phase returns the original limits (no implicit lock).
+      Session-level lock is the responsibility of the orchestrator.
+    """
+
+    base_limits: Dict[str, object] = {str(k): v for k, v in limits.items()}
+    cfg = _load_sentinel_tw_session_config(sentinel_policy_path) or TWSessionConfig.default()
+
+    phase = get_tw_trading_phase(now_ms, tz=cfg.tz)
+    if phase == TWTradingPhase.CLOSED:
+        return dict(base_limits)
+
+    if phase == TWTradingPhase.PREOPEN_AUCTION:
+        multipliers = cfg.preopen_multipliers
+    elif phase == TWTradingPhase.REGULAR:
+        multipliers = cfg.regular_multipliers
+    else:
+        multipliers = cfg.afterhours_multipliers
+
+    adjusted = dict(base_limits)
+    for k, m in multipliers.items():
+        if k not in adjusted:
+            continue
+        try:
+            adjusted[k] = float(adjusted[k]) * float(m)
+        except Exception:
+            # Don't allow session config to break risk evaluation.
+            continue
+
+    # Useful debug metadata for audit logs / metrics.
+    adjusted["tw_trading_phase"] = phase.value  # type: ignore[assignment]
+    return adjusted
+
+
+def tw_session_allows_trading(now_ms: int, tz: str = "Asia/Taipei") -> bool:
+    """True if the timestamp is inside one of the TW trading phases."""
+
+    return get_tw_trading_phase(now_ms, tz=tz) != TWTradingPhase.CLOSED

--- a/tests/test_v4_17_tw_session_rules.py
+++ b/tests/test_v4_17_tw_session_rules.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from zoneinfo import ZoneInfo
+
+from openclaw.risk_engine import default_limits
+from openclaw.tw_session_rules import TWTradingPhase, apply_tw_session_risk_adjustments, get_tw_trading_phase
+
+
+def _ms(y, m, d, hh, mm, ss=0):
+    dt = datetime(y, m, d, hh, mm, ss, tzinfo=ZoneInfo("Asia/Taipei"))
+    return int(dt.timestamp() * 1000)
+
+
+def test_get_tw_trading_phase_boundaries():
+    # Closed
+    assert get_tw_trading_phase(_ms(2026, 2, 28, 8, 59, 0)) == TWTradingPhase.CLOSED
+
+    # Preopen auction: 09:00-09:10
+    assert get_tw_trading_phase(_ms(2026, 2, 28, 9, 0, 0)) == TWTradingPhase.PREOPEN_AUCTION
+    assert get_tw_trading_phase(_ms(2026, 2, 28, 9, 9, 59)) == TWTradingPhase.PREOPEN_AUCTION
+
+    # Regular: 09:10-13:25
+    assert get_tw_trading_phase(_ms(2026, 2, 28, 9, 10, 0)) == TWTradingPhase.REGULAR
+    assert get_tw_trading_phase(_ms(2026, 2, 28, 13, 24, 59)) == TWTradingPhase.REGULAR
+
+    # Between sessions
+    assert get_tw_trading_phase(_ms(2026, 2, 28, 13, 26, 0)) == TWTradingPhase.CLOSED
+
+    # Afterhours auction: 13:30-13:40
+    assert get_tw_trading_phase(_ms(2026, 2, 28, 13, 30, 0)) == TWTradingPhase.AFTERHOURS_AUCTION
+    assert get_tw_trading_phase(_ms(2026, 2, 28, 13, 39, 59)) == TWTradingPhase.AFTERHOURS_AUCTION
+
+
+def test_apply_tw_session_risk_adjustments_preopen():
+    now_ms = _ms(2026, 2, 28, 9, 0, 0)
+    limits = default_limits()
+
+    adjusted = apply_tw_session_risk_adjustments(limits, now_ms=now_ms, sentinel_policy_path="config/sentinel_policy_v1.json")
+
+    assert adjusted["tw_trading_phase"] == "preopen_auction"
+    assert adjusted["max_orders_per_min"] == limits["max_orders_per_min"] * 0.5
+    assert adjusted["max_qty_to_1m_volume_ratio"] == limits["max_qty_to_1m_volume_ratio"] * 0.7

--- a/tests/test_v4_19_order_slicing.py
+++ b/tests/test_v4_19_order_slicing.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from openclaw.order_slicing import (
+    OrderBookLevel,
+    OrderBookSnapshot,
+    check_orderbook_depth,
+    plan_twap_slices,
+    plan_vwap_slices,
+)
+
+
+def test_orderbook_depth_check_buy():
+    book = OrderBookSnapshot(
+        ts_ms=0,
+        bids=[OrderBookLevel(price=99.9, qty=1000)],
+        asks=[
+            OrderBookLevel(price=100.0, qty=50),
+            OrderBookLevel(price=100.01, qty=40),
+            OrderBookLevel(price=100.20, qty=10_000),
+        ],
+    )
+
+    # With 10 bps slippage, we only include up to 100.10; so qty=50+40=90
+    chk = check_orderbook_depth(side="buy", desired_qty=80, book=book, max_slippage_bps=10, min_depth_multiplier=1.0)
+    assert chk.ok is True
+    assert chk.available_qty == 90
+
+    chk2 = check_orderbook_depth(side="buy", desired_qty=100, book=book, max_slippage_bps=10, min_depth_multiplier=1.0)
+    assert chk2.ok is False
+
+
+def test_plan_twap_slices_sum_and_count():
+    plan = plan_twap_slices(total_qty=101, start_ts_ms=1000, duration_ms=4000, n_slices=5)
+    assert plan.method == "twap"
+    assert sum(s.qty for s in plan.slices) == 101
+    assert len(plan.slices) == 5
+
+
+def test_plan_vwap_slices_allocates_by_profile():
+    plan = plan_vwap_slices(total_qty=100, start_ts_ms=0, duration_ms=4000, volume_profile=[1, 1, 2, 6])
+    assert plan.method == "vwap"
+    assert sum(s.qty for s in plan.slices) == 100
+
+    # The last bucket should get the largest allocation
+    assert plan.slices[-1].qty > plan.slices[0].qty

--- a/tests/test_v4_21_take_profit.py
+++ b/tests/test_v4_21_take_profit.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from openclaw.take_profit import TakeProfitPolicy, TakeProfitState, evaluate_take_profit
+
+
+def test_target_price_partial_then_trailing_stop_exit():
+    policy = TakeProfitPolicy(target_rr=2.0, target_exit_fraction=0.5, trailing_stop_pct=0.10, max_hold_ms=999999)
+    state = TakeProfitState(
+        entry_ts_ms=0,
+        entry_price=100.0,
+        side="long",
+        qty=10,
+        initial_stop_price=95.0,
+    )
+
+    # Target price: entry + (100-95)*2 = 110
+    d1 = evaluate_take_profit(state=state, last_price=111.0, now_ms=10, policy=policy)
+    assert d1.action == "exit"
+    assert d1.reason == "target_price"
+    assert d1.qty_to_exit == 5
+    assert state.remaining_qty == 5
+
+    # Price keeps rising -> update peak to 120
+    d_hold = evaluate_take_profit(state=state, last_price=120.0, now_ms=20, policy=policy)
+    assert d_hold.action == "hold"
+
+    # Trailing stop for peak=120, pct=10% => 108
+    d2 = evaluate_take_profit(state=state, last_price=107.0, now_ms=30, policy=policy)
+    assert d2.action == "exit"
+    assert d2.reason == "trailing_stop"
+    assert d2.qty_to_exit == 5
+    assert state.remaining_qty == 0
+
+
+def test_time_decay_exit_when_held_too_long_and_profit_floor_met():
+    policy = TakeProfitPolicy(target_rr=10.0, trailing_stop_pct=0.50, max_hold_ms=1000, time_decay_profit_floor_pct=0.0)
+    state = TakeProfitState(
+        entry_ts_ms=0,
+        entry_price=100.0,
+        side="long",
+        qty=3,
+        initial_stop_price=90.0,
+    )
+
+    d = evaluate_take_profit(state=state, last_price=100.0, now_ms=1500, policy=policy)
+    assert d.action == "exit"
+    assert d.reason == "time_decay"
+    assert d.qty_to_exit == 3


### PR DESCRIPTION
Implements Phase 2.3 Batch D trading feature expansion.

- TaskHub #17 (30b4fe47-23a6-4196-bd4b-0f993cb530d4): add `openclaw.tw_session_rules` with TW market phases + session-aware risk multipliers (loaded from `config/sentinel_policy_v1.json`).
- TaskHub #19 (00c6193e-23d5-400d-850a-765834ddbe62): add `openclaw.order_slicing` (TWAP/VWAP slice planning + orderbook depth check) and helper integrating position sizing -> sliced candidates.
- TaskHub #21 (8c946f90-2d9a-487c-9d8e-2f3510def328): add `openclaw.take_profit` implementing 3-layer take profit (target / trailing / time-decay).

Config:
- Extend `config/sentinel_policy_v1.json` with optional `tw_session_rules` multipliers (backward compatible).

Tests:
- `tests/test_v4_17_tw_session_rules.py`
- `tests/test_v4_19_order_slicing.py`
- `tests/test_v4_21_take_profit.py`

All tests: `pytest` (128 passed locally).
