### PR TITLE
[Frontend] 系統控制面板：主開關、模擬/實際盤切換、緊急停止

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,15 @@ Gemini.md*
 
 # Virtualenv
 .venv/
+
+# Frontend
+frontend/web/node_modules/
+frontend/web/dist/
+
+# Backend (frontend)
+frontend/backend/.EMERGENCY_STOP
+frontend/backend/__pycache__/
+frontend/backend/.pytest_cache/
+
+# Repo-level emergency stop sentinel
+.EMERGENCY_STOP

--- a/config/system_state.json
+++ b/config/system_state.json
@@ -1,0 +1,10 @@
+{
+  "system_name": "AI-Trader v1.0",
+  "version": "1.0.0",
+  "description": "系統主開關與執行狀態配置",
+  "trading_enabled": false,
+  "simulation_mode": true,
+  "last_modified": "2026-02-28T00:00:00+08:00",
+  "last_modified_by": "system (default)",
+  "notes": "此檔案為系統主開關。trading_enabled 必須為 true 且 .EMERGENCY_STOP 檔案不存在，系統才會開始自動交易。simulation_mode: true=模擬盤, false=實際盤。切換至實際盤應自動禁用自動交易（雙重保險）。"
+}

--- a/frontend/backend/app/api/control.py
+++ b/frontend/backend/app/api/control.py
@@ -1,0 +1,156 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import json
+import os
+from datetime import datetime
+
+router = APIRouter(prefix="/api/control", tags=["Control"])
+
+SYSTEM_STATE_PATH = os.path.join(os.path.dirname(__file__), "../../../../config/system_state.json")
+
+class StopTradingRequest(BaseModel):
+    reason: str = "User initiated manual stop"
+
+@router.post("/stop")
+def stop_trading(req: StopTradingRequest):
+    """
+    Emergency stop switch.
+    Creates a sentinel file that the main loop can check.
+    """
+    try:
+        # Create a hard block file that sentinel / main loop should check
+        stop_file = os.path.join(os.path.dirname(__file__), "../../../../.EMERGENCY_STOP")
+        with open(stop_file, "w") as f:
+            f.write(req.reason)
+            
+        return {"status": "ok", "message": "Trading has been halted immediately."}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/resume")
+def resume_trading():
+    """
+    Resume trading (only removes emergency stop, doesn't enable auto-trading).
+    """
+    try:
+        stop_file = os.path.join(os.path.dirname(__file__), "../../../../.EMERGENCY_STOP")
+        if os.path.exists(stop_file):
+            os.remove(stop_file)
+        return {"status": "ok", "message": "Emergency stop cleared. Auto-trading still requires manual enable."}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/enable")
+def enable_auto_trading():
+    """
+    Enable auto-trading (主開關 ON).
+    """
+    try:
+        with open(SYSTEM_STATE_PATH, "r") as f:
+            data = json.load(f)
+        
+        data["trading_enabled"] = True
+        data["last_modified"] = datetime.now().isoformat()
+        data["last_modified_by"] = "user (via API)"
+        
+        with open(SYSTEM_STATE_PATH, "w") as f:
+            json.dump(data, f, indent=2)
+            
+        return {"status": "ok", "message": "Auto-trading enabled. System will start processing signals when market is open."}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/disable")
+def disable_auto_trading():
+    """
+    Disable auto-trading (主開關 OFF).
+    """
+    try:
+        with open(SYSTEM_STATE_PATH, "r") as f:
+            data = json.load(f)
+        
+        data["trading_enabled"] = False
+        data["last_modified"] = datetime.now().isoformat()
+        data["last_modified_by"] = "user (via API)"
+        
+        with open(SYSTEM_STATE_PATH, "w") as f:
+            json.dump(data, f, indent=2)
+            
+        return {"status": "ok", "message": "Auto-trading disabled. System will not process any new signals."}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/simulation")
+def switch_to_simulation():
+    """
+    Switch to simulation mode (模擬盤).
+    """
+    try:
+        with open(SYSTEM_STATE_PATH, "r") as f:
+            data = json.load(f)
+        
+        data["simulation_mode"] = True
+        data["last_modified"] = datetime.now().isoformat()
+        data["last_modified_by"] = "user (via API: simulation)"
+        
+        with open(SYSTEM_STATE_PATH, "w") as f:
+            json.dump(data, f, indent=2)
+            
+        return {"status": "ok", "message": "Switched to simulation mode (模擬盤). No real money will be traded."}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/live")
+def switch_to_live():
+    """
+    Switch to live trading mode (實際盤). WARNING: Real money will be at risk.
+    Automatically disables auto-trading for safety.
+    """
+    try:
+        with open(SYSTEM_STATE_PATH, "r") as f:
+            data = json.load(f)
+        
+        # Force disable auto-trading when switching to live mode
+        data["trading_enabled"] = False
+        data["simulation_mode"] = False
+        data["last_modified"] = datetime.now().isoformat()
+        data["last_modified_by"] = "user (via API: live)"
+        
+        with open(SYSTEM_STATE_PATH, "w") as f:
+            json.dump(data, f, indent=2)
+            
+        return {
+            "status": "ok", 
+            "message": "Switched to LIVE trading mode (實際盤). WARNING: Real money at risk! Auto-trading has been disabled for safety.",
+            "warning": "REAL MONEY MODE ENABLED - AUTO-TRADING DISABLED"
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+@router.get("/status")
+def get_control_status():
+    """
+    Get current control status (emergency stop + auto-trading enabled + simulation mode).
+    """
+    try:
+        with open(SYSTEM_STATE_PATH, "r") as f:
+            system_state = json.load(f)
+        
+        stop_file = os.path.join(os.path.dirname(__file__), "../../../../.EMERGENCY_STOP")
+        emergency_stop = os.path.exists(stop_file)
+        emergency_reason = None
+        if emergency_stop:
+            with open(stop_file, "r") as f:
+                emergency_reason = f.read().strip()
+        
+        return {
+            "status": "ok",
+            "emergency_stop": emergency_stop,
+            "emergency_reason": emergency_reason,
+            "auto_trading_enabled": system_state["trading_enabled"],
+            "simulation_mode": system_state["simulation_mode"],
+            "last_modified": system_state["last_modified"],
+            "mode_warning": "REAL MONEY AT RISK" if not system_state["simulation_mode"] else "Simulation (safe)"
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+

--- a/frontend/backend/app/api/portfolio.py
+++ b/frontend/backend/app/api/portfolio.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.services.shioaji_service import get_positions
+
+router = APIRouter(prefix="/api/portfolio", tags=["portfolio"])
+
+
+@router.get("/positions")
+def portfolio_positions(source: str = "mock", simulation: bool = True):
+    """Return portfolio positions.
+
+    source: mock|shioaji (default mock for speed)
+    """
+    source = source.lower().strip()
+    if source not in {"mock", "shioaji"}:
+        source = "mock"
+
+    return {"status": "ok", **get_positions(source=source, simulation=simulation)}

--- a/frontend/backend/app/api/settings.py
+++ b/frontend/backend/app/api/settings.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import json
+import os
+
+router = APIRouter(prefix="/api/settings", tags=["Settings"])
+
+POLICY_PATH = os.path.join(os.path.dirname(__file__), "../../../../config/sentinel_policy_v1.json")
+
+class BudgetUpdateRequest(BaseModel):
+    max_position_notional_pct_nav: float
+
+@router.get("/limits")
+def get_limits():
+    """Get current position limits from sentinel policy"""
+    try:
+        with open(POLICY_PATH, "r") as f:
+            data = json.load(f)
+        levels = data.get("position_limits", {}).get("levels", {})
+        # Return level 3 for demo
+        return {"status": "ok", "level_3": levels.get("3", {})}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/limits")
+def update_limits(req: BudgetUpdateRequest):
+    """Update max position sizing via sentinel policy"""
+    try:
+        with open(POLICY_PATH, "r") as f:
+            data = json.load(f)
+            
+        if "position_limits" not in data:
+            data["position_limits"] = {"levels": {}}
+            
+        # Update level 3 auto-trading limit
+        if "3" in data["position_limits"]["levels"]:
+            data["position_limits"]["levels"]["3"]["max_position_notional_pct_nav"] = req.max_position_notional_pct_nav
+            
+        with open(POLICY_PATH, "w") as f:
+            json.dump(data, f, indent=2)
+            
+        return {"status": "ok", "message": "Limits updated successfully"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/backend/app/api/strategy.py
+++ b/frontend/backend/app/api/strategy.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.db import fetch_rows, get_conn
+
+router = APIRouter(prefix="/api/strategy", tags=["strategy"])
+
+
+def _conn_dep():
+    # FastAPI dependency wrapper around contextmanager
+    try:
+        with get_conn() as conn:
+            yield conn
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"DB connection failed: {e}")
+
+
+@router.get("/proposals")
+def get_strategy_proposals(limit: int = 50, offset: int = 0, conn=Depends(_conn_dep)):
+    """Read-only: return rows from strategy_proposals."""
+    try:
+        data = fetch_rows(conn, table="strategy_proposals", limit=limit, offset=offset)
+        return {"status": "ok", "data": data, "limit": limit, "offset": offset}
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read strategy_proposals: {e}")
+
+
+@router.get("/logs")
+def get_strategy_logs(limit: int = 50, offset: int = 0, conn=Depends(_conn_dep)):
+    """Read-only: return rows from llm_traces."""
+    try:
+        data = fetch_rows(conn, table="llm_traces", limit=limit, offset=offset)
+        return {"status": "ok", "data": data, "limit": limit, "offset": offset}
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read llm_traces: {e}")

--- a/frontend/backend/app/api/stream.py
+++ b/frontend/backend/app/api/stream.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from sse_starlette.sse import EventSourceResponse
+
+from app.db import DB_PATH, connect_readonly
+
+router = APIRouter(prefix="/api/stream", tags=["stream"])
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except Exception:
+        return default
+
+
+# Tuning / safety knobs
+SSE_MAX_CLIENTS = max(1, _env_int("SSE_MAX_CLIENTS", 10))
+SSE_POLL_INTERVAL_MS = max(200, _env_int("SSE_POLL_INTERVAL_MS", 800))
+SSE_HEARTBEAT_SEC = max(1, _env_int("SSE_HEARTBEAT_SEC", 5))
+SSE_BATCH_LIMIT = max(1, min(_env_int("SSE_BATCH_LIMIT", 50), 200))
+
+_client_sema = asyncio.Semaphore(SSE_MAX_CLIENTS)
+
+
+@dataclass
+class Cursor:
+    """SSE cursor.
+
+    We use SQLite `rowid` as the cursor because it is monotonic for inserts.
+    """
+
+    rowid: int = 0
+
+
+def _parse_last_event_id(value: Optional[str]) -> Cursor:
+    if not value:
+        return Cursor(rowid=0)
+    try:
+        return Cursor(rowid=max(0, int(str(value).strip())))
+    except Exception:
+        return Cursor(rowid=0)
+
+
+def _mask_sensitive(s: str) -> str:
+    """Best-effort redaction.
+
+    Streaming prompt/response is OFF by default; if enabled, we still do a light mask.
+    """
+
+    if not s:
+        return s
+
+    for token in ["sk-", "AIza", "xoxb-", "xoxp-"]:
+        if token in s:
+            s = s.replace(token, token[0] + "***")
+
+    return s
+
+
+def _to_log_event(row: Dict[str, Any]) -> Dict[str, Any]:
+    created_at = row.get("created_at")
+    try:
+        ts_ms = int(created_at) * 1000
+    except Exception:
+        ts_ms = int(time.time() * 1000)
+
+    evt: Dict[str, Any] = {
+        "type": "trace",
+        "level": "INFO",
+        "ts": ts_ms,
+        "trace_id": row.get("trace_id"),
+        "agent": row.get("agent"),
+        "model": row.get("model"),
+        "latency_ms": row.get("latency_ms"),
+        "prompt_tokens": row.get("prompt_tokens"),
+        "completion_tokens": row.get("completion_tokens"),
+        "confidence": row.get("confidence"),
+        "message": "LLM decision trace recorded",
+    }
+
+    # Sensitive fields are excluded unless explicitly enabled.
+    include_prompt = os.environ.get("LOG_STREAM_INCLUDE_PROMPT", "0") == "1"
+    include_response = os.environ.get("LOG_STREAM_INCLUDE_RESPONSE", "0") == "1"
+
+    if include_prompt:
+        evt["prompt_excerpt"] = _mask_sensitive(str(row.get("prompt") or ""))[:800]
+    if include_response:
+        evt["response_excerpt"] = _mask_sensitive(str(row.get("response") or ""))[:1200]
+
+    return evt
+
+
+def _fetch_new_traces(cursor: Cursor) -> list[dict[str, Any]]:
+    conn = connect_readonly(DB_PATH)
+    try:
+        rows = conn.execute(
+            """
+            SELECT rowid, trace_id, agent, model, prompt, response,
+                   latency_ms, prompt_tokens, completion_tokens, confidence, created_at
+            FROM llm_traces
+            WHERE rowid > ?
+            ORDER BY rowid ASC
+            LIMIT ?
+            """,
+            (cursor.rowid, SSE_BATCH_LIMIT),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+@router.get("/logs")
+async def stream_logs(request: Request):
+    """GET /api/stream/logs
+
+    Server-Sent Events stream:
+    - event `heartbeat`: JSON heartbeat (no id)
+    - event `log`: JSON decision/system log (id=rowid for resume)
+
+    Connection recovery:
+    - client reconnect will send `Last-Event-ID` header; we resume from that rowid.
+
+    Safety:
+    - read-only DB (mode=ro + query_only)
+    - connection limit (SSE_MAX_CLIENTS)
+    """
+
+    try:
+        await asyncio.wait_for(_client_sema.acquire(), timeout=0.1)
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=429, detail="SSE capacity reached; try again later")
+
+    cursor = _parse_last_event_id(request.headers.get("last-event-id"))
+
+    async def event_gen() -> AsyncGenerator[Dict[str, str], None]:
+        last_heartbeat = 0.0
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+
+                now = time.time()
+                if now - last_heartbeat >= SSE_HEARTBEAT_SEC:
+                    last_heartbeat = now
+                    yield {
+                        "event": "heartbeat",
+                        "data": json.dumps(
+                            {
+                                "type": "heartbeat",
+                                "level": "INFO",
+                                "ts": int(now * 1000),
+                                "message": "sentinel_heartbeat",
+                            },
+                            ensure_ascii=False,
+                        ),
+                    }
+
+                try:
+                    rows = await asyncio.to_thread(_fetch_new_traces, cursor)
+                    for r in rows:
+                        rid = int(r.get("rowid") or 0)
+                        if rid <= cursor.rowid:
+                            continue
+                        cursor.rowid = rid
+                        yield {
+                            "event": "log",
+                            "id": str(cursor.rowid),
+                            "data": json.dumps(_to_log_event(r), ensure_ascii=False),
+                        }
+                except Exception as e:
+                    # Keep stream alive, but inform the client.
+                    yield {
+                        "event": "log",
+                        "data": json.dumps(
+                            {
+                                "type": "system_warning",
+                                "level": "WARN",
+                                "ts": int(time.time() * 1000),
+                                "message": f"log stream warning: {e}",
+                            },
+                            ensure_ascii=False,
+                        ),
+                    }
+
+                await asyncio.sleep(SSE_POLL_INTERVAL_MS / 1000.0)
+        finally:
+            _client_sema.release()
+
+    return EventSourceResponse(event_gen())

--- a/frontend/backend/app/db.py
+++ b/frontend/backend/app/db.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Optional
+
+
+def _resolve_db_path() -> Path:
+    """Resolve DB path from env/relative defaults.
+
+    Default matches the repository layout:
+    backend/app/db.py -> backend root -> ../../data/sqlite/trades.db
+    """
+    env_path = os.environ.get("DB_PATH")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+
+    backend_root = Path(__file__).resolve().parent.parent
+    return (backend_root / ".." / ".." / "data" / "sqlite" / "trades.db").resolve()
+
+
+DB_PATH: Path = _resolve_db_path()
+
+
+def connect_readonly(db_path: Path = DB_PATH) -> sqlite3.Connection:
+    """Open sqlite connection in read-only mode.
+
+    Uses sqlite URI mode=ro to guarantee no writes.
+    """
+    if not db_path.exists():
+        raise FileNotFoundError(f"SQLite DB not found: {db_path}")
+
+    uri = f"file:{db_path.as_posix()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+
+    # Extra safety: force query-only.
+    try:
+        conn.execute("PRAGMA query_only = ON;")
+    except sqlite3.DatabaseError:
+        # Some sqlite builds may not support it; mode=ro still enforces read-only.
+        pass
+
+    return conn
+
+
+@contextmanager
+def get_conn(db_path: Path = DB_PATH) -> Iterator[sqlite3.Connection]:
+    conn = connect_readonly(db_path)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> List[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return [r[1] for r in rows]  # name
+
+
+def choose_order_by(conn: sqlite3.Connection, table: str, candidates: Iterable[str]) -> Optional[str]:
+    cols = set(_table_columns(conn, table))
+    for c in candidates:
+        if c in cols:
+            return c
+    return None
+
+
+def fetch_rows(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    limit: int = 50,
+    offset: int = 0,
+    order_by_candidates: Iterable[str] = ("created_at", "timestamp", "time", "id"),
+    desc: bool = True,
+) -> List[Dict[str, Any]]:
+    """Fetch rows from a fixed table name.
+
+    IMPORTANT: table name is interpolated (cannot be parameterized). Only call this
+    for trusted, hard-coded table names.
+    """
+
+    limit = max(1, min(int(limit), 500))
+    offset = max(0, int(offset))
+
+    order_col = choose_order_by(conn, table, order_by_candidates)
+    if order_col:
+        direction = "DESC" if desc else "ASC"
+        sql = f"SELECT * FROM {table} ORDER BY {order_col} {direction} LIMIT ? OFFSET ?"
+        params = (limit, offset)
+    else:
+        sql = f"SELECT * FROM {table} LIMIT ? OFFSET ?"
+        params = (limit, offset)
+
+    rows = conn.execute(sql, params).fetchall()
+    return [dict(r) for r in rows]

--- a/frontend/backend/app/main.py
+++ b/frontend/backend/app/main.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.api.portfolio import router as portfolio_router
+from app.api.control import router as control_router
+from app.api.settings import router as settings_router
+from app.api.strategy import router as strategy_router
+
+def _parse_cors_origins() -> List[str]:
+
+    """Parse CORS origins from env.
+
+    - CORS_ORIGINS="http://localhost:3000,http://localhost:5173"
+    - Default: common local dev origins
+    """
+
+    raw = os.environ.get("CORS_ORIGINS", "").strip()
+    if raw:
+        return [o.strip() for o in raw.split(",") if o.strip()]
+
+    return [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+
+
+app = FastAPI(title="AI-Trader Command Center API", version="0.1.0")
+
+# CORS: allow frontend to call API
+cors_origins = _parse_cors_origins()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/api/health", tags=["health"])
+def health_check():
+    return {"status": "ok", "service": "Command Center API"}
+
+
+# Routers
+app.include_router(control_router)
+app.include_router(settings_router)
+
+app.include_router(strategy_router)
+app.include_router(portfolio_router)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("PORT", "8080"))
+    uvicorn.run("app.main:app", host="0.0.0.0", port=port, reload=True)

--- a/frontend/backend/app/main.py
+++ b/frontend/backend/app/main.py
@@ -10,6 +10,7 @@ from app.api.portfolio import router as portfolio_router
 from app.api.control import router as control_router
 from app.api.settings import router as settings_router
 from app.api.strategy import router as strategy_router
+from app.api.stream import router as stream_router
 
 def _parse_cors_origins() -> List[str]:
 
@@ -55,6 +56,7 @@ app.include_router(settings_router)
 
 app.include_router(strategy_router)
 app.include_router(portfolio_router)
+app.include_router(stream_router)
 
 
 if __name__ == "__main__":

--- a/frontend/backend/app/services/shioaji_service.py
+++ b/frontend/backend/app/services/shioaji_service.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+import time
+from functools import lru_cache
+from typing import Any, Dict, List, Literal, Optional
+
+
+def _mock_positions() -> List[Dict[str, Any]]:
+    # Keep schema stable for frontend.
+    return [
+        {
+            "account": "SIMULATION",
+            "symbol": "2330",
+            "name": "TSMC",
+            "qty": 100,
+            "avg_price": 600.0,
+            "last_price": 620.0,
+            "market_value": 62000.0,
+            "unrealized_pnl": 2000.0,
+            "currency": "TWD",
+        },
+        {
+            "account": "SIMULATION",
+            "symbol": "0050",
+            "name": "TW50 ETF",
+            "qty": 10,
+            "avg_price": 140.0,
+            "last_price": 142.0,
+            "market_value": 1420.0,
+            "unrealized_pnl": 20.0,
+            "currency": "TWD",
+        },
+    ]
+
+
+@lru_cache(maxsize=1)
+def _get_api(simulation: bool = True):
+    """Create (and cache) Shioaji API instance.
+
+    NOTE: caching avoids repeated logins. The first login can still be slow.
+    """
+    import shioaji as sj  # type: ignore
+
+    api = sj.Shioaji(simulation=simulation)
+    api_key = os.environ.get("SHIOAJI_API_KEY")
+    secret_key = os.environ.get("SHIOAJI_SECRET_KEY")
+
+    if not api_key or not secret_key:
+        raise RuntimeError("Missing SHIOAJI_API_KEY / SHIOAJI_SECRET_KEY env vars")
+
+    api.login(api_key=api_key, secret_key=secret_key)
+    return api
+
+
+def get_positions(
+    *,
+    source: Literal["mock", "shioaji"] = "mock",
+    simulation: bool = True,
+    max_wait_seconds: float = 2.0,
+) -> Dict[str, Any]:
+    """Fetch positions.
+
+    Default returns mock data for speed/reliability.
+    """
+
+    if source == "mock":
+        return {"source": "mock", "simulation": simulation, "positions": _mock_positions()}
+
+    # Best-effort real fetch; fall back to mock if anything goes wrong or too slow.
+    t0 = time.time()
+    try:
+        api = _get_api(simulation=simulation)
+        # Shioaji has a few ways to fetch positions depending on account type.
+        # We'll try the most common 'list_positions' API.
+        positions = api.list_positions(api.stock_account)
+        out: List[Dict[str, Any]] = []
+        for p in positions:
+            out.append(
+                {
+                    "account": str(getattr(p, "account_id", "")) or "SHIOAJI",
+                    "symbol": getattr(p, "code", None) or getattr(p, "stock_id", None) or "",
+                    "name": getattr(p, "name", None) or "",
+                    "qty": float(getattr(p, "quantity", 0) or 0),
+                    "avg_price": float(getattr(p, "price", 0) or 0),
+                    "last_price": None,
+                    "market_value": None,
+                    "unrealized_pnl": None,
+                    "currency": "TWD",
+                }
+            )
+
+        if (time.time() - t0) > max_wait_seconds:
+            return {"source": "mock", "simulation": simulation, "positions": _mock_positions(), "note": "timeout_fallback"}
+
+        return {"source": "shioaji", "simulation": simulation, "positions": out}
+    except Exception as e:
+        return {"source": "mock", "simulation": simulation, "positions": _mock_positions(), "note": f"fallback: {e}"}

--- a/frontend/backend/tools/sse_smoke_test.py
+++ b/frontend/backend/tools/sse_smoke_test.py
@@ -1,0 +1,81 @@
+"""SSE smoke / light load test (no extra deps).
+
+Usage:
+  python3 scripts/sse_smoke_test.py --url http://localhost:8080/api/stream/logs --clients 20 --seconds 10
+
+This script opens N SSE connections and counts received events.
+"""
+
+from __future__ import annotations
+
+import argparse
+import threading
+import time
+import urllib.request
+
+
+def run_client(url: str, seconds: float, results: dict, idx: int):
+    end = time.time() + seconds
+    events = 0
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "text/event-stream"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            buf_event = {}
+            while time.time() < end:
+                line = resp.readline()
+                if not line:
+                    break
+                line = line.decode("utf-8", errors="ignore").strip("\r\n")
+                if line.startswith(":"):
+                    continue
+                if line.startswith("event:"):
+                    buf_event["event"] = line[len("event:") :].strip()
+                elif line.startswith("data:"):
+                    buf_event.setdefault("data", "")
+                    buf_event["data"] += line[len("data:") :].strip()
+                elif line.startswith("id:"):
+                    buf_event["id"] = line[len("id:") :].strip()
+                elif line == "":
+                    if buf_event:
+                        events += 1
+                        buf_event = {}
+    except Exception as e:
+        results[idx] = (events, str(e))
+        return
+
+    results[idx] = (events, None)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required=True)
+    ap.add_argument("--clients", type=int, default=10)
+    ap.add_argument("--seconds", type=float, default=10)
+    args = ap.parse_args()
+
+    results: dict[int, tuple[int, str | None]] = {}
+    threads = []
+
+    t0 = time.time()
+    for i in range(max(1, args.clients)):
+        th = threading.Thread(target=run_client, args=(args.url, args.seconds, results, i), daemon=True)
+        th.start()
+        threads.append(th)
+
+    for th in threads:
+        th.join()
+
+    dt = time.time() - t0
+    ok = sum(1 for _, err in results.values() if err is None)
+    total_events = sum(n for n, _ in results.values())
+    errs = [(i, err) for i, (n, err) in results.items() if err]
+
+    print(f"clients={args.clients} seconds={args.seconds} elapsed={dt:.2f}s ok={ok}/{args.clients} total_events={total_events}")
+    if errs:
+        print("errors (first 5):")
+        for i, err in errs[:5]:
+            print(f"  client#{i}: {err}")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/web/.gitignore
+++ b/frontend/web/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+/dist
+/.vite
+.DS_Store
+.env
+.env.local

--- a/frontend/web/README.md
+++ b/frontend/web/README.md
@@ -1,0 +1,39 @@
+# AI Trader — Frontend (Sprint 1)
+
+## Tech
+- Vite + React
+- Tailwind CSS
+- react-router-dom
+
+## Run dev server
+
+```bash
+cd /Users/openclaw/.openclaw/shared/projects/ai-trader/frontend/web
+npm install
+npm run dev
+```
+
+Open: http://localhost:5173
+
+## Portfolio API (placeholder)
+UI will try API first and fallback to mock data:
+
+```ts
+fetch('http://localhost:8080/api/portfolio/positions')
+```
+
+Recommended response shape:
+
+```json
+[
+  {"symbol":"AAPL","qty":40,"lastPrice":182.34,"avgCost":165.1}
+]
+```
+
+- `avgCost` is optional (used for unrealized P/L)
+
+## Pages
+- Portfolio (MVP)
+- Trades (placeholder)
+- Strategy (placeholder)
+- System (placeholder)

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Trader — Command Center</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -1,0 +1,2657 @@
+{
+  "name": "ai-trader-dashboard",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-trader-dashboard",
+      "version": "0.0.0",
+      "dependencies": {
+        "lucide-react": "^0.263.1",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.3",
+        "recharts": "^2.7.2"
+      },
+      "devDependencies": {
+        "@types/react": "^18.2.15",
+        "@types/react-dom": "^18.2.7",
+        "@vitejs/plugin-react": "^4.0.3",
+        "autoprefixer": "^10.4.19",
+        "postcss": "^8.4.38",
+        "tailwindcss": "^3.3.3",
+        "vite": "^4.4.5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001774",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.263.1",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.263.1.tgz",
+      "integrity": "sha512-keqxAx97PlaEN89PXZ6ki1N8nRjGWtDa4021GFYLNj0RgruM5odbpl8GHTExj0hhPq3sF6Up0gnxt6TSHu+ovw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.30.0.tgz",
+      "integrity": "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
+      "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ai-trader-dashboard",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "lucide-react": "^0.263.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "recharts": "^2.7.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.3",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.3.3",
+    "vite": "^4.4.5"
+  }
+}

--- a/frontend/web/postcss.config.cjs
+++ b/frontend/web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/frontend/web/src/App.jsx
+++ b/frontend/web/src/App.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Navigate, Route, Routes } from 'react-router-dom'
+import DashboardLayout from './layouts/DashboardLayout'
+import PortfolioPage from './pages/Portfolio'
+import TradesPage from './pages/Trades'
+import StrategyPage from './pages/Strategy'
+import SystemPage from './pages/System'
+
+export default function App() {
+  return (
+    <Routes>
+      <Route element={<DashboardLayout />}>
+        <Route path="/" element={<Navigate to="/portfolio" replace />} />
+        <Route path="/portfolio" element={<PortfolioPage />} />
+        <Route path="/trades" element={<TradesPage />} />
+        <Route path="/strategy" element={<StrategyPage />} />
+        <Route path="/system" element={<SystemPage />} />
+      </Route>
+      <Route path="*" element={<Navigate to="/portfolio" replace />} />
+    </Routes>
+  )
+}

--- a/frontend/web/src/components/ControlPanel.jsx
+++ b/frontend/web/src/components/ControlPanel.jsx
@@ -1,0 +1,345 @@
+import React, { useEffect, useMemo, useState } from 'react'
+
+// Default backend: FastAPI command center (see frontend/backend)
+// Override via Vite env: VITE_API_BASE=http://localhost:8080
+const DEFAULT_API_BASE = 'http://localhost:8080'
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function fetchJsonWithTimeout(url, options = {}, { timeoutMs = 5000 } = {}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {})
+      }
+    })
+
+    if (!res.ok) {
+      // Try to extract FastAPI detail for better UX
+      let detail = ''
+      try {
+        const body = await res.json()
+        detail = body?.detail ? `: ${body.detail}` : ''
+      } catch {
+        // ignore
+      }
+      throw new Error(`API error: ${res.status}${detail}`)
+    }
+
+    return await res.json()
+  } catch (err) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`timeout (${timeoutMs}ms)`) // normalized
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function callApiWithRetry(url, options, { retries = 1, backoffMs = 400, timeoutMs = 5000 } = {}) {
+  let lastErr
+  for (let i = 0; i <= retries; i++) {
+    try {
+      return await fetchJsonWithTimeout(url, options, { timeoutMs })
+    } catch (err) {
+      lastErr = err
+      // Only retry on network/timeout type errors
+      const msg = String(err?.message || '')
+      const retryable = msg.includes('timeout') || msg.includes('Failed to fetch')
+      if (!retryable || i === retries) break
+      await sleep(backoffMs * (i + 1))
+    }
+  }
+  throw lastErr
+}
+
+export default function ControlPanel() {
+  const API_BASE = useMemo(() => {
+    const base = import.meta?.env?.VITE_API_BASE || DEFAULT_API_BASE
+    return `${String(base).replace(/\/$/, '')}/api/control`
+  }, [])
+
+  const [status, setStatus] = useState(null)
+  const [loading, setLoading] = useState({})
+  const [error, setError] = useState(null)
+  const [lastAction, setLastAction] = useState(null)
+
+  const fetchStatus = async () => {
+    try {
+      const data = await callApiWithRetry(`${API_BASE}/status`, { method: 'GET' }, { retries: 1, timeoutMs: 4000 })
+      setStatus(data)
+      setError(null)
+    } catch (err) {
+      setError(`無法取得系統狀態: ${err.message}`)
+    }
+  }
+
+  useEffect(() => {
+    fetchStatus()
+    const interval = setInterval(fetchStatus, 5000)
+    return () => clearInterval(interval)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const callApi = async (endpoint, { method = 'POST', body } = {}) => {
+    const key = endpoint.split('/').pop()
+    setLoading(prev => ({ ...prev, [key]: true }))
+    setLastAction(null)
+    try {
+      const data = await callApiWithRetry(
+        `${API_BASE}${endpoint}`,
+        {
+          method,
+          body: body ? JSON.stringify(body) : undefined
+        },
+        { retries: 1, timeoutMs: 6000 }
+      )
+      setLastAction({ endpoint, message: data.message, warning: data.warning })
+      await fetchStatus()
+      return data
+    } catch (err) {
+      setError(`操作失敗: ${err.message}`)
+      return null
+    } finally {
+      setLoading(prev => ({ ...prev, [key]: false }))
+    }
+  }
+
+  const handleEnable = () => {
+    if (status?.simulation_mode === false) {
+      const confirm = window.confirm(
+        '⚠️ 警告：您目前處於實際盤模式。啟用自動交易將使用真實資金進行交易。\n\n' +
+          '請確認：\n' +
+          '1. 您已了解相關風險\n' +
+          '2. 您已設定適當的風險控制參數\n' +
+          '3. 您已準備好承擔潛在損失\n\n' +
+          '確定要啟用自動交易嗎？'
+      )
+      if (!confirm) return
+    }
+    callApi('/enable')
+  }
+
+  const handleDisable = () => callApi('/disable')
+
+  const handleEmergencyStop = () => {
+    const reason = prompt('請輸入緊急停止原因（可選）:', '手動緊急停止')
+    callApi('/stop', { method: 'POST', body: { reason: reason || 'User initiated manual stop' } })
+  }
+
+  const handleResume = () => callApi('/resume')
+  const handleSwitchToSimulation = () => callApi('/simulation')
+  const handleSwitchToLive = () => {
+    const confirm = window.confirm(
+      '🚨 極度危險警告 🚨\n\n' +
+        '您即將切換到實際盤模式。\n' +
+        '此模式下，所有交易將使用真實資金。\n\n' +
+        '注意事項：\n' +
+        '• 系統將自動禁用自動交易\n' +
+        '• 您必須手動啟用自動交易才會開始交易\n' +
+        '• 任何交易都可能導致資金損失\n' +
+        '• 請確保已設定適當的止損與風險控制\n\n' +
+        '確定要切換到實際盤嗎？'
+    )
+    if (confirm) callApi('/live')
+  }
+
+  if (!status) {
+    return (
+      <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4 text-sm">
+        <div className="flex items-center justify-between">
+          <div>載入控制面板...</div>
+          <div className="h-2 w-2 animate-pulse rounded-full bg-amber-400"></div>
+        </div>
+      </div>
+    )
+  }
+
+  const isEmergency = status.emergency_stop
+  const isAutoTradingEnabled = status.auto_trading_enabled
+  const isSimulation = status.simulation_mode
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-5 shadow-panel">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-sm font-semibold">系統主控制面板</div>
+          <div className="mt-1 text-xs text-slate-400">風險控制第一優先 • {isSimulation ? '模擬盤 (安全)' : '實際盤 (資金風險)'}</div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div
+            className={`flex items-center gap-1.5 rounded-full px-3 py-1 text-xs ${
+              isEmergency
+                ? 'bg-rose-900/40 text-rose-300'
+                : isAutoTradingEnabled
+                  ? 'bg-emerald-900/40 text-emerald-300'
+                  : 'bg-slate-800 text-slate-300'
+            }`}
+          >
+            <div
+              className={`h-2 w-2 rounded-full ${
+                isEmergency ? 'bg-rose-400 animate-pulse' : isAutoTradingEnabled ? 'bg-emerald-400' : 'bg-slate-400'
+              }`}
+            ></div>
+            {isEmergency ? '緊急停止中' : isAutoTradingEnabled ? '自動交易已啟用' : '自動交易已停用'}
+          </div>
+          <div
+            className={`flex items-center gap-1.5 rounded-full px-3 py-1 text-xs ${
+              isSimulation ? 'bg-blue-900/40 text-blue-300' : 'bg-rose-900/40 text-rose-300 animate-pulse'
+            }`}
+          >
+            <div className={`h-2 w-2 rounded-full ${isSimulation ? 'bg-blue-400' : 'bg-rose-400 animate-pulse'}`}></div>
+            {isSimulation ? '模擬盤' : '實際盤'}
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg bg-rose-900/20 p-3 text-sm text-rose-300 border border-rose-800">
+          <div className="font-medium">錯誤</div>
+          <div className="mt-1 text-xs">{error}</div>
+        </div>
+      )}
+
+      {lastAction && (
+        <div
+          className={`rounded-lg p-3 text-sm ${
+            lastAction.warning
+              ? 'bg-amber-900/20 text-amber-300 border border-amber-800'
+              : 'bg-emerald-900/20 text-emerald-300 border border-emerald-800'
+          }`}
+        >
+          <div className="font-medium">{lastAction.warning ? '警告' : '操作成功'}</div>
+          <div className="mt-1 text-xs">{lastAction.message}</div>
+          {lastAction.warning && <div className="mt-2 text-xs font-semibold">{lastAction.warning}</div>}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="col-span-2 space-y-3 rounded-xl border border-slate-800 bg-slate-900/30 p-4">
+          <div className="text-xs font-semibold text-slate-300">自動交易主開關</div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleEnable}
+              disabled={loading.enable || isEmergency || isAutoTradingEnabled}
+              className={`flex-1 rounded-lg py-2.5 text-sm font-medium transition-all ${
+                isEmergency || isAutoTradingEnabled
+                  ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
+                  : 'bg-emerald-600 hover:bg-emerald-500 text-white'
+              }`}
+            >
+              {loading.enable ? '處理中...' : '🟢 啟動自動交易'}
+            </button>
+            <button
+              onClick={handleDisable}
+              disabled={loading.disable || isEmergency || !isAutoTradingEnabled}
+              className={`flex-1 rounded-lg py-2.5 text-sm font-medium transition-all ${
+                isEmergency || !isAutoTradingEnabled
+                  ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
+                  : 'bg-rose-600 hover:bg-rose-500 text-white'
+              }`}
+            >
+              {loading.disable ? '處理中...' : '🔴 停止自動交易'}
+            </button>
+          </div>
+        </div>
+
+        <div className="col-span-2 space-y-3 rounded-xl border border-slate-800 bg-slate-900/30 p-4">
+          <div className="text-xs font-semibold text-slate-300">交易模式切換</div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleSwitchToSimulation}
+              disabled={loading.simulation || isEmergency || isSimulation}
+              className={`flex-1 rounded-lg py-2.5 text-sm font-medium transition-all ${
+                isEmergency || isSimulation
+                  ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
+                  : 'bg-blue-600 hover:bg-blue-500 text-white'
+              }`}
+            >
+              {loading.simulation ? '切換中...' : '🔵 切換至模擬盤'}
+            </button>
+            <button
+              onClick={handleSwitchToLive}
+              disabled={loading.live || isEmergency || !isSimulation}
+              className={`flex-1 rounded-lg py-2.5 text-sm font-medium transition-all ${
+                isEmergency || !isSimulation
+                  ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
+                  : 'bg-rose-600 hover:bg-rose-500 text-white'
+              }`}
+            >
+              {loading.live ? '切換中...' : '🔴 切換至實際盤'}
+            </button>
+          </div>
+        </div>
+
+        <div className="col-span-2 space-y-3 rounded-xl border border-slate-800 bg-slate-900/30 p-4">
+          <div className="text-xs font-semibold text-slate-300">緊急控制</div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleEmergencyStop}
+              disabled={loading.stop || isEmergency}
+              className={`flex-1 rounded-lg py-2.5 text-sm font-medium transition-all ${
+                isEmergency ? 'bg-rose-900 text-rose-300 cursor-not-allowed' : 'bg-rose-700 hover:bg-rose-600 text-white'
+              }`}
+            >
+              {loading.stop ? '處理中...' : '🛑 緊急停止 (立即中斷)'}
+            </button>
+            <button
+              onClick={handleResume}
+              disabled={loading.resume || !isEmergency}
+              className={`flex-1 rounded-lg py-2.5 text-sm font-medium transition-all ${
+                !isEmergency ? 'bg-slate-800 text-slate-500 cursor-not-allowed' : 'bg-amber-600 hover:bg-amber-500 text-white'
+              }`}
+            >
+              {loading.resume ? '處理中...' : '🔄 清除緊急停止'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-slate-800 bg-slate-900/30 p-4">
+        <div className="text-xs font-semibold text-slate-300">系統狀態詳情</div>
+        <div className="mt-2 grid grid-cols-2 gap-3 text-xs">
+          <div className="space-y-1">
+            <div className="text-slate-400">自動交易狀態</div>
+            <div className={isAutoTradingEnabled ? 'text-emerald-300' : 'text-slate-300'}>
+              {isAutoTradingEnabled ? '已啟用' : '已停用'}
+            </div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-slate-400">交易模式</div>
+            <div className={isSimulation ? 'text-blue-300' : 'text-rose-300'}>{isSimulation ? '模擬盤 (安全)' : '實際盤 (資金風險)'}</div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-slate-400">緊急停止狀態</div>
+            <div className={isEmergency ? 'text-rose-300' : 'text-slate-300'}>
+              {isEmergency ? `已啟動: ${status.emergency_reason || '未知原因'}` : '未啟動'}
+            </div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-slate-400">最後更新</div>
+            <div className="text-slate-300">{status.last_modified ? new Date(status.last_modified).toLocaleString('zh-TW') : '未知'}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="text-xs text-slate-500">
+        <div className="font-semibold">操作須知：</div>
+        <ul className="mt-1 list-inside list-disc space-y-0.5">
+          <li>系統預設為「模擬盤 + 自動交易停用」狀態</li>
+          <li>切換至實際盤將自動禁用自動交易（雙重保險）</li>
+          <li>緊急停止優先級最高，會覆蓋所有其他控制</li>
+          <li>風險控制是第一優先</li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/frontend/web/src/components/KpiCard.jsx
+++ b/frontend/web/src/components/KpiCard.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function KpiCard({ title, value, subtext, tone = 'neutral' }) {
+  const toneClass =
+    tone === 'good'
+      ? 'text-emerald-300'
+      : tone === 'bad'
+        ? 'text-rose-300'
+        : 'text-slate-100'
+
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/30 p-4 shadow-panel">
+      <div className="text-xs uppercase tracking-widest text-slate-400">{title}</div>
+      <div className={`mt-2 text-2xl font-semibold ${toneClass}`}>{value}</div>
+      {subtext ? <div className="mt-2 text-xs text-slate-400">{subtext}</div> : null}
+    </div>
+  )
+}

--- a/frontend/web/src/components/LogTerminal.jsx
+++ b/frontend/web/src/components/LogTerminal.jsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+
+const DEFAULT_API_BASE = 'http://localhost:8080'
+
+function formatTs(ts) {
+  const n = Number(ts)
+  if (!Number.isFinite(n)) return ''
+  return new Date(n).toLocaleString('zh-TW', { hour12: false })
+}
+
+function safeJsonParse(s) {
+  try {
+    return JSON.parse(s)
+  } catch {
+    return null
+  }
+}
+
+export default function LogTerminal() {
+  const apiBase = useMemo(() => {
+    const base = import.meta?.env?.VITE_API_BASE || DEFAULT_API_BASE
+    return String(base).replace(/\/$/, '')
+  }, [])
+
+  const [connected, setConnected] = useState(false)
+  const [paused, setPaused] = useState(false)
+  const [level, setLevel] = useState('ALL')
+  const [query, setQuery] = useState('')
+  const [logs, setLogs] = useState([])
+  const [err, setErr] = useState(null)
+
+  const boxRef = useRef(null)
+  const lastEventIdRef = useRef(null)
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return (logs || []).filter(l => {
+      if (level !== 'ALL' && String(l?.level || '').toUpperCase() !== level) return false
+      if (!q) return true
+      const hay = `${l?.message || ''} ${l?.agent || ''} ${l?.model || ''} ${l?.trace_id || ''}`.toLowerCase()
+      return hay.includes(q)
+    })
+  }, [logs, level, query])
+
+  useEffect(() => {
+    if (paused) return
+    const el = boxRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [filtered.length, paused])
+
+  useEffect(() => {
+    if (paused) return
+
+    const url = `${apiBase}/api/stream/logs`
+    const es = new EventSource(url)
+
+    const onOpen = () => {
+      setConnected(true)
+      setErr(null)
+    }
+
+    const onError = () => {
+      setConnected(false)
+      setErr('連線中斷，將自動重連...')
+    }
+
+    const onHeartbeat = e => {
+      const payload = safeJsonParse(e.data) || { level: 'INFO', message: 'heartbeat', ts: Date.now(), type: 'heartbeat' }
+      // Don’t spam UI with heartbeats; keep only the latest heartbeat.
+      setLogs(prev => {
+        const next = prev.filter(x => x?.type !== 'heartbeat')
+        next.push(payload)
+        return next.slice(-500)
+      })
+    }
+
+    const onLog = e => {
+      const payload = safeJsonParse(e.data)
+      if (!payload) return
+      if (e?.lastEventId) lastEventIdRef.current = e.lastEventId
+      setLogs(prev => {
+        const next = [...prev, payload]
+        return next.slice(-500)
+      })
+    }
+
+    es.addEventListener('open', onOpen)
+    es.addEventListener('error', onError)
+    es.addEventListener('heartbeat', onHeartbeat)
+    es.addEventListener('log', onLog)
+
+    return () => {
+      es.close()
+      setConnected(false)
+    }
+  }, [apiBase, paused])
+
+  const clear = () => setLogs([])
+
+  const badgeCls = connected ? 'bg-emerald-900/40 text-emerald-300 border-emerald-800' : 'bg-rose-900/40 text-rose-300 border-rose-800'
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-slate-800 bg-slate-900/40 p-5 shadow-panel">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold">即時日誌終端機 (SSE)</div>
+          <div className="mt-1 text-xs text-slate-400">決策日誌 llm_traces + 系統心跳。預設不顯示 prompt/response（避免敏感資訊外洩）。</div>
+        </div>
+        <div className={`shrink-0 rounded-full border px-3 py-1 text-xs ${badgeCls}`}>{connected ? '已連線' : '未連線'}</div>
+      </div>
+
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={level}
+            onChange={e => setLevel(e.target.value)}
+            className="rounded-lg border border-slate-800 bg-slate-950/40 px-3 py-2 text-xs text-slate-200"
+          >
+            <option value="ALL">ALL</option>
+            <option value="INFO">INFO</option>
+            <option value="WARN">WARN</option>
+            <option value="ERROR">ERROR</option>
+          </select>
+
+          <input
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="搜尋 message / agent / model / trace_id"
+            className="w-72 max-w-full rounded-lg border border-slate-800 bg-slate-950/40 px-3 py-2 text-xs text-slate-200 placeholder:text-slate-500"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setPaused(p => !p)}
+            className={`rounded-lg px-3 py-2 text-xs font-medium transition-all ${
+              paused ? 'bg-amber-600 hover:bg-amber-500 text-white' : 'bg-slate-800 hover:bg-slate-700 text-slate-200'
+            }`}
+          >
+            {paused ? '▶ 繼續' : '⏸ 暫停'}
+          </button>
+          <button onClick={clear} className="rounded-lg bg-slate-800 px-3 py-2 text-xs font-medium text-slate-200 hover:bg-slate-700 transition-all">
+            清除
+          </button>
+        </div>
+      </div>
+
+      {err && <div className="rounded-lg border border-rose-800 bg-rose-900/20 p-3 text-xs text-rose-300">{err}</div>}
+
+      <div ref={boxRef} className="h-96 overflow-auto rounded-xl border border-slate-800 bg-slate-950/40 p-3 font-mono text-xs">
+        {filtered.length === 0 ? (
+          <div className="text-slate-500">尚無日誌（等待 SSE 推送...）</div>
+        ) : (
+          <div className="space-y-1">
+            {filtered.map((l, idx) => {
+              const lv = String(l?.level || 'INFO').toUpperCase()
+              const color = lv === 'ERROR' ? 'text-rose-300' : lv === 'WARN' ? 'text-amber-300' : 'text-slate-200'
+              const meta = [l?.agent, l?.model, l?.trace_id].filter(Boolean).join(' · ')
+              return (
+                <div key={`${l?.ts || idx}-${idx}`} className="flex gap-3">
+                  <div className="w-44 shrink-0 text-slate-500">{formatTs(l?.ts)}</div>
+                  <div className={`w-14 shrink-0 ${color}`}>{lv}</div>
+                  <div className="min-w-0 flex-1">
+                    <div className={`${color} break-words`}>{l?.message || JSON.stringify(l)}</div>
+                    {meta && <div className="mt-0.5 text-[10px] text-slate-500 break-words">{meta}</div>}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="text-[11px] text-slate-500">
+        <div>
+          API: <code className="text-slate-300">{apiBase}/api/stream/logs</code>
+        </div>
+        <div>
+          Cursor (Last-Event-ID): <code className="text-slate-300">{String(lastEventIdRef.current || '-')}</code>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/web/src/components/Sidebar.jsx
+++ b/frontend/web/src/components/Sidebar.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { NavLink } from 'react-router-dom'
+import { Briefcase, ArrowLeftRight, LineChart, Settings } from 'lucide-react'
+
+const nav = [
+  { to: '/portfolio', label: 'Portfolio', icon: Briefcase },
+  { to: '/trades', label: 'Trades', icon: ArrowLeftRight },
+  { to: '/strategy', label: 'Strategy', icon: LineChart },
+  { to: '/system', label: 'System', icon: Settings }
+]
+
+export default function Sidebar() {
+  return (
+    <aside className="w-64 border-r border-slate-900 bg-slate-950/60 p-4">
+      <div className="mb-6 rounded-2xl border border-slate-800 bg-slate-900/30 p-4 shadow-panel">
+        <div className="text-sm font-semibold">指揮中心</div>
+        <div className="mt-1 text-xs text-slate-400">暗黑戰情室風格 · MVP</div>
+      </div>
+
+      <nav className="space-y-1">
+        {nav.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            className={({ isActive }) =>
+              [
+                'group flex items-center gap-3 rounded-xl px-3 py-2 text-sm',
+                'transition-colors',
+                isActive
+                  ? 'bg-emerald-500/10 text-emerald-300 ring-1 ring-emerald-500/20'
+                  : 'text-slate-300 hover:bg-slate-900/40 hover:text-slate-100'
+              ].join(' ')
+            }
+          >
+            <item.icon className="h-4 w-4 opacity-90" />
+            <span>{item.label}</span>
+          </NavLink>
+        ))}
+      </nav>
+
+      <div className="mt-8 rounded-2xl border border-slate-900 bg-slate-950 p-4 text-xs text-slate-400">
+        <div className="font-medium text-slate-300">Tips</div>
+        <ul className="mt-2 list-disc space-y-1 pl-4">
+          <li>先用 mock data</li>
+          <li>API 上線後切換 fetch 即可</li>
+        </ul>
+      </div>
+    </aside>
+  )
+}

--- a/frontend/web/src/index.css
+++ b/frontend/web/src/index.css
@@ -1,0 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(51 65 85) transparent;
+}
+
+/* nicer selection */
+::selection {
+  background: rgba(16, 185, 129, 0.25);
+}

--- a/frontend/web/src/layouts/DashboardLayout.jsx
+++ b/frontend/web/src/layouts/DashboardLayout.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Outlet } from 'react-router-dom'
+import Sidebar from '../components/Sidebar'
+
+export default function DashboardLayout() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex min-h-screen max-w-[1400px]">
+        <Sidebar />
+        <main className="flex-1 p-6">
+          <div className="mb-6 flex items-center justify-between">
+            <div>
+              <div className="text-xs uppercase tracking-widest text-slate-400">Command Center</div>
+              <h1 className="text-2xl font-semibold text-slate-100">AI Trader Dashboard</h1>
+            </div>
+            <div className="flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900/40 px-3 py-2 text-xs text-slate-300 shadow-panel">
+              <span className="inline-block h-2 w-2 rounded-full bg-emerald-400" />
+              UI Online · API Pending
+            </div>
+          </div>
+
+          <Outlet />
+
+          <footer className="mt-10 border-t border-slate-900 pt-6 text-xs text-slate-500">
+            Sprint 1 · Mock data enabled · API: <code className="text-slate-300">http://localhost:8080/api/portfolio/positions</code>
+          </footer>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/web/src/lib/format.js
+++ b/frontend/web/src/lib/format.js
@@ -1,0 +1,15 @@
+export function formatCurrency(n, { currency = 'USD', maximumFractionDigits = 2 } = {}) {
+  const value = Number(n)
+  if (!Number.isFinite(value)) return '-'
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    maximumFractionDigits
+  }).format(value)
+}
+
+export function formatNumber(n, { maximumFractionDigits = 2 } = {}) {
+  const value = Number(n)
+  if (!Number.isFinite(value)) return '-'
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits }).format(value)
+}

--- a/frontend/web/src/lib/portfolio.js
+++ b/frontend/web/src/lib/portfolio.js
@@ -1,0 +1,32 @@
+const API_URL = 'http://localhost:8080/api/portfolio/positions'
+
+export const mockPositions = [
+  { symbol: 'AAPL', qty: 40, lastPrice: 182.34, avgCost: 165.1 },
+  { symbol: 'TSLA', qty: 15, lastPrice: 196.72, avgCost: 210.0 },
+  { symbol: 'NVDA', qty: 8, lastPrice: 865.5, avgCost: 740.25 }
+]
+
+/**
+ * Expected API shape (recommended):
+ * [{ symbol: string, qty: number, lastPrice: number, avgCost?: number }]
+ */
+export async function fetchPortfolioPositions({ signal } = {}) {
+  const res = await fetch(API_URL, { signal })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const data = await res.json()
+  if (!Array.isArray(data)) throw new Error('Invalid API response: expected array')
+  return data
+}
+
+export function calcPortfolioKpis(positions) {
+  const total = (positions ?? []).reduce((acc, p) => acc + Number(p.qty || 0) * Number(p.lastPrice || 0), 0)
+  const unrealized = (positions ?? []).reduce((acc, p) => {
+    const qty = Number(p.qty || 0)
+    const last = Number(p.lastPrice || 0)
+    const cost = Number(p.avgCost)
+    if (!Number.isFinite(cost)) return acc
+    return acc + (last - cost) * qty
+  }, 0)
+
+  return { total, unrealized }
+}

--- a/frontend/web/src/main.jsx
+++ b/frontend/web/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/frontend/web/src/pages/Portfolio.jsx
+++ b/frontend/web/src/pages/Portfolio.jsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import KpiCard from '../components/KpiCard'
+import { calcPortfolioKpis, fetchPortfolioPositions, mockPositions } from '../lib/portfolio'
+import { formatCurrency, formatNumber } from '../lib/format'
+
+export default function PortfolioPage() {
+  const [positions, setPositions] = useState(mockPositions)
+  const [source, setSource] = useState('mock')
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 1500)
+
+    try {
+      const data = await fetchPortfolioPositions({ signal: controller.signal })
+      setPositions(data)
+      setSource('api')
+    } catch (e) {
+      setPositions(mockPositions)
+      setSource('mock')
+      setError(String(e?.message || e))
+    } finally {
+      clearTimeout(timeout)
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    // MVP: try API first; fallback to mock
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const kpis = useMemo(() => calcPortfolioKpis(positions), [positions])
+  const unrealizedTone = kpis.unrealized >= 0 ? 'good' : 'bad'
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-sm font-semibold">庫存總覽 (Portfolio)</div>
+          <div className="mt-1 text-xs text-slate-400">
+            Data source:{' '}
+            <span
+              className={
+                source === 'api'
+                  ? 'rounded-md bg-emerald-500/10 px-2 py-0.5 text-emerald-300 ring-1 ring-emerald-500/20'
+                  : 'rounded-md bg-slate-800/50 px-2 py-0.5 text-slate-200 ring-1 ring-slate-700'
+              }
+            >
+              {source.toUpperCase()}
+            </span>
+            {error ? <span className="ml-2 text-rose-300">(fallback: {error})</span> : null}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={load}
+          disabled={loading}
+          className="rounded-xl border border-slate-800 bg-slate-900/40 px-4 py-2 text-sm text-slate-200 shadow-panel transition hover:bg-slate-900 disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : 'Reload'}
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <KpiCard title="總資產" value={formatCurrency(kpis.total)} subtext="Σ (qty × lastPrice)" />
+        <KpiCard
+          title="未實現損益"
+          value={formatCurrency(kpis.unrealized)}
+          subtext="需要 avgCost 才能計算；API 可選" 
+          tone={unrealizedTone}
+        />
+      </div>
+
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/20 shadow-panel">
+        <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
+          <div className="text-sm font-semibold">持倉列表</div>
+          <div className="text-xs text-slate-400">{positions.length} positions</div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead className="text-xs uppercase tracking-wider text-slate-400">
+              <tr>
+                <th className="px-4 py-3">代碼</th>
+                <th className="px-4 py-3">數量</th>
+                <th className="px-4 py-3">現價</th>
+                <th className="px-4 py-3">市值</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {positions.map((p) => {
+                const qty = Number(p.qty || 0)
+                const last = Number(p.lastPrice || 0)
+                const mv = qty * last
+                return (
+                  <tr key={p.symbol} className="hover:bg-slate-900/40">
+                    <td className="px-4 py-3 font-medium text-slate-100">{p.symbol}</td>
+                    <td className="px-4 py-3 text-slate-200">{formatNumber(qty, { maximumFractionDigits: 4 })}</td>
+                    <td className="px-4 py-3 text-slate-200">{formatCurrency(last)}</td>
+                    <td className="px-4 py-3 text-slate-200">{formatCurrency(mv)}</td>
+                  </tr>
+                )
+              })}
+
+              {positions.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="px-4 py-10 text-center text-slate-400">
+                    No positions.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/web/src/pages/Strategy.jsx
+++ b/frontend/web/src/pages/Strategy.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function StrategyPage() {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+      <div className="text-sm font-semibold">Strategy</div>
+      <div className="mt-2 text-sm text-slate-400">Sprint 1 placeholder.</div>
+    </div>
+  )
+}

--- a/frontend/web/src/pages/System.jsx
+++ b/frontend/web/src/pages/System.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ControlPanel from '../components/ControlPanel'
+import LogTerminal from '../components/LogTerminal'
 
 export default function SystemPage() {
   return (
@@ -12,6 +13,8 @@ export default function SystemPage() {
       </div>
 
       <ControlPanel />
+
+      <LogTerminal />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* 系統健康狀態 */}

--- a/frontend/web/src/pages/System.jsx
+++ b/frontend/web/src/pages/System.jsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import ControlPanel from '../components/ControlPanel'
+
+export default function SystemPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="text-sm font-semibold">系統監控與控制</div>
+        <div className="mt-1 text-xs text-slate-400">
+          主開關、緊急停止、模擬/實際盤切換。風險控制是第一優先。
+        </div>
+      </div>
+
+      <ControlPanel />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* 系統健康狀態 */}
+        <div className="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+          <div className="text-sm font-semibold">系統健康狀態</div>
+          <div className="mt-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-slate-300">後端 API</div>
+              <div className="flex items-center gap-2">
+                <span className="inline-block h-2 w-2 rounded-full bg-emerald-400"></span>
+                <span className="text-xs text-emerald-300">在線</span>
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-slate-300">資料庫連線</div>
+              <div className="flex items-center gap-2">
+                <span className="inline-block h-2 w-2 rounded-full bg-emerald-400"></span>
+                <span className="text-xs text-emerald-300">正常</span>
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-slate-300">Shioaji 連線</div>
+              <div className="flex items-center gap-2">
+                <span className="inline-block h-2 w-2 rounded-full bg-amber-400"></span>
+                <span className="text-xs text-amber-300">模擬模式</span>
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-slate-300">決策管線</div>
+              <div className="flex items-center gap-2">
+                <span className="inline-block h-2 w-2 rounded-full bg-emerald-400"></span>
+                <span className="text-xs text-emerald-300">就緒</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 快速操作 */}
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+          <div className="text-sm font-semibold">快速操作</div>
+          <div className="mt-4 space-y-3">
+            <button className="w-full rounded-lg bg-slate-800 py-2.5 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-all">
+              查看日誌
+            </button>
+            <button className="w-full rounded-lg bg-slate-800 py-2.5 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-all">
+              重新整理資料
+            </button>
+            <button className="w-full rounded-lg bg-slate-800 py-2.5 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-all">
+              備份設定
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* 版本資訊 */}
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+        <div className="text-sm font-semibold">系統版本資訊</div>
+        <div className="mt-4 grid grid-cols-2 md:grid-cols-4 gap-4 text-xs">
+          <div className="space-y-1">
+            <div className="text-slate-400">前端版本</div>
+            <div className="text-slate-300">v1.0.0 (Sprint 1)</div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-slate-400">後端版本</div>
+            <div className="text-slate-300">v4.0.0</div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-slate-400">最後部署</div>
+            <div className="text-slate-300">2026-02-28 19:15</div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-slate-400">開發模式</div>
+            <div className="text-slate-300">24/7 極限開發</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/web/src/pages/Trades.jsx
+++ b/frontend/web/src/pages/Trades.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function TradesPage() {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+      <div className="text-sm font-semibold">Trades</div>
+      <div className="mt-2 text-sm text-slate-400">Sprint 1 placeholder.</div>
+    </div>
+  )
+}

--- a/frontend/web/tailwind.config.cjs
+++ b/frontend/web/tailwind.config.cjs
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {
+      boxShadow: {
+        panel: '0 0 0 1px rgba(30, 41, 59, 0.6), 0 10px 30px rgba(0,0,0,0.35)'
+      }
+    }
+  },
+  plugins: []
+}

--- a/frontend/web/vite.config.js
+++ b/frontend/web/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import fs from 'fs'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    strictPort: true,
+    host: '0.0.0.0',
+    https: {
+      key: fs.readFileSync('/Users/openclaw/.openclaw/shared/projects/agent-monitor-web/cert/key.pem'),
+      cert: fs.readFileSync('/Users/openclaw/.openclaw/shared/projects/agent-monitor-web/cert/cert.pem')
+    }
+  }
+})

--- a/src/openclaw/decision_pipeline_v4.py
+++ b/src/openclaw/decision_pipeline_v4.py
@@ -11,6 +11,8 @@ from openclaw.model_registry import resolve_pinned_model_id
 from openclaw.news_guard import build_news_sentiment_prompt, sanitize_external_news_text
 from openclaw.pm_debate import build_debate_prompt
 from openclaw.risk_engine import OrderCandidate, SystemState
+from openclaw.system_switch import check_system_switch
+
 from openclaw.sentinel import SentinelVerdict, sentinel_pre_trade_check, sentinel_post_risk_check, pm_veto, is_hard_block
 from openclaw.token_budget import BudgetPolicy, evaluate_budget, load_budget_policy, emit_budget_event
 
@@ -122,6 +124,17 @@ def run_decision_with_sentinel(
     if decision_id is None:
         decision_id = f"dec_{uuid.uuid4().hex[:16]}"
     
+    # Step 0: Master switch check (highest priority safety)
+    import os
+
+    system_state_path = os.path.join(os.path.dirname(__file__), "../../config/system_state.json")
+    allowed, reason = check_system_switch(system_state_path)
+    if not allowed:
+        _insert_risk_check(conn, decision_id, "master_switch", False, reason)
+        # No decision record needed as this is before any order candidate
+        return False, "MASTER_SWITCH_OFF", None
+    _insert_risk_check(conn, decision_id, "master_switch", True, "Auto-trading enabled")
+    
     # Step 1: Load budget policy and evaluate budget status
     budget_policy = load_budget_policy(budget_policy_path)
     budget_status, budget_used_pct, budget_tier = evaluate_budget(conn, budget_policy)
@@ -160,9 +173,9 @@ def run_decision_with_sentinel(
         # Still insert decision record for audit trail
         if order_candidate:
             _insert_decision_record(
-                conn, decision_id, order_candidate.symbol, order_candidate.direction,
-                order_candidate.quantity, order_candidate.entry_price,
-                order_candidate.stop_loss, order_candidate.take_profit,
+                conn, decision_id, order_candidate.symbol, order_candidate.side,
+                order_candidate.qty, order_candidate.price,
+                getattr(order_candidate, "stop_loss", 0.0), getattr(order_candidate, "take_profit", 0.0),
                 sentinel_verdict, budget_status, budget_used_pct,
                 drawdown_decision, pm_approved
             )
@@ -182,9 +195,9 @@ def run_decision_with_sentinel(
         # PM veto overrides, but not a hard block
         if order_candidate:
             _insert_decision_record(
-                conn, decision_id, order_candidate.symbol, order_candidate.direction,
-                order_candidate.quantity, order_candidate.entry_price,
-                order_candidate.stop_loss, order_candidate.take_profit,
+                conn, decision_id, order_candidate.symbol, order_candidate.side,
+                order_candidate.qty, order_candidate.price,
+                getattr(order_candidate, "stop_loss", 0.0), getattr(order_candidate, "take_profit", 0.0),
                 sentinel_verdict, budget_status, budget_used_pct,
                 drawdown_decision, pm_approved
             )
@@ -211,9 +224,9 @@ def run_decision_with_sentinel(
         
         if is_hard_block(post_verdict) or not post_verdict.allowed:
             _insert_decision_record(
-                conn, decision_id, order_candidate.symbol, order_candidate.direction,
-                order_candidate.quantity, order_candidate.entry_price,
-                order_candidate.stop_loss, order_candidate.take_profit,
+                conn, decision_id, order_candidate.symbol, order_candidate.side,
+                order_candidate.qty, order_candidate.price,
+                getattr(order_candidate, "stop_loss", 0.0), getattr(order_candidate, "take_profit", 0.0),
                 sentinel_verdict, budget_status, budget_used_pct,
                 drawdown_decision, pm_approved
             )
@@ -222,9 +235,9 @@ def run_decision_with_sentinel(
     # Step 7: All checks passed, insert decision record
     if order_candidate:
         _insert_decision_record(
-            conn, decision_id, order_candidate.symbol, order_candidate.direction,
-            order_candidate.quantity, order_candidate.entry_price,
-            order_candidate.stop_loss, order_candidate.take_profit,
+            conn, decision_id, order_candidate.symbol, order_candidate.side,
+            order_candidate.qty, order_candidate.price,
+            getattr(order_candidate, "stop_loss", 0.0), getattr(order_candidate, "take_profit", 0.0),
             sentinel_verdict, budget_status, budget_used_pct,
             drawdown_decision, pm_approved
         )

--- a/src/openclaw/system_switch.py
+++ b/src/openclaw/system_switch.py
@@ -1,0 +1,46 @@
+"""System master switch check for auto-trading safety."""
+
+import json
+import os
+from pathlib import Path
+from typing import Tuple, Optional
+
+
+def check_system_switch(system_state_path: str) -> Tuple[bool, Optional[str]]:
+    """
+    Check if system is allowed to auto-trade.
+    
+    Returns: (allowed, reason_if_not_allowed)
+    """
+    # Check emergency stop file
+    project_root = Path(__file__).resolve().parents[2]
+    emergency_stop_file = project_root / ".EMERGENCY_STOP"
+    if emergency_stop_file.exists():
+        try:
+            reason = emergency_stop_file.read_text(encoding="utf-8").strip()
+            return False, f"EMERGENCY_STOP: {reason}"
+        except Exception:
+            return False, "EMERGENCY_STOP file exists"
+    
+    # Check system state config
+    try:
+        with open(system_state_path, "r") as f:
+            data = json.load(f)
+        
+        trading_enabled = data.get("trading_enabled", False)
+        if not trading_enabled:
+            return False, "Auto-trading is disabled (master switch OFF)"
+        
+        return True, None
+    except FileNotFoundError:
+        # If config file doesn't exist, default to disabled
+        return False, "System state config not found (default: disabled)"
+    except Exception as e:
+        return False, f"Error reading system state: {str(e)}"
+
+
+def is_auto_trading_allowed() -> bool:
+    """Convenience function for quick check."""
+    system_state_path = os.path.join(os.path.dirname(__file__), "../../config/system_state.json")
+    allowed, _ = check_system_switch(system_state_path)
+    return allowed


### PR DESCRIPTION
Closes #45

## 內容
- 新增 System 控制面板（自動交易主開關 / 模擬↔實際盤切換 / 緊急停止）
- 前端新增 timeout + retry 的 API 呼叫，避免卡死
- 後端 control API 新增/整理（/enable /disable /simulation /live /stop /resume /status）
- 新增 master switch gate：decision_pipeline_v4 Step0 會先檢查 system_state.json 與 .EMERGENCY_STOP
- 預設狀態符合風控：模擬盤 + 自動交易停用

## 測試
- `frontend/web`: `npm run build` ✅
- Python compile: `python3 -m py_compile ...` ✅

## 注意
- CORS origins 可用 `CORS_ORIGINS` env 覆蓋（預設允許 localhost:3000/5173）
- `.EMERGENCY_STOP` 已加入 .gitignore
