### PR TITLE
[Infra] Tailscale 安全部署：私有網路隔離，外部裝置安全連入儀表板

### DIFF
--- a/docs/tailscale/CLIENT_GUIDE.md
+++ b/docs/tailscale/CLIENT_GUIDE.md
@@ -1,0 +1,73 @@
+# 老闆端（手機/筆電）連線指南：透過 Tailscale 存取 Dashboard
+
+目標：人在外面也能安全打開 Dashboard，不需要公開 IP、不需要開路由器 port forwarding。
+
+---
+
+## A. 安裝並加入同一個 Tailnet
+
+1) 安裝 Tailscale
+- iOS/Android：App Store / Google Play 搜尋「Tailscale」
+- macOS/Windows：到 Tailscale 官網下載安裝
+
+2) 登入
+- 使用公司指定的登入方式（Google/Microsoft/SSO）
+
+3) 等待 Mac mini 裝置核准
+- 第一次加入可能需要 Admin 核准（建議開啟 Device approval）
+
+---
+
+## B. 連線確認
+
+開啟 Tailscale App，確認：
+- 狀態顯示 Connected
+- 能看到 Mac mini（例如名稱：`mac-mini` 或 `life-macmini`）
+
+---
+
+## C. 開啟 Dashboard / API
+
+### Dashboard（HTTPS）
+- 建議使用 MagicDNS：
+  - `https://<mac-mini-hostname>.<tailnet-name>.ts.net/`
+  - 或 `https://<mac-mini-hostname>/`（若 MagicDNS 已開啟）
+
+### API（HTTP / TCP）
+- `http://<mac-mini-hostname>.<tailnet-name>.ts.net:8080/`
+
+> 若使用 Caddy 方案，可能會是 `https://<TAILSCALE_IP>/`。
+
+---
+
+## D.（選配）使用 Exit Node
+
+若你在外面想把「所有流量」走家裡的 Mac mini（例如公司網路限制、或需要固定出口），可以：
+
+- 手機：Tailscale App → Exit Node → 選 Mac mini
+- 筆電：同上
+
+不用時請關閉 Exit Node。
+
+---
+
+## E. 故障排除
+
+1) 打不開網頁
+- 確認 Tailscale 已 Connected
+- 確認你加入的是同一個 Tailnet
+- 確認 Admin Console 裝置已核准
+- 確認 ACL 允許你連到 `443/8080`
+
+2) DNS 找不到主機
+- 確認 MagicDNS 已開啟
+- 改用 IP 測試：在 Mac mini 上查 `tailscale ip -4`，用 `https://<ip>/` 測試
+
+3) 速度慢
+- 先關閉 Exit Node 測試
+- 在手機/筆電查看是否顯示 Direct 連線（不是 DERP 中繼）
+
+4) 回報時請提供
+- 你的裝置名稱
+- 當下使用的網址
+- Tailscale App 畫面（Connected / Exit Node / 連線方式）

--- a/docs/tailscale/Caddyfile.example
+++ b/docs/tailscale/Caddyfile.example
@@ -1,0 +1,24 @@
+{
+	# Optional: disable auto HTTPS because we provide cert/key
+	auto_https off
+}
+
+# IMPORTANT:
+# - Replace <TAILSCALE_IP> with `tailscale ip -4`
+# - This listener will bind ONLY to the Tailscale interface IP.
+# - Web/API are only on localhost; Caddy reverse-proxies them.
+
+https://<TAILSCALE_IP> {
+	# Use existing cert from agent-monitor-web
+	tls /Users/openclaw/.openclaw/shared/projects/agent-monitor-web/cert/cert.pem /Users/openclaw/.openclaw/shared/projects/agent-monitor-web/cert/key.pem
+
+	# Dashboard
+	reverse_proxy /* 127.0.0.1:3000
+
+	# API (example: route /api/* to backend)
+	@api path /api/*
+	handle @api {
+		rewrite * {path}
+		reverse_proxy 127.0.0.1:8080
+	}
+}

--- a/docs/tailscale/DEPLOYMENT.md
+++ b/docs/tailscale/DEPLOYMENT.md
@@ -1,0 +1,185 @@
+# Tailscale 私有網路隔離部署（Mac mini）
+
+目標：讓外部裝置（老闆手機/筆電）**僅透過 Tailscale** 安全存取 Dashboard 與 API，**不暴露公網 IP**。
+
+> 本專案已將 Web/API 服務改為 **只綁定 localhost**：
+> - Web: `127.0.0.1:3000`
+> - API: `127.0.0.1:8080`
+>
+> 對外（Tailnet 內）存取請使用 Tailscale 的 `serve` 或反向代理（Caddy）。
+
+---
+
+## 1) 先決條件
+
+- 需要在 Mac mini 安裝並登入 Tailscale（GUI 或 CLI）
+- Tailnet 建議開啟：
+  - Device approval（裝置需核准）
+  - MagicDNS（方便用名稱存取）
+  - Key expiry（不要用永久 key）
+
+---
+
+## 2) Mac mini：Tailscale 基本設定
+
+### 2.1 安裝與登入
+
+GUI：下載安裝後登入即可。
+
+CLI（若已安裝）：
+
+```bash
+tailscale up --accept-dns=true --accept-routes=false
+```
+
+### 2.2（選配）啟用 Exit Node
+
+若需求是讓外部裝置把「所有流量」都走 Mac mini（例如在外地使用家中網路出口），才需要啟用。
+
+在 Mac mini 上：
+
+```bash
+tailscale up --advertise-exit-node=true
+```
+
+在客戶端裝置上：選擇使用此 Exit Node。
+
+> 安全提醒：Exit Node 會讓裝置的所有流量經過 Mac mini，請務必搭配 ACL/裝置核准與定期檢查。
+
+---
+
+## 3) 服務曝光方式（擇一）
+
+### 方案 A（建議、最省事）：`tailscale serve`
+
+優點：不需要額外安裝反向代理；服務僅在 tailnet 內可達。
+
+1) 先確保 Web/API 服務已由 PM2 啟動（本機仍是 localhost）：
+
+```bash
+pm2 start ecosystem.config.js
+pm2 status
+```
+
+2) 讓 tailnet 內用 HTTPS 存取 Dashboard（對應 localhost:3000）：
+
+```bash
+# 讓 443 -> http://127.0.0.1:3000
+tailscale serve --bg --https=443 http://127.0.0.1:3000
+```
+
+3) 讓 tailnet 內用 HTTP 存取 API（對應 localhost:8080）：
+
+```bash
+# 讓 8080 -> http://127.0.0.1:8080
+tailscale serve --bg --tcp=8080 tcp://127.0.0.1:8080
+```
+
+檢查：
+
+```bash
+tailscale serve status
+```
+
+存取方式：
+- Dashboard（HTTPS）：`https://<mac-mini-hostname>.<tailnet-name>.ts.net/`
+- API（HTTP）：`http://<mac-mini-hostname>.<tailnet-name>.ts.net:8080/`
+
+> 若你已開 MagicDNS，可直接用 `<mac-mini-hostname>`。
+
+---
+
+### 方案 B（需要既有憑證）：Caddy 只綁 Tailscale IP
+
+此方案使用既有 `agent-monitor-web` 憑證：
+- `/Users/openclaw/.openclaw/shared/projects/agent-monitor-web/cert/cert.pem`
+- `/Users/openclaw/.openclaw/shared/projects/agent-monitor-web/cert/key.pem`
+
+1) 取得 Tailscale IP：
+
+```bash
+tailscale ip -4
+```
+
+2) 建立 `docs/tailscale/Caddyfile.example`（已提供範本）並啟動 Caddy：
+
+```bash
+caddy run --config /path/to/Caddyfile
+```
+
+> Caddy 需要自行安裝（例如 brew）。
+
+---
+
+## 4) ACL（只允許老闆裝置）建議
+
+在 Tailscale Admin Console → **Access controls** 設定 ACL，建議做法：
+
+- 先把「老闆手機」「老闆筆電」「Mac mini」命名清楚
+- 建議建立 device tags（例如 `tag:dashboard-host`）
+- ACL 只允許：老闆裝置 → dashboard-host 的 `443,8080`
+
+範例（概念示意，需依 tailnet 實際 identity 調整）：
+
+```json
+{
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["user:boss@example.com"],
+      "dst": [
+        "tag:dashboard-host:443",
+        "tag:dashboard-host:8080"
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 5) 防火牆/暴露面檢查
+
+因本專案已改為綁 `127.0.0.1`，即使在 LAN 內也無法直接連到 `3000/8080`，只會在本機可達。
+
+建議定期檢查：
+
+```bash
+# 本機確認只在 loopback 聆聽
+lsof -nP -iTCP:3000 -sTCP:LISTEN
+lsof -nP -iTCP:8080 -sTCP:LISTEN
+```
+
+---
+
+## 6) 監控與稽核
+
+- 連線狀態：
+
+```bash
+tailscale status
+```
+
+- `serve` 狀態：
+
+```bash
+tailscale serve status
+```
+
+- Admin Console：查看 Device 連線/登入事件/ACL 命中
+
+---
+
+## 7) 回復/停用
+
+停用 `serve`：
+
+```bash
+tailscale serve reset
+```
+
+停用 exit node：
+
+```bash
+tailscale up --advertise-exit-node=false
+```

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,30 @@
+module.exports = {
+  apps: [
+    {
+      name: "ai-trader-api",
+      script: "/Users/openclaw/.openclaw/shared/projects/ai-trader/frontend/backend/run.sh",
+      cwd: "/Users/openclaw/.openclaw/shared/projects/ai-trader/frontend/backend",
+      interpreter: "bash",
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: "1G",
+      env: {
+        NODE_ENV: "development",
+        DB_PATH: "/Users/openclaw/.openclaw/shared/projects/ai-trader/data/sqlite/trades.db"
+      }
+    },
+    {
+      name: "ai-trader-web",
+      script: "npm",
+      args: "run dev -- --host 127.0.0.1 --port 3000",
+      cwd: "/Users/openclaw/.openclaw/shared/projects/ai-trader/frontend/web",
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      env: {
+        NODE_ENV: "development"
+      }
+    }
+  ]
+};

--- a/frontend/backend/run.sh
+++ b/frontend/backend/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+cd /Users/openclaw/.openclaw/shared/projects/ai-trader/frontend/backend
+# Get absolute path to the venv
+VENV_PYTHON="/Users/openclaw/.openclaw/shared/projects/ai-trader/bin/venv/bin/python"
+
+# Ensure requirements are met (optional on every start, but safe)
+# $VENV_PYTHON -m pip install -r requirements.txt > /dev/null 2>&1
+
+export PYTHONPATH="/Users/openclaw/.openclaw/shared/projects/ai-trader/src:/Users/openclaw/.openclaw/shared/projects/ai-trader/frontend/backend"
+export DB_PATH="/Users/openclaw/.openclaw/shared/projects/ai-trader/data/sqlite/trades.db"
+
+# Run uvicorn via python
+# Security: bind backend to localhost only; expose via Tailscale reverse-proxy/serve.
+exec $VENV_PYTHON -m uvicorn app.main:app --host 127.0.0.1 --port 8080

--- a/ops/tailscale/healthcheck.sh
+++ b/ops/tailscale/healthcheck.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple healthcheck for Tailscale + local services
+
+echo "[tailscale] status:" 
+tailscale status --json >/dev/null && echo "OK" || (echo "FAIL" && exit 1)
+
+echo "[serve] status:" 
+tailscale serve status || true
+
+echo "[listen] web 3000:" 
+lsof -nP -iTCP:3000 -sTCP:LISTEN || true
+
+echo "[listen] api 8080:" 
+lsof -nP -iTCP:8080 -sTCP:LISTEN || true

--- a/ops/tailscale/port_scan_local.sh
+++ b/ops/tailscale/port_scan_local.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local exposure check: ensure ports are NOT listening on non-loopback
+# Requires: lsof
+
+fail=0
+for port in 3000 8080; do
+  echo "Checking port $port ..."
+  # Grab LISTEN sockets and their local addresses
+  out=$(lsof -nP -iTCP:${port} -sTCP:LISTEN 2>/dev/null || true)
+  if [[ -z "$out" ]]; then
+    echo "  - Not listening"
+    continue
+  fi
+  echo "$out" | tail -n +2 | awk '{print $9}' | while read -r addr; do
+    # Example addr: 127.0.0.1:3000 or *:3000
+    if [[ "$addr" == *"*:"* ]] || [[ "$addr" == 0.0.0.0:* ]] || [[ "$addr" == "[::]"* ]]; then
+      echo "  [FAIL] $port is exposed on wildcard address: $addr"
+      fail=1
+    elif [[ "$addr" != 127.0.0.1:* ]] && [[ "$addr" != "[::1]:"* ]]; then
+      echo "  [WARN] $port listening on non-loopback: $addr"
+      fail=1
+    else
+      echo "  [OK] $addr"
+    fi
+  done
+
+done
+
+exit $fail


### PR DESCRIPTION
Closes #42

- Bind Web/API to localhost only (no LAN exposure)
- Document recommended Tailscale `tailscale serve` setup, ACL guidance, and client steps
- Provide optional Caddy config using existing agent-monitor-web cert
- Add ops scripts for healthcheck/port exposure verification