### PR TITLE
[Frontend] SSE 實時日誌流：推送決策日誌與系統心跳至前端

### DIFF
--- a/frontend/backend/app/api/stream.py
+++ b/frontend/backend/app/api/stream.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from sse_starlette.sse import EventSourceResponse
+
+from app.db import DB_PATH, connect_readonly
+
+router = APIRouter(prefix="/api/stream", tags=["stream"])
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except Exception:
+        return default
+
+
+# Tuning / safety knobs
+SSE_MAX_CLIENTS = max(1, _env_int("SSE_MAX_CLIENTS", 10))
+SSE_POLL_INTERVAL_MS = max(200, _env_int("SSE_POLL_INTERVAL_MS", 800))
+SSE_HEARTBEAT_SEC = max(1, _env_int("SSE_HEARTBEAT_SEC", 5))
+SSE_BATCH_LIMIT = max(1, min(_env_int("SSE_BATCH_LIMIT", 50), 200))
+
+_client_sema = asyncio.Semaphore(SSE_MAX_CLIENTS)
+
+
+@dataclass
+class Cursor:
+    """SSE cursor.
+
+    We use SQLite `rowid` as the cursor because it is monotonic for inserts.
+    """
+
+    rowid: int = 0
+
+
+def _parse_last_event_id(value: Optional[str]) -> Cursor:
+    if not value:
+        return Cursor(rowid=0)
+    try:
+        return Cursor(rowid=max(0, int(str(value).strip())))
+    except Exception:
+        return Cursor(rowid=0)
+
+
+def _mask_sensitive(s: str) -> str:
+    """Best-effort redaction.
+
+    Streaming prompt/response is OFF by default; if enabled, we still do a light mask.
+    """
+
+    if not s:
+        return s
+
+    for token in ["sk-", "AIza", "xoxb-", "xoxp-"]:
+        if token in s:
+            s = s.replace(token, token[0] + "***")
+
+    return s
+
+
+def _to_log_event(row: Dict[str, Any]) -> Dict[str, Any]:
+    created_at = row.get("created_at")
+    try:
+        ts_ms = int(created_at) * 1000
+    except Exception:
+        ts_ms = int(time.time() * 1000)
+
+    evt: Dict[str, Any] = {
+        "type": "trace",
+        "level": "INFO",
+        "ts": ts_ms,
+        "trace_id": row.get("trace_id"),
+        "agent": row.get("agent"),
+        "model": row.get("model"),
+        "latency_ms": row.get("latency_ms"),
+        "prompt_tokens": row.get("prompt_tokens"),
+        "completion_tokens": row.get("completion_tokens"),
+        "confidence": row.get("confidence"),
+        "message": "LLM decision trace recorded",
+    }
+
+    # Sensitive fields are excluded unless explicitly enabled.
+    include_prompt = os.environ.get("LOG_STREAM_INCLUDE_PROMPT", "0") == "1"
+    include_response = os.environ.get("LOG_STREAM_INCLUDE_RESPONSE", "0") == "1"
+
+    if include_prompt:
+        evt["prompt_excerpt"] = _mask_sensitive(str(row.get("prompt") or ""))[:800]
+    if include_response:
+        evt["response_excerpt"] = _mask_sensitive(str(row.get("response") or ""))[:1200]
+
+    return evt
+
+
+def _fetch_new_traces(cursor: Cursor) -> list[dict[str, Any]]:
+    conn = connect_readonly(DB_PATH)
+    try:
+        rows = conn.execute(
+            """
+            SELECT rowid, trace_id, agent, model, prompt, response,
+                   latency_ms, prompt_tokens, completion_tokens, confidence, created_at
+            FROM llm_traces
+            WHERE rowid > ?
+            ORDER BY rowid ASC
+            LIMIT ?
+            """,
+            (cursor.rowid, SSE_BATCH_LIMIT),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+@router.get("/logs")
+async def stream_logs(request: Request):
+    """GET /api/stream/logs
+
+    Server-Sent Events stream:
+    - event `heartbeat`: JSON heartbeat (no id)
+    - event `log`: JSON decision/system log (id=rowid for resume)
+
+    Connection recovery:
+    - client reconnect will send `Last-Event-ID` header; we resume from that rowid.
+
+    Safety:
+    - read-only DB (mode=ro + query_only)
+    - connection limit (SSE_MAX_CLIENTS)
+    """
+
+    try:
+        await asyncio.wait_for(_client_sema.acquire(), timeout=0.1)
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=429, detail="SSE capacity reached; try again later")
+
+    cursor = _parse_last_event_id(request.headers.get("last-event-id"))
+
+    async def event_gen() -> AsyncGenerator[Dict[str, str], None]:
+        last_heartbeat = 0.0
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+
+                now = time.time()
+                if now - last_heartbeat >= SSE_HEARTBEAT_SEC:
+                    last_heartbeat = now
+                    yield {
+                        "event": "heartbeat",
+                        "data": json.dumps(
+                            {
+                                "type": "heartbeat",
+                                "level": "INFO",
+                                "ts": int(now * 1000),
+                                "message": "sentinel_heartbeat",
+                            },
+                            ensure_ascii=False,
+                        ),
+                    }
+
+                try:
+                    rows = await asyncio.to_thread(_fetch_new_traces, cursor)
+                    for r in rows:
+                        rid = int(r.get("rowid") or 0)
+                        if rid <= cursor.rowid:
+                            continue
+                        cursor.rowid = rid
+                        yield {
+                            "event": "log",
+                            "id": str(cursor.rowid),
+                            "data": json.dumps(_to_log_event(r), ensure_ascii=False),
+                        }
+                except Exception as e:
+                    # Keep stream alive, but inform the client.
+                    yield {
+                        "event": "log",
+                        "data": json.dumps(
+                            {
+                                "type": "system_warning",
+                                "level": "WARN",
+                                "ts": int(time.time() * 1000),
+                                "message": f"log stream warning: {e}",
+                            },
+                            ensure_ascii=False,
+                        ),
+                    }
+
+                await asyncio.sleep(SSE_POLL_INTERVAL_MS / 1000.0)
+        finally:
+            _client_sema.release()
+
+    return EventSourceResponse(event_gen())

--- a/frontend/backend/app/main.py
+++ b/frontend/backend/app/main.py
@@ -10,6 +10,7 @@ from app.api.portfolio import router as portfolio_router
 from app.api.control import router as control_router
 from app.api.settings import router as settings_router
 from app.api.strategy import router as strategy_router
+from app.api.stream import router as stream_router
 
 def _parse_cors_origins() -> List[str]:
 
@@ -55,6 +56,7 @@ app.include_router(settings_router)
 
 app.include_router(strategy_router)
 app.include_router(portfolio_router)
+app.include_router(stream_router)
 
 
 if __name__ == "__main__":

--- a/frontend/backend/tools/sse_smoke_test.py
+++ b/frontend/backend/tools/sse_smoke_test.py
@@ -1,0 +1,81 @@
+"""SSE smoke / light load test (no extra deps).
+
+Usage:
+  python3 scripts/sse_smoke_test.py --url http://localhost:8080/api/stream/logs --clients 20 --seconds 10
+
+This script opens N SSE connections and counts received events.
+"""
+
+from __future__ import annotations
+
+import argparse
+import threading
+import time
+import urllib.request
+
+
+def run_client(url: str, seconds: float, results: dict, idx: int):
+    end = time.time() + seconds
+    events = 0
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "text/event-stream"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            buf_event = {}
+            while time.time() < end:
+                line = resp.readline()
+                if not line:
+                    break
+                line = line.decode("utf-8", errors="ignore").strip("\r\n")
+                if line.startswith(":"):
+                    continue
+                if line.startswith("event:"):
+                    buf_event["event"] = line[len("event:") :].strip()
+                elif line.startswith("data:"):
+                    buf_event.setdefault("data", "")
+                    buf_event["data"] += line[len("data:") :].strip()
+                elif line.startswith("id:"):
+                    buf_event["id"] = line[len("id:") :].strip()
+                elif line == "":
+                    if buf_event:
+                        events += 1
+                        buf_event = {}
+    except Exception as e:
+        results[idx] = (events, str(e))
+        return
+
+    results[idx] = (events, None)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required=True)
+    ap.add_argument("--clients", type=int, default=10)
+    ap.add_argument("--seconds", type=float, default=10)
+    args = ap.parse_args()
+
+    results: dict[int, tuple[int, str | None]] = {}
+    threads = []
+
+    t0 = time.time()
+    for i in range(max(1, args.clients)):
+        th = threading.Thread(target=run_client, args=(args.url, args.seconds, results, i), daemon=True)
+        th.start()
+        threads.append(th)
+
+    for th in threads:
+        th.join()
+
+    dt = time.time() - t0
+    ok = sum(1 for _, err in results.values() if err is None)
+    total_events = sum(n for n, _ in results.values())
+    errs = [(i, err) for i, (n, err) in results.items() if err]
+
+    print(f"clients={args.clients} seconds={args.seconds} elapsed={dt:.2f}s ok={ok}/{args.clients} total_events={total_events}")
+    if errs:
+        print("errors (first 5):")
+        for i, err in errs[:5]:
+            print(f"  client#{i}: {err}")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/web/src/components/LogTerminal.jsx
+++ b/frontend/web/src/components/LogTerminal.jsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+
+const DEFAULT_API_BASE = 'http://localhost:8080'
+
+function formatTs(ts) {
+  const n = Number(ts)
+  if (!Number.isFinite(n)) return ''
+  return new Date(n).toLocaleString('zh-TW', { hour12: false })
+}
+
+function safeJsonParse(s) {
+  try {
+    return JSON.parse(s)
+  } catch {
+    return null
+  }
+}
+
+export default function LogTerminal() {
+  const apiBase = useMemo(() => {
+    const base = import.meta?.env?.VITE_API_BASE || DEFAULT_API_BASE
+    return String(base).replace(/\/$/, '')
+  }, [])
+
+  const [connected, setConnected] = useState(false)
+  const [paused, setPaused] = useState(false)
+  const [level, setLevel] = useState('ALL')
+  const [query, setQuery] = useState('')
+  const [logs, setLogs] = useState([])
+  const [err, setErr] = useState(null)
+
+  const boxRef = useRef(null)
+  const lastEventIdRef = useRef(null)
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return (logs || []).filter(l => {
+      if (level !== 'ALL' && String(l?.level || '').toUpperCase() !== level) return false
+      if (!q) return true
+      const hay = `${l?.message || ''} ${l?.agent || ''} ${l?.model || ''} ${l?.trace_id || ''}`.toLowerCase()
+      return hay.includes(q)
+    })
+  }, [logs, level, query])
+
+  useEffect(() => {
+    if (paused) return
+    const el = boxRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [filtered.length, paused])
+
+  useEffect(() => {
+    if (paused) return
+
+    const url = `${apiBase}/api/stream/logs`
+    const es = new EventSource(url)
+
+    const onOpen = () => {
+      setConnected(true)
+      setErr(null)
+    }
+
+    const onError = () => {
+      setConnected(false)
+      setErr('連線中斷，將自動重連...')
+    }
+
+    const onHeartbeat = e => {
+      const payload = safeJsonParse(e.data) || { level: 'INFO', message: 'heartbeat', ts: Date.now(), type: 'heartbeat' }
+      // Don’t spam UI with heartbeats; keep only the latest heartbeat.
+      setLogs(prev => {
+        const next = prev.filter(x => x?.type !== 'heartbeat')
+        next.push(payload)
+        return next.slice(-500)
+      })
+    }
+
+    const onLog = e => {
+      const payload = safeJsonParse(e.data)
+      if (!payload) return
+      if (e?.lastEventId) lastEventIdRef.current = e.lastEventId
+      setLogs(prev => {
+        const next = [...prev, payload]
+        return next.slice(-500)
+      })
+    }
+
+    es.addEventListener('open', onOpen)
+    es.addEventListener('error', onError)
+    es.addEventListener('heartbeat', onHeartbeat)
+    es.addEventListener('log', onLog)
+
+    return () => {
+      es.close()
+      setConnected(false)
+    }
+  }, [apiBase, paused])
+
+  const clear = () => setLogs([])
+
+  const badgeCls = connected ? 'bg-emerald-900/40 text-emerald-300 border-emerald-800' : 'bg-rose-900/40 text-rose-300 border-rose-800'
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-slate-800 bg-slate-900/40 p-5 shadow-panel">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold">即時日誌終端機 (SSE)</div>
+          <div className="mt-1 text-xs text-slate-400">決策日誌 llm_traces + 系統心跳。預設不顯示 prompt/response（避免敏感資訊外洩）。</div>
+        </div>
+        <div className={`shrink-0 rounded-full border px-3 py-1 text-xs ${badgeCls}`}>{connected ? '已連線' : '未連線'}</div>
+      </div>
+
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={level}
+            onChange={e => setLevel(e.target.value)}
+            className="rounded-lg border border-slate-800 bg-slate-950/40 px-3 py-2 text-xs text-slate-200"
+          >
+            <option value="ALL">ALL</option>
+            <option value="INFO">INFO</option>
+            <option value="WARN">WARN</option>
+            <option value="ERROR">ERROR</option>
+          </select>
+
+          <input
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="搜尋 message / agent / model / trace_id"
+            className="w-72 max-w-full rounded-lg border border-slate-800 bg-slate-950/40 px-3 py-2 text-xs text-slate-200 placeholder:text-slate-500"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setPaused(p => !p)}
+            className={`rounded-lg px-3 py-2 text-xs font-medium transition-all ${
+              paused ? 'bg-amber-600 hover:bg-amber-500 text-white' : 'bg-slate-800 hover:bg-slate-700 text-slate-200'
+            }`}
+          >
+            {paused ? '▶ 繼續' : '⏸ 暫停'}
+          </button>
+          <button onClick={clear} className="rounded-lg bg-slate-800 px-3 py-2 text-xs font-medium text-slate-200 hover:bg-slate-700 transition-all">
+            清除
+          </button>
+        </div>
+      </div>
+
+      {err && <div className="rounded-lg border border-rose-800 bg-rose-900/20 p-3 text-xs text-rose-300">{err}</div>}
+
+      <div ref={boxRef} className="h-96 overflow-auto rounded-xl border border-slate-800 bg-slate-950/40 p-3 font-mono text-xs">
+        {filtered.length === 0 ? (
+          <div className="text-slate-500">尚無日誌（等待 SSE 推送...）</div>
+        ) : (
+          <div className="space-y-1">
+            {filtered.map((l, idx) => {
+              const lv = String(l?.level || 'INFO').toUpperCase()
+              const color = lv === 'ERROR' ? 'text-rose-300' : lv === 'WARN' ? 'text-amber-300' : 'text-slate-200'
+              const meta = [l?.agent, l?.model, l?.trace_id].filter(Boolean).join(' · ')
+              return (
+                <div key={`${l?.ts || idx}-${idx}`} className="flex gap-3">
+                  <div className="w-44 shrink-0 text-slate-500">{formatTs(l?.ts)}</div>
+                  <div className={`w-14 shrink-0 ${color}`}>{lv}</div>
+                  <div className="min-w-0 flex-1">
+                    <div className={`${color} break-words`}>{l?.message || JSON.stringify(l)}</div>
+                    {meta && <div className="mt-0.5 text-[10px] text-slate-500 break-words">{meta}</div>}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="text-[11px] text-slate-500">
+        <div>
+          API: <code className="text-slate-300">{apiBase}/api/stream/logs</code>
+        </div>
+        <div>
+          Cursor (Last-Event-ID): <code className="text-slate-300">{String(lastEventIdRef.current || '-')}</code>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/web/src/pages/System.jsx
+++ b/frontend/web/src/pages/System.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ControlPanel from '../components/ControlPanel'
+import LogTerminal from '../components/LogTerminal'
 
 export default function SystemPage() {
   return (
@@ -12,6 +13,8 @@ export default function SystemPage() {
       </div>
 
       <ControlPanel />
+
+      <LogTerminal />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* 系統健康狀態 */}


### PR DESCRIPTION
Closes #41

## What
- Backend: add `GET /api/stream/logs` SSE endpoint streaming heartbeat + `llm_traces` (read-only)
- Frontend: add `LogTerminal` component (filter/search/pause/autoscroll) shown in System page
- Tools: include light load test script (`frontend/backend/tools/sse_smoke_test.py`)

## Notes
- Uses SQLite `rowid` as SSE cursor (supports `Last-Event-ID` resume)
- Connection limit via `SSE_MAX_CLIENTS` env (default 10)
- `prompt` / `response` excluded by default; can enable excerpts via:
  - `LOG_STREAM_INCLUDE_PROMPT=1`
  - `LOG_STREAM_INCLUDE_RESPONSE=1`