### PR TITLE
[Frontend] 控制面板按鈕提升至全域導航欄（所有頁面可見）

### DIFF
--- a/frontend/web/src/components/ControlPanel.jsx
+++ b/frontend/web/src/components/ControlPanel.jsx
@@ -1,117 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react'
-
-// Default backend: FastAPI command center (see frontend/backend)
-// Override via Vite env: VITE_API_BASE=http://localhost:8080
-const DEFAULT_API_BASE = 'http://localhost:8080'
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
-
-async function fetchJsonWithTimeout(url, options = {}, { timeoutMs = 5000 } = {}) {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), timeoutMs)
-  try {
-    const res = await fetch(url, {
-      ...options,
-      signal: controller.signal,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(options.headers || {})
-      }
-    })
-
-    if (!res.ok) {
-      // Try to extract FastAPI detail for better UX
-      let detail = ''
-      try {
-        const body = await res.json()
-        detail = body?.detail ? `: ${body.detail}` : ''
-      } catch {
-        // ignore
-      }
-      throw new Error(`API error: ${res.status}${detail}`)
-    }
-
-    return await res.json()
-  } catch (err) {
-    if (err?.name === 'AbortError') {
-      throw new Error(`timeout (${timeoutMs}ms)`) // normalized
-    }
-    throw err
-  } finally {
-    clearTimeout(timer)
-  }
-}
-
-async function callApiWithRetry(url, options, { retries = 1, backoffMs = 400, timeoutMs = 5000 } = {}) {
-  let lastErr
-  for (let i = 0; i <= retries; i++) {
-    try {
-      return await fetchJsonWithTimeout(url, options, { timeoutMs })
-    } catch (err) {
-      lastErr = err
-      // Only retry on network/timeout type errors
-      const msg = String(err?.message || '')
-      const retryable = msg.includes('timeout') || msg.includes('Failed to fetch')
-      if (!retryable || i === retries) break
-      await sleep(backoffMs * (i + 1))
-    }
-  }
-  throw lastErr
-}
+import React from 'react'
+import { useControlStatus } from '../lib/controlApi'
 
 export default function ControlPanel() {
-  const API_BASE = useMemo(() => {
-    const base = import.meta?.env?.VITE_API_BASE || DEFAULT_API_BASE
-    return `${String(base).replace(/\/$/, '')}/api/control`
-  }, [])
-
-  const [status, setStatus] = useState(null)
-  const [loading, setLoading] = useState({})
-  const [error, setError] = useState(null)
-  const [lastAction, setLastAction] = useState(null)
-
-  const fetchStatus = async () => {
-    try {
-      const data = await callApiWithRetry(`${API_BASE}/status`, { method: 'GET' }, { retries: 1, timeoutMs: 4000 })
-      setStatus(data)
-      setError(null)
-    } catch (err) {
-      setError(`無法取得系統狀態: ${err.message}`)
-    }
-  }
-
-  useEffect(() => {
-    fetchStatus()
-    const interval = setInterval(fetchStatus, 5000)
-    return () => clearInterval(interval)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  const callApi = async (endpoint, { method = 'POST', body } = {}) => {
-    const key = endpoint.split('/').pop()
-    setLoading(prev => ({ ...prev, [key]: true }))
-    setLastAction(null)
-    try {
-      const data = await callApiWithRetry(
-        `${API_BASE}${endpoint}`,
-        {
-          method,
-          body: body ? JSON.stringify(body) : undefined
-        },
-        { retries: 1, timeoutMs: 6000 }
-      )
-      setLastAction({ endpoint, message: data.message, warning: data.warning })
-      await fetchStatus()
-      return data
-    } catch (err) {
-      setError(`操作失敗: ${err.message}`)
-      return null
-    } finally {
-      setLoading(prev => ({ ...prev, [key]: false }))
-    }
-  }
+  const { status, error, loading, lastAction, act } = useControlStatus({ pollMs: 5000 })
 
   const handleEnable = () => {
     if (status?.simulation_mode === false) {
@@ -125,18 +16,18 @@ export default function ControlPanel() {
       )
       if (!confirm) return
     }
-    callApi('/enable')
+    act('/enable')
   }
 
-  const handleDisable = () => callApi('/disable')
+  const handleDisable = () => act('/disable')
 
   const handleEmergencyStop = () => {
     const reason = prompt('請輸入緊急停止原因（可選）:', '手動緊急停止')
-    callApi('/stop', { method: 'POST', body: { reason: reason || 'User initiated manual stop' } })
+    act('/stop', { method: 'POST', body: { reason: reason || 'User initiated manual stop' } })
   }
 
-  const handleResume = () => callApi('/resume')
-  const handleSwitchToSimulation = () => callApi('/simulation')
+  const handleResume = () => act('/resume')
+  const handleSwitchToSimulation = () => act('/simulation')
   const handleSwitchToLive = () => {
     const confirm = window.confirm(
       '🚨 極度危險警告 🚨\n\n' +
@@ -149,7 +40,7 @@ export default function ControlPanel() {
         '• 請確保已設定適當的止損與風險控制\n\n' +
         '確定要切換到實際盤嗎？'
     )
-    if (confirm) callApi('/live')
+    if (confirm) act('/live')
   }
 
   if (!status) {
@@ -172,7 +63,9 @@ export default function ControlPanel() {
       <div className="flex items-center justify-between">
         <div>
           <div className="text-sm font-semibold">系統主控制面板</div>
-          <div className="mt-1 text-xs text-slate-400">風險控制第一優先 • {isSimulation ? '模擬盤 (安全)' : '實際盤 (資金風險)'}</div>
+          <div className="mt-1 text-xs text-slate-400">
+            風險控制第一優先 • {isSimulation ? '模擬盤 (安全)' : '實際盤 (資金風險)'}
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <div
@@ -316,7 +209,9 @@ export default function ControlPanel() {
           </div>
           <div className="space-y-1">
             <div className="text-slate-400">交易模式</div>
-            <div className={isSimulation ? 'text-blue-300' : 'text-rose-300'}>{isSimulation ? '模擬盤 (安全)' : '實際盤 (資金風險)'}</div>
+            <div className={isSimulation ? 'text-blue-300' : 'text-rose-300'}>
+              {isSimulation ? '模擬盤 (安全)' : '實際盤 (資金風險)'}
+            </div>
           </div>
           <div className="space-y-1">
             <div className="text-slate-400">緊急停止狀態</div>
@@ -326,7 +221,9 @@ export default function ControlPanel() {
           </div>
           <div className="space-y-1">
             <div className="text-slate-400">最後更新</div>
-            <div className="text-slate-300">{status.last_modified ? new Date(status.last_modified).toLocaleString('zh-TW') : '未知'}</div>
+            <div className="text-slate-300">
+              {status.last_modified ? new Date(status.last_modified).toLocaleString('zh-TW') : '未知'}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/web/src/components/GlobalControlBar.jsx
+++ b/frontend/web/src/components/GlobalControlBar.jsx
@@ -1,0 +1,202 @@
+import React from 'react'
+import { useControlStatus } from '../lib/controlApi'
+
+function Pill({ tone = 'slate', dotClassName = '', className = '', children, title }) {
+  const base = 'flex items-center gap-1.5 rounded-full px-3 py-1 text-xs whitespace-nowrap'
+  const toneMap = {
+    slate: 'bg-slate-900/40 text-slate-200 border border-slate-800',
+    emerald: 'bg-emerald-900/25 text-emerald-200 border border-emerald-900/40',
+    rose: 'bg-rose-900/25 text-rose-200 border border-rose-900/40',
+    blue: 'bg-blue-900/25 text-blue-200 border border-blue-900/40',
+    amber: 'bg-amber-900/20 text-amber-200 border border-amber-900/40'
+  }
+
+  return (
+    <div className={[base, toneMap[tone] || toneMap.slate, className].join(' ')} title={title}>
+      <span className={['h-2 w-2 rounded-full', dotClassName].join(' ')} />
+      <span>{children}</span>
+    </div>
+  )
+}
+
+export default function GlobalControlBar() {
+  const { status, error, loading, lastAction, act } = useControlStatus({ pollMs: 5000 })
+
+  const isEmergency = Boolean(status?.emergency_stop)
+  const isAutoTradingEnabled = Boolean(status?.auto_trading_enabled)
+  const isSimulation = status?.simulation_mode !== false // treat null as simulation/safe-ish
+
+  const handleEnable = () => {
+    if (status?.simulation_mode === false) {
+      const ok = window.confirm(
+        '⚠️ 警告：您目前處於實際盤模式。啟用自動交易將使用真實資金進行交易。\n\n確定要啟用自動交易嗎？'
+      )
+      if (!ok) return
+    }
+    act('/enable')
+  }
+
+  const handleDisable = () => act('/disable')
+
+  const handleSwitchToSimulation = () => act('/simulation')
+
+  const handleSwitchToLive = () => {
+    const ok = window.confirm(
+      '🚨 極度危險警告 🚨\n\n您即將切換到實際盤模式，所有交易將使用真實資金。\n\n確定要切換到實際盤嗎？'
+    )
+    if (ok) act('/live')
+  }
+
+  const handleEmergencyStop = () => {
+    const reason = prompt('請輸入緊急停止原因（可選）:', '手動緊急停止')
+    act('/stop', { method: 'POST', body: { reason: reason || 'User initiated manual stop' } })
+  }
+
+  const handleResume = () => act('/resume')
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex w-full flex-wrap items-center justify-end gap-2">
+        {/* Status pills */}
+        {status ? (
+          <>
+            <Pill
+              tone={isEmergency ? 'rose' : isAutoTradingEnabled ? 'emerald' : 'slate'}
+              dotClassName={isEmergency ? 'bg-rose-400 animate-pulse' : isAutoTradingEnabled ? 'bg-emerald-400' : 'bg-slate-400'}
+              title="自動交易狀態"
+            >
+              {isEmergency ? '緊急停止中' : isAutoTradingEnabled ? '自動交易：啟用' : '自動交易：停用'}
+            </Pill>
+            <Pill
+              tone={isSimulation ? 'blue' : 'rose'}
+              dotClassName={isSimulation ? 'bg-blue-400' : 'bg-rose-400 animate-pulse'}
+              title="交易模式"
+            >
+              {isSimulation ? '模式：模擬盤' : '模式：實際盤'}
+            </Pill>
+          </>
+        ) : (
+          <Pill tone="amber" dotClassName="bg-amber-400 animate-pulse" title="狀態載入中">
+            讀取系統狀態...
+          </Pill>
+        )}
+
+        {/* Actions */}
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            title="啟用自動交易"
+            onClick={handleEnable}
+            disabled={!status || loading.enable || isEmergency || isAutoTradingEnabled}
+            className={[
+              'rounded-lg px-3 py-1.5 text-xs font-semibold transition-all',
+              !status || isEmergency || isAutoTradingEnabled
+                ? 'bg-slate-900/40 text-slate-500 border border-slate-800 cursor-not-allowed'
+                : 'bg-emerald-600 hover:bg-emerald-500 text-white'
+            ].join(' ')}
+          >
+            {loading.enable ? '啟用中...' : '啟用'}
+          </button>
+
+          <button
+            title="停用自動交易"
+            onClick={handleDisable}
+            disabled={!status || loading.disable || isEmergency || !isAutoTradingEnabled}
+            className={[
+              'rounded-lg px-3 py-1.5 text-xs font-semibold transition-all',
+              !status || isEmergency || !isAutoTradingEnabled
+                ? 'bg-slate-900/40 text-slate-500 border border-slate-800 cursor-not-allowed'
+                : 'bg-slate-800 hover:bg-slate-700 text-slate-100 border border-slate-700'
+            ].join(' ')}
+          >
+            {loading.disable ? '停用中...' : '停用'}
+          </button>
+
+          <div className="hidden md:block h-5 w-px bg-slate-800 mx-1" />
+
+          <button
+            title="切換到模擬盤（較安全）"
+            onClick={handleSwitchToSimulation}
+            disabled={!status || loading.simulation || isEmergency || isSimulation}
+            className={[
+              'rounded-lg px-3 py-1.5 text-xs font-semibold transition-all',
+              !status || isEmergency || isSimulation
+                ? 'bg-slate-900/40 text-slate-500 border border-slate-800 cursor-not-allowed'
+                : 'bg-blue-600 hover:bg-blue-500 text-white'
+            ].join(' ')}
+          >
+            {loading.simulation ? '切換中...' : '模擬'}
+          </button>
+
+          <button
+            title="切換到實際盤（需二次確認）"
+            onClick={handleSwitchToLive}
+            disabled={!status || loading.live || isEmergency || !isSimulation}
+            className={[
+              'rounded-lg px-3 py-1.5 text-xs font-semibold transition-all',
+              !status || isEmergency || !isSimulation
+                ? 'bg-slate-900/40 text-slate-500 border border-slate-800 cursor-not-allowed'
+                : 'bg-rose-700 hover:bg-rose-600 text-white'
+            ].join(' ')}
+          >
+            {loading.live ? '切換中...' : '實際'}
+          </button>
+
+          <div className="hidden md:block h-5 w-px bg-slate-800 mx-1" />
+
+          <button
+            title="緊急停止（最高優先級）"
+            onClick={handleEmergencyStop}
+            disabled={!status || loading.stop || isEmergency}
+            className={[
+              'rounded-lg px-3 py-1.5 text-xs font-semibold transition-all',
+              !status || isEmergency
+                ? 'bg-rose-950/40 text-rose-300 border border-rose-900/40 cursor-not-allowed'
+                : 'bg-rose-600 hover:bg-rose-500 text-white'
+            ].join(' ')}
+          >
+            {loading.stop ? '停止中...' : '緊急停止'}
+          </button>
+
+          <button
+            title="清除緊急停止"
+            onClick={handleResume}
+            disabled={!status || loading.resume || !isEmergency}
+            className={[
+              'rounded-lg px-3 py-1.5 text-xs font-semibold transition-all',
+              !status || !isEmergency
+                ? 'bg-slate-900/40 text-slate-500 border border-slate-800 cursor-not-allowed'
+                : 'bg-amber-600 hover:bg-amber-500 text-white'
+            ].join(' ')}
+          >
+            {loading.resume ? '處理中...' : '解除停止'}
+          </button>
+        </div>
+      </div>
+
+      {/* lightweight feedback area */}
+      {(error || lastAction) && (
+        <div className="flex justify-end">
+          <div
+            className={[
+              'max-w-[720px] rounded-lg px-3 py-2 text-xs border',
+              error
+                ? 'bg-rose-900/20 text-rose-200 border-rose-900/50'
+                : lastAction?.warning
+                  ? 'bg-amber-900/20 text-amber-200 border-amber-900/50'
+                  : 'bg-emerald-900/15 text-emerald-200 border-emerald-900/40'
+            ].join(' ')}
+          >
+            {error ? (
+              <span>{error}</span>
+            ) : (
+              <span>
+                {lastAction?.warning ? `警告：${lastAction.message}` : `成功：${lastAction?.message}`}
+                {lastAction?.warning ? `（${lastAction.warning}）` : ''}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/web/src/layouts/DashboardLayout.jsx
+++ b/frontend/web/src/layouts/DashboardLayout.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Outlet } from 'react-router-dom'
 import Sidebar from '../components/Sidebar'
+import GlobalControlBar from '../components/GlobalControlBar'
 
 export default function DashboardLayout() {
   return (
@@ -8,21 +9,23 @@ export default function DashboardLayout() {
       <div className="mx-auto flex min-h-screen max-w-[1400px]">
         <Sidebar />
         <main className="flex-1 p-6">
-          <div className="mb-6 flex items-center justify-between">
+          <div className="mb-6 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div>
               <div className="text-xs uppercase tracking-widest text-slate-400">Command Center</div>
               <h1 className="text-2xl font-semibold text-slate-100">AI Trader Dashboard</h1>
             </div>
-            <div className="flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900/40 px-3 py-2 text-xs text-slate-300 shadow-panel">
-              <span className="inline-block h-2 w-2 rounded-full bg-emerald-400" />
-              UI Online · API Pending
+
+            {/* Global control bar: visible on all pages */}
+            <div className="lg:flex-1 lg:flex lg:justify-end">
+              <GlobalControlBar />
             </div>
           </div>
 
           <Outlet />
 
           <footer className="mt-10 border-t border-slate-900 pt-6 text-xs text-slate-500">
-            Sprint 1 · Mock data enabled · API: <code className="text-slate-300">http://localhost:8080/api/portfolio/positions</code>
+            Sprint 1 · Mock data enabled · API:{' '}
+            <code className="text-slate-300">http://localhost:8080/api/portfolio/positions</code>
           </footer>
         </main>
       </div>

--- a/frontend/web/src/lib/controlApi.js
+++ b/frontend/web/src/lib/controlApi.js
@@ -1,0 +1,149 @@
+// Shared control API client + React hook
+// Used by both System page ControlPanel and GlobalControlBar
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+// Default backend: FastAPI command center (see frontend/backend)
+// Override via Vite env: VITE_API_BASE=http://localhost:8080
+const DEFAULT_API_BASE = 'http://localhost:8080'
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function fetchJsonWithTimeout(url, options = {}, { timeoutMs = 5000 } = {}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {})
+      }
+    })
+
+    if (!res.ok) {
+      // Try to extract FastAPI detail for better UX
+      let detail = ''
+      try {
+        const body = await res.json()
+        detail = body?.detail ? `: ${body.detail}` : ''
+      } catch {
+        // ignore
+      }
+      throw new Error(`API error: ${res.status}${detail}`)
+    }
+
+    return await res.json()
+  } catch (err) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`timeout (${timeoutMs}ms)`) // normalized
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function callApiWithRetry(url, options, { retries = 1, backoffMs = 400, timeoutMs = 5000 } = {}) {
+  let lastErr
+  for (let i = 0; i <= retries; i++) {
+    try {
+      return await fetchJsonWithTimeout(url, options, { timeoutMs })
+    } catch (err) {
+      lastErr = err
+      // Only retry on network/timeout type errors
+      const msg = String(err?.message || '')
+      const retryable = msg.includes('timeout') || msg.includes('Failed to fetch')
+      if (!retryable || i === retries) break
+      await sleep(backoffMs * (i + 1))
+    }
+  }
+  throw lastErr
+}
+
+export function useControlApiBase() {
+  return useMemo(() => {
+    const base = import.meta?.env?.VITE_API_BASE || DEFAULT_API_BASE
+    return `${String(base).replace(/\/$/, '')}/api/control`
+  }, [])
+}
+
+export function createControlClient(API_BASE) {
+  return {
+    async status({ timeoutMs = 4000 } = {}) {
+      return await callApiWithRetry(`${API_BASE}/status`, { method: 'GET' }, { retries: 1, timeoutMs })
+    },
+    async action(endpoint, { method = 'POST', body, timeoutMs = 6000 } = {}) {
+      return await callApiWithRetry(
+        `${API_BASE}${endpoint}`,
+        {
+          method,
+          body: body ? JSON.stringify(body) : undefined
+        },
+        { retries: 1, timeoutMs }
+      )
+    }
+  }
+}
+
+/**
+ * Polls /status and provides an `act` helper that refreshes status after actions.
+ */
+export function useControlStatus({ pollMs = 5000 } = {}) {
+  const API_BASE = useControlApiBase()
+  const client = useMemo(() => createControlClient(API_BASE), [API_BASE])
+
+  const [status, setStatus] = useState(null)
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState({})
+  const [lastAction, setLastAction] = useState(null)
+
+  const mountedRef = useRef(false)
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const data = await client.status({ timeoutMs: 4000 })
+      if (!mountedRef.current) return
+      setStatus(data)
+      setError(null)
+    } catch (err) {
+      if (!mountedRef.current) return
+      setError(`無法取得系統狀態: ${err.message}`)
+    }
+  }, [client])
+
+  useEffect(() => {
+    mountedRef.current = true
+    fetchStatus()
+    const interval = setInterval(fetchStatus, pollMs)
+    return () => {
+      mountedRef.current = false
+      clearInterval(interval)
+    }
+  }, [fetchStatus, pollMs])
+
+  const act = useCallback(
+    async (endpoint, { method = 'POST', body } = {}) => {
+      const key = endpoint.split('/').pop()
+      setLoading(prev => ({ ...prev, [key]: true }))
+      setLastAction(null)
+      try {
+        const data = await client.action(endpoint, { method, body, timeoutMs: 6000 })
+        setLastAction({ endpoint, message: data.message, warning: data.warning })
+        await fetchStatus()
+        return data
+      } catch (err) {
+        setError(`操作失敗: ${err.message}`)
+        return null
+      } finally {
+        setLoading(prev => ({ ...prev, [key]: false }))
+      }
+    },
+    [client, fetchStatus]
+  )
+
+  return { status, error, loading, lastAction, fetchStatus, act, API_BASE }
+}


### PR DESCRIPTION
將 System 控制面板的核心邏輯抽出為共用 hook（useControlStatus），並新增 GlobalControlBar 置於 DashboardLayout 頂部導航列，讓主開關/模式切換/緊急停止在所有頁面可見。

- 新增：frontend/web/src/components/GlobalControlBar.jsx
- 新增：frontend/web/src/lib/controlApi.js（共用 API client + polling hook）
- 調整：DashboardLayout 頂部導覽列導入 GlobalControlBar
- 調整：ControlPanel 改用共用 hook，確保狀態同步

Closes #48

Closes #48

---
*Pull Request 由 TaskHub 自動建立*