### PR TITLE
Closes #52: FastAPI backend foundation + readonly SQLite

### DIFF
--- a/frontend/backend/.env.example
+++ b/frontend/backend/.env.example
@@ -1,0 +1,16 @@
+# Backend configuration
+
+# Path to sqlite DB (read-only mode is enforced by backend)
+DB_PATH=/Users/openclaw/.openclaw/shared/projects/ai-trader/data/sqlite/trades.db
+
+# CORS
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+
+# Rate limiting (requests per minute per client IP)
+RATE_LIMIT_RPM=120
+
+# Optional: allow state-changing endpoints (default false for safety)
+ENABLE_RW_ENDPOINTS=false
+
+# Operator token (used only when ENABLE_RW_ENDPOINTS=true)
+STRATEGY_OPS_TOKEN=change-me

--- a/frontend/backend/app/api/strategy.py
+++ b/frontend/backend/app/api/strategy.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+import sqlite3
+from typing import Optional
 
-from app.db import fetch_rows, get_conn
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel
+
+from app.core.config import get_settings
+from app.db import get_conn
+from app.services.strategy_service import StrategyService
 
 router = APIRouter(prefix="/api/strategy", tags=["strategy"])
 
+service = StrategyService()
 
-def _conn_dep():
-    # FastAPI dependency wrapper around contextmanager
+
+def conn_dep():
     try:
         with get_conn() as conn:
             yield conn
@@ -18,25 +25,67 @@ def _conn_dep():
         raise HTTPException(status_code=500, detail=f"DB connection failed: {e}")
 
 
+def require_ops_token(x_ops_token: Optional[str] = Header(default=None)) -> None:
+    settings = get_settings()
+    if not settings.strategy_ops_token:
+        raise HTTPException(status_code=503, detail="STRATEGY_OPS_TOKEN not configured on backend")
+    if not x_ops_token or x_ops_token != settings.strategy_ops_token:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+class DecideRequest(BaseModel):
+    actor: str = "user"
+    reason: str = ""
+
+
 @router.get("/proposals")
-def get_strategy_proposals(limit: int = 50, offset: int = 0, conn=Depends(_conn_dep)):
-    """Read-only: return rows from strategy_proposals."""
+def get_strategy_proposals(
+    limit: int = 50,
+    offset: int = 0,
+    status: Optional[str] = None,
+    conn: sqlite3.Connection = Depends(conn_dep),
+):
     try:
-        data = fetch_rows(conn, table="strategy_proposals", limit=limit, offset=offset)
-        return {"status": "ok", "data": data, "limit": limit, "offset": offset}
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=503, detail=str(e))
-    except Exception as e:
+        return service.list_proposals(conn, limit=limit, offset=offset, status=status)
+    except sqlite3.OperationalError as e:
+        # If the table doesn't exist in a fresh db, return empty (read-only service).
+        if "no such table" in str(e).lower():
+            return {"status": "ok", "data": [], "limit": limit, "offset": offset}
         raise HTTPException(status_code=500, detail=f"Failed to read strategy_proposals: {e}")
 
 
 @router.get("/logs")
-def get_strategy_logs(limit: int = 50, offset: int = 0, conn=Depends(_conn_dep)):
-    """Read-only: return rows from llm_traces."""
+def get_strategy_logs(
+    limit: int = 50,
+    offset: int = 0,
+    trace_id: Optional[str] = None,
+    conn: sqlite3.Connection = Depends(conn_dep),
+):
     try:
-        data = fetch_rows(conn, table="llm_traces", limit=limit, offset=offset)
-        return {"status": "ok", "data": data, "limit": limit, "offset": offset}
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=503, detail=str(e))
-    except Exception as e:
+        return service.list_logs(conn, limit=limit, offset=offset, trace_id=trace_id)
+    except sqlite3.OperationalError as e:
+        if "no such table" in str(e).lower():
+            return {"status": "ok", "data": [], "limit": limit, "offset": offset}
         raise HTTPException(status_code=500, detail=f"Failed to read llm_traces: {e}")
+
+
+@router.post("/{proposal_id}/approve")
+def approve_strategy_proposal(
+    proposal_id: str,
+    req: DecideRequest,
+    _=Depends(require_ops_token),
+):
+    settings = get_settings()
+    service.ensure_rw_allowed(settings)
+    raise HTTPException(status_code=501, detail="RW workflow is not enabled in read-only backend build")
+
+
+@router.post("/{proposal_id}/reject")
+def reject_strategy_proposal(
+    proposal_id: str,
+    req: DecideRequest,
+    _=Depends(require_ops_token),
+):
+    settings = get_settings()
+    service.ensure_rw_allowed(settings)
+    raise HTTPException(status_code=501, detail="RW workflow is not enabled in read-only backend build")

--- a/frontend/backend/app/core/config.py
+++ b/frontend/backend/app/core/config.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import List
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """App settings loaded from environment/.env.
+
+    Notes:
+    - Keep defaults safe for local dev.
+    - Do not store secrets in code.
+    """
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    # DB
+    db_path: str = Field(default="", alias="DB_PATH")
+
+    # CORS
+    cors_origins: str = Field(default="", alias="CORS_ORIGINS")
+
+    # Rate limit
+    rate_limit_rpm: int = Field(default=120, alias="RATE_LIMIT_RPM")
+
+    # Safety
+    enable_rw_endpoints: bool = Field(default=False, alias="ENABLE_RW_ENDPOINTS")
+    strategy_ops_token: str | None = Field(default=None, alias="STRATEGY_OPS_TOKEN")
+
+    # Service
+    service_name: str = "AI-Trader Command Center API"
+    version: str = "0.1.0"
+
+    def parse_cors_origins(self) -> List[str]:
+        raw = (self.cors_origins or "").strip()
+        if raw:
+            return [o.strip() for o in raw.split(",") if o.strip()]
+        return [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+        ]
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/frontend/backend/app/core/errors.py
+++ b/frontend/backend/app/core/errors.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+logger = logging.getLogger(__name__)
+
+
+def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"status": "error", "detail": exc.detail, "path": str(request.url.path)},
+    )
+
+
+def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled error: %s %s", request.method, request.url.path)
+    return JSONResponse(
+        status_code=500,
+        content={"status": "error", "detail": "Internal Server Error", "path": str(request.url.path)},
+    )

--- a/frontend/backend/app/core/logging.py
+++ b/frontend/backend/app/core/logging.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable
+
+
+class SensitiveFilter(logging.Filter):
+    """Best-effort filter to avoid leaking secrets into logs."""
+
+    def __init__(self, patterns: Iterable[str] = ("token", "authorization", "password")) -> None:
+        super().__init__()
+        self._patterns = tuple(p.lower() for p in patterns)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+            lowered = msg.lower()
+            for p in self._patterns:
+                if p in lowered:
+                    # Redact whole message (simple/safe)
+                    record.msg = "[REDACTED]"
+                    record.args = ()
+                    break
+        except Exception:
+            # Never break logging
+            pass
+        return True
+
+
+def setup_logging() -> None:
+    level = os.environ.get("LOG_LEVEL", "INFO").upper()
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    root = logging.getLogger()
+    root.addFilter(SensitiveFilter())

--- a/frontend/backend/app/db.py
+++ b/frontend/backend/app/db.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import os
+import queue
 import sqlite3
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional
 
@@ -13,6 +15,7 @@ def _resolve_db_path() -> Path:
     Default matches the repository layout:
     backend/app/db.py -> backend root -> ../../data/sqlite/trades.db
     """
+
     env_path = os.environ.get("DB_PATH")
     if env_path:
         return Path(env_path).expanduser().resolve()
@@ -29,6 +32,7 @@ def connect_readonly(db_path: Path = DB_PATH) -> sqlite3.Connection:
 
     Uses sqlite URI mode=ro to guarantee no writes.
     """
+
     if not db_path.exists():
         raise FileNotFoundError(f"SQLite DB not found: {db_path}")
 
@@ -46,13 +50,75 @@ def connect_readonly(db_path: Path = DB_PATH) -> sqlite3.Connection:
     return conn
 
 
+@dataclass
+class SQLiteReadonlyPool:
+    size: int = 5
+    _q: queue.Queue[sqlite3.Connection] | None = None
+    _db_path: Path | None = None
+
+    def init(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._q = queue.Queue(maxsize=self.size)
+        for _ in range(self.size):
+            self._q.put(connect_readonly(db_path))
+
+    @contextmanager
+    def conn(self) -> Iterator[sqlite3.Connection]:
+        if not self._q or not self._db_path:
+            # fallback
+            c = connect_readonly(DB_PATH)
+            try:
+                yield c
+            finally:
+                c.close()
+            return
+
+        c = self._q.get()
+        try:
+            yield c
+        finally:
+            # Return to pool
+            self._q.put(c)
+
+    def close(self) -> None:
+        if not self._q:
+            return
+        while True:
+            try:
+                c = self._q.get_nowait()
+            except queue.Empty:
+                break
+            try:
+                c.close()
+            except Exception:
+                pass
+
+
+READONLY_POOL = SQLiteReadonlyPool(size=int(os.environ.get("DB_POOL_SIZE", "5")))
+
+
+def init_readonly_pool(db_path: Path = DB_PATH) -> None:
+    """Initialize a small read-only connection pool.
+
+    SQLite doesn't have server-side pooling; this is a pragmatic optimization to
+    avoid reconnect overhead under concurrent API calls.
+    """
+
+    READONLY_POOL.init(db_path)
+
+
 @contextmanager
 def get_conn(db_path: Path = DB_PATH) -> Iterator[sqlite3.Connection]:
-    conn = connect_readonly(db_path)
-    try:
-        yield conn
-    finally:
-        conn.close()
+    # If pool initialized, use it.
+    if READONLY_POOL._q is not None:
+        with READONLY_POOL.conn() as conn:
+            yield conn
+    else:
+        conn = connect_readonly(db_path)
+        try:
+            yield conn
+        finally:
+            conn.close()
 
 
 def _table_columns(conn: sqlite3.Connection, table: str) -> List[str]:

--- a/frontend/backend/app/main.py
+++ b/frontend/backend/app/main.py
@@ -1,66 +1,75 @@
 from __future__ import annotations
 
-import os
-from typing import List
+import logging
 
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from app.api.portfolio import router as portfolio_router
 from app.api.control import router as control_router
+from app.api.portfolio import router as portfolio_router
 from app.api.settings import router as settings_router
 from app.api.strategy import router as strategy_router
 from app.api.stream import router as stream_router
+from app.core.config import get_settings
+from app.core.errors import http_exception_handler, unhandled_exception_handler
+from app.core.logging import setup_logging
+from app.db import DB_PATH, READONLY_POOL, init_readonly_pool
+from app.middleware.rate_limit import RateLimitMiddleware
 
-def _parse_cors_origins() -> List[str]:
+# Load .env early (pydantic-settings also loads, but this helps other libs)
+load_dotenv()
+setup_logging()
+logger = logging.getLogger(__name__)
 
-    """Parse CORS origins from env.
+settings = get_settings()
 
-    - CORS_ORIGINS="http://localhost:3000,http://localhost:5173"
-    - Default: common local dev origins
-    """
+app = FastAPI(title=settings.service_name, version=settings.version)
 
-    raw = os.environ.get("CORS_ORIGINS", "").strip()
-    if raw:
-        return [o.strip() for o in raw.split(",") if o.strip()]
+# Exception handlers (unified error shape)
+app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+app.add_exception_handler(Exception, unhandled_exception_handler)
 
-    return [
-        "http://localhost:3000",
-        "http://127.0.0.1:3000",
-        "http://localhost:5173",
-        "http://127.0.0.1:5173",
-    ]
-
-
-app = FastAPI(title="AI-Trader Command Center API", version="0.1.0")
-
-# CORS: allow frontend to call API
-cors_origins = _parse_cors_origins()
+# CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=cors_origins,
+    allow_origins=settings.parse_cors_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
+# Rate limiting
+app.add_middleware(RateLimitMiddleware, rpm=settings.rate_limit_rpm)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    # Initialize readonly pool (best-effort)
+    try:
+        init_readonly_pool(DB_PATH)
+        logger.info("SQLite readonly pool initialized size=%s path=%s", READONLY_POOL.size, DB_PATH)
+    except Exception as e:
+        logger.warning("Failed to init readonly pool: %s", e)
+
+
+@app.on_event("shutdown")
+def on_shutdown() -> None:
+    try:
+        READONLY_POOL.close()
+    except Exception:
+        pass
+
 
 @app.get("/api/health", tags=["health"])
 def health_check():
-    return {"status": "ok", "service": "Command Center API"}
+    return {"status": "ok", "service": settings.service_name}
 
 
 # Routers
 app.include_router(control_router)
 app.include_router(settings_router)
-
 app.include_router(strategy_router)
 app.include_router(portfolio_router)
 app.include_router(stream_router)
-
-
-if __name__ == "__main__":
-    import uvicorn
-
-    port = int(os.environ.get("PORT", "8080"))
-    uvicorn.run("app.main:app", host="0.0.0.0", port=port, reload=True)

--- a/frontend/backend/app/middleware/rate_limit.py
+++ b/frontend/backend/app/middleware/rate_limit.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+@dataclass
+class Bucket:
+    tokens: float
+    last: float
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Simple in-memory token bucket rate limiter.
+
+    - Per-client IP
+    - Global across routes (except excluded paths)
+
+    Notes:
+    - In-memory only: suitable for single-process deployment.
+    - Safe default: 120 req/min/IP.
+    """
+
+    def __init__(
+        self,
+        app,
+        *,
+        rpm: int = 120,
+        burst: int | None = None,
+        exclude_paths: Tuple[str, ...] = ("/api/health", "/docs", "/openapi.json", "/redoc"),
+    ):
+        super().__init__(app)
+        self.rpm = max(1, int(rpm))
+        self.capacity = float(burst if burst is not None else self.rpm)
+        self.refill_per_sec = self.rpm / 60.0
+        self.exclude_paths = exclude_paths
+        self._buckets: Dict[str, Bucket] = {}
+
+    def _client_key(self, request: Request) -> str:
+        # If behind a reverse proxy, you may need to trust X-Forwarded-For.
+        # For safety we default to direct client host.
+        host = request.client.host if request.client else "unknown"
+        return host
+
+    def _allow(self, key: str) -> bool:
+        now = time.monotonic()
+        b = self._buckets.get(key)
+        if not b:
+            self._buckets[key] = Bucket(tokens=self.capacity - 1.0, last=now)
+            return True
+
+        # refill
+        elapsed = max(0.0, now - b.last)
+        b.tokens = min(self.capacity, b.tokens + elapsed * self.refill_per_sec)
+        b.last = now
+
+        if b.tokens >= 1.0:
+            b.tokens -= 1.0
+            return True
+        return False
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+        if path.startswith(self.exclude_paths):
+            return await call_next(request)
+
+        key = self._client_key(request)
+        if not self._allow(key):
+            return Response(
+                content='{"status":"error","detail":"Too Many Requests"}',
+                status_code=429,
+                media_type="application/json",
+            )
+
+        return await call_next(request)

--- a/frontend/backend/app/repositories/strategy_repository.py
+++ b/frontend/backend/app/repositories/strategy_repository.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+from app.db import fetch_rows
+
+
+class StrategyRepository:
+    """DB access layer for strategy-related read operations."""
+
+    def get_proposals(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        status: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        data = fetch_rows(conn, table="strategy_proposals", limit=limit, offset=offset)
+        if status:
+            s = status.strip().lower()
+            data = [r for r in data if str(r.get("status") or "").lower() == s]
+        return data
+
+    def get_logs(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        trace_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        limit = max(1, min(int(limit), 500))
+        offset = max(0, int(offset))
+
+        if trace_id:
+            rows = conn.execute(
+                """
+                SELECT * FROM llm_traces
+                WHERE trace_id = ?
+                ORDER BY created_at DESC
+                LIMIT ? OFFSET ?
+                """,
+                (trace_id, limit, offset),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+        return fetch_rows(conn, table="llm_traces", limit=limit, offset=offset)

--- a/frontend/backend/app/services/strategy_service.py
+++ b/frontend/backend/app/services/strategy_service.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException
+
+from app.core.config import Settings
+from app.repositories.strategy_repository import StrategyRepository
+
+
+class StrategyService:
+    def __init__(self, repo: StrategyRepository | None = None) -> None:
+        self.repo = repo or StrategyRepository()
+
+    def list_proposals(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        status: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        data = self.repo.get_proposals(conn, limit=limit, offset=offset, status=status)
+        return {"status": "ok", "data": data, "limit": limit, "offset": offset}
+
+    def list_logs(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        trace_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        data = self.repo.get_logs(conn, limit=limit, offset=offset, trace_id=trace_id)
+        return {"status": "ok", "data": data, "limit": limit, "offset": offset}
+
+    def ensure_rw_allowed(self, settings: Settings) -> None:
+        if not settings.enable_rw_endpoints:
+            raise HTTPException(
+                status_code=405,
+                detail="RW endpoints are disabled (ENABLE_RW_ENDPOINTS=false). Backend enforces read-only SQLite by default.",
+            )

--- a/frontend/backend/requirements.txt
+++ b/frontend/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.110
+uvicorn[standard]>=0.27
+pydantic>=2.6
+pydantic-settings>=2.2
+python-dotenv>=1.0
+pytest>=8.0
+httpx>=0.27

--- a/frontend/backend/tests/conftest.py
+++ b/frontend/backend/tests/conftest.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _init_test_db(path: Path) -> None:
+    conn = sqlite3.connect(path.as_posix())
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS strategy_proposals (
+                proposal_id TEXT PRIMARY KEY,
+                status TEXT,
+                created_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS llm_traces (
+                trace_id TEXT,
+                content TEXT,
+                created_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO strategy_proposals(proposal_id, status, created_at) VALUES(?, ?, ?) ",
+            ("p1", "pending", 123),
+        )
+        conn.execute(
+            "INSERT INTO llm_traces(trace_id, content, created_at) VALUES(?, ?, ?)",
+            ("t1", "hello", 456),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "trades.db"
+    _init_test_db(db_path)
+
+    monkeypatch.setenv("DB_PATH", db_path.as_posix())
+    monkeypatch.setenv("RATE_LIMIT_RPM", "1000")
+
+    # Reload modules that read env at import-time
+    import app.core.config as config
+    importlib.reload(config)
+    import app.db as db
+    importlib.reload(db)
+    import app.main as main
+    importlib.reload(main)
+
+    with TestClient(main.app) as c:
+        yield c

--- a/frontend/backend/tests/test_health.py
+++ b/frontend/backend/tests/test_health.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def test_health(client):
+    r = client.get('/api/health')
+    assert r.status_code == 200
+    data = r.json()
+    assert data['status'] == 'ok'

--- a/frontend/backend/tests/test_strategy_endpoints.py
+++ b/frontend/backend/tests/test_strategy_endpoints.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def test_get_proposals(client):
+    r = client.get('/api/strategy/proposals?limit=10&offset=0')
+    assert r.status_code == 200
+    data = r.json()
+    assert data['status'] == 'ok'
+    assert isinstance(data['data'], list)
+    assert data['data'][0]['proposal_id'] == 'p1'
+
+
+def test_get_logs(client):
+    r = client.get('/api/strategy/logs?limit=10&offset=0')
+    assert r.status_code == 200
+    data = r.json()
+    assert data['status'] == 'ok'
+    assert data['data'][0]['trace_id'] == 't1'
+
+
+def test_rw_endpoints_disabled(client):
+    r = client.post('/api/strategy/p1/approve', json={'actor':'u','reason':'x'}, headers={'X-OPS-TOKEN':'nope'})
+    # unauthorized comes before 405
+    assert r.status_code in (401, 503)


### PR DESCRIPTION
Closes #52\n\n- Standardized backend structure (core config/logging/errors, middleware)\n- Read-only SQLite (mode=ro + query_only) with small connection pool\n- CORS + env/.env support\n- Basic in-memory rate limiting\n- pytest unit/integration tests for key endpoints