### PR TITLE
[Risk] Decision pipeline: enforce trading_enabled master switch (API fallback)

### DIFF
--- a/src/openclaw/decision_pipeline_v4.py
+++ b/src/openclaw/decision_pipeline_v4.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional, Tuple
 
 from openclaw.drawdown_guard import DrawdownDecision, evaluate_drawdown_guard, DrawdownPolicy
@@ -18,6 +20,9 @@ from openclaw.token_budget import BudgetPolicy, evaluate_budget, load_budget_pol
 
 
 LLMCaller = Callable[[str, str], Dict[str, Any]]
+
+logger = logging.getLogger(__name__)
+
 
 
 def _safe_float(v: Any, default: float = 0.0) -> float:
@@ -129,8 +134,16 @@ def run_decision_with_sentinel(
 
     system_state_path = os.path.join(os.path.dirname(__file__), "../../config/system_state.json")
     allowed, reason = check_system_switch(system_state_path)
+    ts = datetime.now(timezone.utc).isoformat()
+    logger.warning(
+        "master_switch_check decision_id=%s ts=%s allowed=%s reason=%s",
+        decision_id,
+        ts,
+        allowed,
+        reason or "",
+    )
     if not allowed:
-        _insert_risk_check(conn, decision_id, "master_switch", False, reason)
+        _insert_risk_check(conn, decision_id, "master_switch", False, reason or "disabled")
         # No decision record needed as this is before any order candidate
         return False, "MASTER_SWITCH_OFF", None
     _insert_risk_check(conn, decision_id, "master_switch", True, "Auto-trading enabled")

--- a/src/openclaw/system_switch.py
+++ b/src/openclaw/system_switch.py
@@ -1,17 +1,61 @@
 """System master switch check for auto-trading safety."""
 
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 
-def check_system_switch(system_state_path: str) -> Tuple[bool, Optional[str]]:
+DEFAULT_CONTROL_STATUS_URL = "http://127.0.0.1:8000/api/control/status"
+
+
+def _read_trading_enabled_from_api(
+    api_url: str,
+    *,
+    timeout_s: float = 1.0,
+) -> Tuple[Optional[bool], Optional[str]]:
+    """Read trading_enabled from control panel API.
+
+    Returns: (trading_enabled_or_none, error_or_none)
     """
-    Check if system is allowed to auto-trade.
-    
+
+    try:
+        req = Request(api_url, headers={"Accept": "application/json"})
+        with urlopen(req, timeout=timeout_s) as resp:
+            raw = resp.read().decode("utf-8")
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return None, "Control API returned non-object JSON"
+        return bool(data.get("trading_enabled", False)), None
+    except (HTTPError, URLError) as e:
+        return None, f"Control API request failed: {e}"
+    except Exception as e:
+        return None, f"Control API error: {e}"
+
+
+def check_system_switch(
+    system_state_path: str,
+    *,
+    api_url: Optional[str] = None,
+    api_timeout_s: float = 1.0,
+) -> Tuple[bool, Optional[str]]:
+    """Check if system is allowed to auto-trade.
+
+    Source priority:
+    1) .EMERGENCY_STOP file (hard stop)
+    2) config/system_state.json (local state)
+    3) GET /api/control/status (fallback)
+
+    Safety-first principle:
+    - If reading state fails, default to disabled.
+
     Returns: (allowed, reason_if_not_allowed)
     """
+
     # Check emergency stop file
     project_root = Path(__file__).resolve().parents[2]
     emergency_stop_file = project_root / ".EMERGENCY_STOP"
@@ -21,26 +65,44 @@ def check_system_switch(system_state_path: str) -> Tuple[bool, Optional[str]]:
             return False, f"EMERGENCY_STOP: {reason}"
         except Exception:
             return False, "EMERGENCY_STOP file exists"
-    
-    # Check system state config
+
+    # Check system state config (primary)
     try:
-        with open(system_state_path, "r") as f:
+        with open(system_state_path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        
-        trading_enabled = data.get("trading_enabled", False)
+
+        trading_enabled = bool(data.get("trading_enabled", False))
         if not trading_enabled:
             return False, "Auto-trading is disabled (master switch OFF)"
-        
+
         return True, None
     except FileNotFoundError:
-        # If config file doesn't exist, default to disabled
-        return False, "System state config not found (default: disabled)"
+        # Fallback to API
+        pass
     except Exception as e:
-        return False, f"Error reading system state: {str(e)}"
+        # Fallback to API, but include file error for audit
+        file_error = f"Error reading system state: {str(e)}"
+        api_url2 = api_url or os.getenv("CONTROL_STATUS_URL") or DEFAULT_CONTROL_STATUS_URL
+        v, api_err = _read_trading_enabled_from_api(api_url2, timeout_s=api_timeout_s)
+        if v is None:
+            return False, f"{file_error}; fallback failed: {api_err}"
+        if not v:
+            return False, "Auto-trading is disabled (master switch OFF)"
+        return True, None
+
+    # File not found: try API fallback
+    api_url2 = api_url or os.getenv("CONTROL_STATUS_URL") or DEFAULT_CONTROL_STATUS_URL
+    v, api_err = _read_trading_enabled_from_api(api_url2, timeout_s=api_timeout_s)
+    if v is None:
+        return False, "System state config not found and control API unavailable (default: disabled)"
+    if not v:
+        return False, "Auto-trading is disabled (master switch OFF)"
+    return True, None
 
 
 def is_auto_trading_allowed() -> bool:
     """Convenience function for quick check."""
+
     system_state_path = os.path.join(os.path.dirname(__file__), "../../config/system_state.json")
     allowed, _ = check_system_switch(system_state_path)
     return allowed

--- a/tests/test_decision_pipeline_master_switch.py
+++ b/tests/test_decision_pipeline_master_switch.py
@@ -1,0 +1,36 @@
+import sqlite3
+import time
+
+from openclaw.decision_pipeline_v4 import run_decision_with_sentinel
+from openclaw.drawdown_guard import DrawdownPolicy
+from openclaw.risk_engine import SystemState
+
+
+def test_decision_pipeline_stops_when_master_switch_off(monkeypatch):
+    import openclaw.decision_pipeline_v4 as mod
+
+    monkeypatch.setattr(mod, "check_system_switch", lambda *args, **kwargs: (False, "disabled"))
+
+    conn = sqlite3.connect(":memory:")
+    ok, reason_code, record = run_decision_with_sentinel(
+        conn,
+        system_state=SystemState(
+            now_ms=int(time.time() * 1000),
+            trading_locked=False,
+            broker_connected=True,
+            db_write_p99_ms=10,
+            orders_last_60s=0,
+            reduce_only_mode=False,
+        ),
+        order_candidate=None,
+        budget_policy_path="config/budget_policy_v1.json",
+        drawdown_policy=DrawdownPolicy(),
+        pm_context={},
+        pm_approved=False,
+        llm_call=lambda model, prompt: {},
+        decision_id="dec_test_001",
+    )
+
+    assert ok is False
+    assert reason_code == "MASTER_SWITCH_OFF"
+    assert record is None

--- a/tests/test_system_switch_api_fallback.py
+++ b/tests/test_system_switch_api_fallback.py
@@ -1,0 +1,64 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from openclaw.system_switch import check_system_switch
+
+
+class _Handler(BaseHTTPRequestHandler):
+    payload = {"trading_enabled": False}
+
+    def do_GET(self):
+        if self.path != "/api/control/status":
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = json.dumps(self.payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        # silence test output
+        return
+
+
+def _start_server(payload):
+    _Handler.payload = payload
+    httpd = HTTPServer(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    host, port = httpd.server_address
+    return httpd, f"http://{host}:{port}/api/control/status"
+
+
+def test_api_fallback_enabled_when_file_missing(tmp_path):
+    httpd, url = _start_server({"trading_enabled": True})
+    try:
+        allowed, reason = check_system_switch(str(tmp_path / "missing.json"), api_url=url, api_timeout_s=1.0)
+        assert allowed is True
+        assert reason is None
+    finally:
+        httpd.shutdown()
+
+
+def test_api_fallback_disabled_when_file_missing(tmp_path):
+    httpd, url = _start_server({"trading_enabled": False})
+    try:
+        allowed, reason = check_system_switch(str(tmp_path / "missing.json"), api_url=url, api_timeout_s=1.0)
+        assert allowed is False
+        assert reason == "Auto-trading is disabled (master switch OFF)"
+    finally:
+        httpd.shutdown()
+
+
+def test_api_fallback_unavailable_defaults_disabled(tmp_path):
+    # point to unused port to force connection error
+    url = "http://127.0.0.1:9/api/control/status"
+    allowed, reason = check_system_switch(str(tmp_path / "missing.json"), api_url=url, api_timeout_s=0.2)
+    assert allowed is False
+    assert "default: disabled" in reason

--- a/tests/test_system_switch_full.py
+++ b/tests/test_system_switch_full.py
@@ -1,0 +1,80 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from openclaw.system_switch import check_system_switch, is_auto_trading_allowed
+
+
+def _project_root() -> Path:
+    # src/openclaw/system_switch.py -> parents[2] == project root
+    import openclaw.system_switch as mod
+
+    return Path(mod.__file__).resolve().parents[2]
+
+
+def test_check_system_switch_emergency_stop_readable(tmp_path):
+    root = _project_root()
+    stop = root / ".EMERGENCY_STOP"
+    stop.write_text("maintenance", encoding="utf-8")
+    try:
+        allowed, reason = check_system_switch(str(tmp_path / "missing.json"))
+        assert allowed is False
+        assert reason == "EMERGENCY_STOP: maintenance"
+    finally:
+        stop.unlink(missing_ok=True)
+
+
+def test_check_system_switch_emergency_stop_unreadable(monkeypatch, tmp_path):
+    root = _project_root()
+    stop = root / ".EMERGENCY_STOP"
+    stop.write_text("x", encoding="utf-8")
+
+    def boom(*args, **kwargs):
+        raise OSError("nope")
+
+    try:
+        monkeypatch.setattr(Path, "read_text", boom)
+        allowed, reason = check_system_switch(str(tmp_path / "missing.json"))
+        assert allowed is False
+        assert reason == "EMERGENCY_STOP file exists"
+    finally:
+        stop.unlink(missing_ok=True)
+
+
+def test_check_system_switch_config_not_found(tmp_path):
+    allowed, reason = check_system_switch(str(tmp_path / "nope.json"))
+    assert allowed is False
+    assert "config not found" in reason
+
+
+def test_check_system_switch_config_disabled(tmp_path):
+    p = tmp_path / "state.json"
+    p.write_text(json.dumps({"trading_enabled": False}), encoding="utf-8")
+    allowed, reason = check_system_switch(str(p))
+    assert allowed is False
+    assert reason == "Auto-trading is disabled (master switch OFF)"
+
+
+def test_check_system_switch_config_enabled(tmp_path):
+    p = tmp_path / "state.json"
+    p.write_text(json.dumps({"trading_enabled": True}), encoding="utf-8")
+    allowed, reason = check_system_switch(str(p))
+    assert allowed is True
+    assert reason is None
+
+
+def test_check_system_switch_invalid_json(tmp_path):
+    p = tmp_path / "state.json"
+    p.write_text("{not json}", encoding="utf-8")
+    allowed, reason = check_system_switch(str(p))
+    assert allowed is False
+    assert reason.startswith("Error reading system state")
+
+
+def test_is_auto_trading_allowed_false_when_check_fails(monkeypatch):
+    import openclaw.system_switch as mod
+
+    monkeypatch.setattr(mod, "check_system_switch", lambda system_state_path: (False, "x"))
+    assert is_auto_trading_allowed() is False


### PR DESCRIPTION
Closes #57\n\n- Add Step 0 master switch check logging (decision_id + timestamp) in decision_pipeline_v4\n- Extend system_switch to read trading_enabled from config/system_state.json with /api/control/status fallback (safe-default OFF)\n- Add tests for API fallback and decision pipeline stop behavior