### PR TITLE
CI guardrails: block hardcoded local paths/certs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,29 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
 
+      - name: 🛡️ Guardrails: block hardcoded local paths / secret-file references
+        run: |
+          set -euo pipefail
+
+          echo "Scanning for forbidden local/secret file references in tracked source files..."
+
+          # Only scan common source/config extensions to reduce false positives.
+          files=$(git ls-files \
+            '*.js' '*.jsx' '*.ts' '*.tsx' \
+            '*.py' '*.yml' '*.yaml' '*.json' '*.toml' \
+            '*.sh' '*.md')
+
+          # Fail if any hardcoded local path or PEM key/cert read is found.
+          # - /Users/... (macOS local)
+          # - .openclaw/ (local agent workspace)
+          # - readFileSync(...*.pem) (commonly used for cert/key)
+          if echo "$files" | xargs -r grep -nIE '(/Users/|\.openclaw/|readFileSync\([^)]*\.pem)'; then
+            echo "::error::Forbidden pattern found. Use relative paths or env vars; do not hardcode local cert/key paths."
+            exit 1
+          fi
+
+          echo "OK: guardrail scan passed."
+
       - name: 🐍 Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Why (root-cause)
Recent CI breakages came from hardcoded local paths (e.g. ) and local cert reads () being committed into config (e.g. Vite), which works on one machine but fails on GitHub runners.

## What
Add an early CI step that scans tracked source/config files and fails fast if it finds:
-  (macOS local absolute paths)
-  (local agent workspace paths)
-  (cert/key reads hardcoded into repo)

## Outcome
This prevents the same class of CI-breaking changes from landing in  again.