### PR TITLE
Fix CI: remove hardcoded /Users path from backend .env.example

### DIFF
--- a/frontend/backend/.env.example
+++ b/frontend/backend/.env.example
@@ -1,7 +1,7 @@
 # Backend configuration
 
 # Path to sqlite DB (read-only mode is enforced by backend)
-DB_PATH=/Users/openclaw/.openclaw/shared/projects/ai-trader/data/sqlite/trades.db
+DB_PATH=./data/sqlite/trades.db
 
 # CORS
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173


### PR DESCRIPTION
## Problem\nAfter enabling CI guardrails (#67/#68), CI fails because  contains a hardcoded local absolute path:\n- \n\n## Fix\nUse a relative default instead:\n- \n\nThis keeps examples portable and compatible with CI guardrails.