### PR TITLE
feat(system): F-1 System.jsx 動態監控 + 修復 shioaji 可選依賴

### DIFF
--- a/frontend/backend/app/services/shioaji_service.py
+++ b/frontend/backend/app/services/shioaji_service.py
@@ -42,7 +42,14 @@ def _get_api(simulation: bool = True):
 
     NOTE: caching avoids repeated logins. The first login can still be slow.
     """
-    import shioaji as sj  # type: ignore
+    try:
+        import shioaji as sj  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "shioaji 未安裝。若要使用真實/模擬券商模式，請執行：\n"
+            "  pip install shioaji>=1.0\n"
+            "或繼續使用 Mock 模式（預設）。"
+        ) from exc
 
     api = sj.Shioaji(simulation=simulation)
     api_key = os.environ.get("SHIOAJI_API_KEY")

--- a/frontend/backend/requirements.txt
+++ b/frontend/backend/requirements.txt
@@ -3,15 +3,12 @@ uvicorn[standard]>=0.27
 pydantic>=2.6
 pydantic-settings>=2.2
 python-dotenv>=1.0
-uvicorn>=0.27
-pydantic>=2.6
-pydantic-settings>=2.2
-python-dotenv>=1.0
 pytest>=8.0
 httpx>=0.27
+psutil>=5.9
 
 # SSE
 sse-starlette>=2.1
 
-# Shioaji for real simulation (optional)
-shioaji>=1.0
+# Optional: install separately for live/simulation broker mode
+# pip install shioaji>=1.0

--- a/frontend/web/src/lib/systemApi.js
+++ b/frontend/web/src/lib/systemApi.js
@@ -1,0 +1,114 @@
+// System monitoring API client + React hooks
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const DEFAULT_API_BASE = 'http://localhost:8080'
+
+async function fetchJson(url, { timeoutMs = 5000 } = {}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    if (!res.ok) throw new Error(`API ${res.status}`)
+    return await res.json()
+  } catch (err) {
+    if (err?.name === 'AbortError') throw new Error('timeout')
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function getBase() {
+  return (typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_BASE) || DEFAULT_API_BASE
+}
+
+export function useSystemHealth({ pollMs = 5000 } = {}) {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+  const timerRef = useRef(null)
+
+  const fetch_ = useCallback(async () => {
+    try {
+      const d = await fetchJson(`${getBase()}/api/system/health`)
+      setData(d)
+      setError(null)
+    } catch (e) {
+      setError(e.message)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetch_()
+    timerRef.current = setInterval(fetch_, pollMs)
+    return () => clearInterval(timerRef.current)
+  }, [fetch_, pollMs])
+
+  return { data, error, refresh: fetch_ }
+}
+
+export function useSystemQuota({ pollMs = 30000 } = {}) {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let active = true
+    async function load() {
+      try {
+        const d = await fetchJson(`${getBase()}/api/system/quota`)
+        if (active) { setData(d); setError(null) }
+      } catch (e) {
+        if (active) setError(e.message)
+      }
+    }
+    load()
+    const t = setInterval(load, pollMs)
+    return () => { active = false; clearInterval(t) }
+  }, [pollMs])
+
+  return { data, error }
+}
+
+export function useSystemRisk({ pollMs = 30000 } = {}) {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let active = true
+    async function load() {
+      try {
+        const d = await fetchJson(`${getBase()}/api/system/risk`)
+        if (active) { setData(d); setError(null) }
+      } catch (e) {
+        if (active) setError(e.message)
+      }
+    }
+    load()
+    const t = setInterval(load, pollMs)
+    return () => { active = false; clearInterval(t) }
+  }, [pollMs])
+
+  return { data, error }
+}
+
+export function useSystemEvents({ pollMs = 15000 } = {}) {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let active = true
+    async function load() {
+      try {
+        const d = await fetchJson(`${getBase()}/api/system/events`)
+        if (active) { setData(d); setError(null) }
+      } catch (e) {
+        if (active) setError(e.message)
+      }
+    }
+    load()
+    const t = setInterval(load, pollMs)
+    return () => { active = false; clearInterval(t) }
+  }, [pollMs])
+
+  return { data, error }
+}

--- a/frontend/web/src/pages/System.jsx
+++ b/frontend/web/src/pages/System.jsx
@@ -1,8 +1,276 @@
 import React from 'react'
 import ControlPanel from '../components/ControlPanel'
 import LogTerminal from '../components/LogTerminal'
+import { useSystemHealth, useSystemQuota, useSystemRisk, useSystemEvents } from '../lib/systemApi'
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function statusDot(status) {
+  const map = {
+    online: 'bg-emerald-400',
+    simulation: 'bg-amber-400',
+    warning: 'bg-amber-400',
+    offline: 'bg-rose-500',
+    delayed: 'bg-amber-400',
+    unknown: 'bg-slate-500',
+  }
+  return map[status] || 'bg-slate-500'
+}
+
+function statusText(status) {
+  const map = {
+    online: '在線',
+    simulation: '模擬模式',
+    warning: '警告',
+    offline: '離線',
+    delayed: '延遲',
+    unknown: '未知',
+  }
+  return map[status] || status || '未知'
+}
+
+function statusTextColor(status) {
+  const map = {
+    online: 'text-emerald-300',
+    simulation: 'text-amber-300',
+    warning: 'text-amber-300',
+    offline: 'text-rose-400',
+    delayed: 'text-amber-300',
+    unknown: 'text-slate-400',
+  }
+  return map[status] || 'text-slate-400'
+}
+
+function ProgressBar({ pct, warn = 80, danger = 100 }) {
+  const color = pct >= danger ? 'bg-rose-500' : pct >= warn ? 'bg-amber-400' : 'bg-emerald-400'
+  return (
+    <div className="h-2 w-full rounded-full bg-slate-800">
+      <div
+        className={`h-2 rounded-full transition-all ${color}`}
+        style={{ width: `${Math.min(pct, 100)}%` }}
+      />
+    </div>
+  )
+}
+
+function severityColor(severity) {
+  const map = {
+    error: 'text-rose-400',
+    warning: 'text-amber-300',
+    info: 'text-slate-300',
+  }
+  return map[severity] || 'text-slate-400'
+}
+
+// ─── panels ──────────────────────────────────────────────────────────────────
+
+function ServiceStatusPanel({ health }) {
+  const services = health?.services || {}
+  const rows = [
+    { key: 'fastapi', label: '後端 API' },
+    { key: 'sqlite', label: '資料庫' },
+    { key: 'shioaji', label: 'Shioaji 連線' },
+    { key: 'sentinel', label: 'Sentinel 守衛' },
+  ]
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+      <div className="text-sm font-semibold">服務狀態</div>
+      <div className="mt-4 space-y-3">
+        {rows.map(({ key, label }) => {
+          const svc = services[key] || {}
+          const status = svc.status || 'unknown'
+          return (
+            <div key={key} className="flex items-center justify-between">
+              <span className="text-sm text-slate-300">{label}</span>
+              <div className="flex items-center gap-2">
+                <span className={`inline-block h-2 w-2 rounded-full ${statusDot(status)}`} />
+                <span className={`text-xs ${statusTextColor(status)}`}>{statusText(status)}</span>
+                {svc.latency_ms != null && (
+                  <span className="text-xs text-slate-500">{svc.latency_ms}ms</span>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function SentinelPanel({ health }) {
+  const sentinel = health?.services?.sentinel || {}
+  const { last_heartbeat, today_circuit_breaks = 0, status = 'unknown' } = sentinel
+  const ago = last_heartbeat ? Math.floor((Date.now() - new Date(last_heartbeat).getTime()) / 1000) : null
+  const agoText = ago == null ? '—' : ago < 60 ? `${ago}s 前` : `${Math.floor(ago / 60)}m 前`
+  const alertColor = ago != null && ago > 60 ? 'text-rose-400' : 'text-emerald-300'
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+      <div className="text-sm font-semibold">Sentinel 心跳</div>
+      <div className="mt-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-slate-300">最後心跳</span>
+          <span className={`text-xs ${alertColor}`}>{agoText}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-slate-300">今日熔斷</span>
+          <span className={`text-xs ${today_circuit_breaks > 0 ? 'text-rose-400' : 'text-emerald-300'}`}>
+            {today_circuit_breaks} 次
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-slate-300">狀態</span>
+          <div className="flex items-center gap-2">
+            <span className={`inline-block h-2 w-2 rounded-full ${statusDot(status)}`} />
+            <span className={`text-xs ${statusTextColor(status)}`}>{statusText(status)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ResourcePanel({ health }) {
+  const res = health?.resources || {}
+  const { cpu_percent = 0, memory_percent = 0, disk_used_gb = 0, disk_total_gb = 1 } = res
+  const diskPct = disk_total_gb > 0 ? Math.round((disk_used_gb / disk_total_gb) * 100) : 0
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+      <div className="text-sm font-semibold">系統資源</div>
+      <div className="mt-4 space-y-4">
+        <div>
+          <div className="flex justify-between text-xs mb-1">
+            <span className="text-slate-400">CPU</span>
+            <span className={cpu_percent > 80 ? 'text-rose-400' : 'text-slate-300'}>{cpu_percent.toFixed(1)}%</span>
+          </div>
+          <ProgressBar pct={cpu_percent} />
+        </div>
+        <div>
+          <div className="flex justify-between text-xs mb-1">
+            <span className="text-slate-400">記憶體</span>
+            <span className={memory_percent > 85 ? 'text-rose-400' : 'text-slate-300'}>{memory_percent.toFixed(1)}%</span>
+          </div>
+          <ProgressBar pct={memory_percent} warn={85} />
+        </div>
+        <div>
+          <div className="flex justify-between text-xs mb-1">
+            <span className="text-slate-400">磁碟</span>
+            <span className="text-slate-300">{disk_used_gb.toFixed(1)} / {disk_total_gb.toFixed(1)} GB</span>
+          </div>
+          <ProgressBar pct={diskPct} warn={85} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function QuotaPanel({ quota }) {
+  const { month = '—', budget_twd = 650, used_twd = 0, used_percent = 0, status = 'ok', daily_trend = [] } = quota || {}
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-semibold">API 配額 {month}</div>
+        <span className={`text-xs px-2 py-0.5 rounded-full ${status === 'exceeded' ? 'bg-rose-900/40 text-rose-300' : status === 'warning' ? 'bg-amber-900/40 text-amber-300' : 'bg-emerald-900/40 text-emerald-300'}`}>
+          {status === 'exceeded' ? '超限' : status === 'warning' ? '警告' : '正常'}
+        </span>
+      </div>
+      <div className="mt-4 space-y-3">
+        <div className="flex justify-between text-xs mb-1">
+          <span className="text-slate-400">已用 / 預算</span>
+          <span className={used_percent >= 80 ? 'text-amber-300' : 'text-slate-300'}>
+            NT$ {used_twd.toFixed(0)} / {budget_twd.toFixed(0)}（{used_percent}%）
+          </span>
+        </div>
+        <ProgressBar pct={used_percent} />
+        {daily_trend.length > 0 && (
+          <div className="mt-3 space-y-1 text-xs text-slate-500">
+            {daily_trend.slice(0, 3).map(d => (
+              <div key={d.date} className="flex justify-between">
+                <span>{d.date}</span>
+                <span>NT$ {d.cost_twd}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function RiskPanel({ risk }) {
+  const {
+    today_realized_pnl = 0,
+    monthly_drawdown_pct = 0,
+    monthly_drawdown_limit_pct = 0.15,
+    drawdown_remaining_pct = 0.15,
+    losing_streak_days = 0,
+    risk_mode = 'normal',
+  } = risk || {}
+  const drawdownUsedPct = Math.round((monthly_drawdown_pct / monthly_drawdown_limit_pct) * 100)
+  const remainingPct = Math.round(drawdown_remaining_pct * 100)
+  const modeColor = risk_mode === 'high' ? 'text-rose-400' : risk_mode === 'elevated' ? 'text-amber-300' : 'text-emerald-300'
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-semibold">風控狀態</div>
+        <span className={`text-xs font-medium ${modeColor}`}>{risk_mode.toUpperCase()}</span>
+      </div>
+      <div className="mt-4 space-y-4">
+        <div>
+          <div className="flex justify-between text-xs mb-1">
+            <span className="text-slate-400">月度回撤</span>
+            <span className={remainingPct < 20 ? 'text-rose-400' : 'text-slate-300'}>
+              {(monthly_drawdown_pct * 100).toFixed(2)}% / {(monthly_drawdown_limit_pct * 100).toFixed(0)}%
+            </span>
+          </div>
+          <ProgressBar pct={drawdownUsedPct} warn={70} danger={90} />
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-slate-400">今日損益</span>
+          <span className={today_realized_pnl < 0 ? 'text-rose-400' : 'text-emerald-300'}>
+            {today_realized_pnl >= 0 ? '+' : ''}{today_realized_pnl.toLocaleString()} NT$
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-slate-400">連續虧損天數</span>
+          <span className={losing_streak_days >= 3 ? 'text-rose-400' : 'text-slate-300'}>
+            {losing_streak_days} 天
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EventsPanel({ events }) {
+  const list = events?.events || []
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
+      <div className="text-sm font-semibold">事件時間軸</div>
+      <div className="mt-4 space-y-2 max-h-64 overflow-y-auto">
+        {list.length === 0 ? (
+          <div className="text-xs text-slate-500">暫無事件</div>
+        ) : (
+          list.slice(0, 20).map((ev, i) => (
+            <div key={i} className="flex gap-3 text-xs">
+              <span className="shrink-0 text-slate-500">{String(ev.ts || '').slice(11, 19)}</span>
+              <span className={`shrink-0 ${severityColor(ev.severity)}`}>[{ev.source}]</span>
+              <span className="text-slate-400 truncate">{ev.code}: {ev.detail}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── main page ────────────────────────────────────────────────────────────────
 
 export default function SystemPage() {
+  const { data: health, error: healthErr } = useSystemHealth({ pollMs: 5000 })
+  const { data: quota } = useSystemQuota({ pollMs: 30000 })
+  const { data: risk } = useSystemRisk({ pollMs: 30000 })
+  const { data: events } = useSystemEvents({ pollMs: 15000 })
+
   return (
     <div className="space-y-6">
       <div>
@@ -10,84 +278,58 @@ export default function SystemPage() {
         <div className="mt-1 text-xs text-slate-400">
           主開關、緊急停止、模擬/實際盤切換。風險控制是第一優先。
         </div>
+        {healthErr && (
+          <div className="mt-2 text-xs text-rose-400">健康狀態 API 離線：{healthErr}</div>
+        )}
       </div>
 
       <ControlPanel />
 
-      <LogTerminal />
-
+      {/* Row 1: Service status + Sentinel + Resource */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* 系統健康狀態 */}
-        <div className="lg:col-span-2 rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
-          <div className="text-sm font-semibold">系統健康狀態</div>
-          <div className="mt-4 space-y-4">
-            <div className="flex items-center justify-between">
-              <div className="text-sm text-slate-300">後端 API</div>
-              <div className="flex items-center gap-2">
-                <span className="inline-block h-2 w-2 rounded-full bg-emerald-400"></span>
-                <span className="text-xs text-emerald-300">在線</span>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="text-sm text-slate-300">資料庫連線</div>
-              <div className="flex items-center gap-2">
-                <span className="inline-block h-2 w-2 rounded-full bg-emerald-400"></span>
-                <span className="text-xs text-emerald-300">正常</span>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="text-sm text-slate-300">Shioaji 連線</div>
-              <div className="flex items-center gap-2">
-                <span className="inline-block h-2 w-2 rounded-full bg-amber-400"></span>
-                <span className="text-xs text-amber-300">模擬模式</span>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="text-sm text-slate-300">決策管線</div>
-              <div className="flex items-center gap-2">
-                <span className="inline-block h-2 w-2 rounded-full bg-emerald-400"></span>
-                <span className="text-xs text-emerald-300">就緒</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* 快速操作 */}
-        <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
-          <div className="text-sm font-semibold">快速操作</div>
-          <div className="mt-4 space-y-3">
-            <button className="w-full rounded-lg bg-slate-800 py-2.5 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-all">
-              查看日誌
-            </button>
-            <button className="w-full rounded-lg bg-slate-800 py-2.5 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-all">
-              重新整理資料
-            </button>
-            <button className="w-full rounded-lg bg-slate-800 py-2.5 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-all">
-              備份設定
-            </button>
-          </div>
-        </div>
+        <ServiceStatusPanel health={health} />
+        <SentinelPanel health={health} />
+        <ResourcePanel health={health} />
       </div>
 
-      {/* 版本資訊 */}
+      {/* Row 2: Quota + Risk */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <QuotaPanel quota={quota} />
+        <RiskPanel risk={risk} />
+      </div>
+
+      {/* Row 3: Event timeline */}
+      <EventsPanel events={events} />
+
+      <LogTerminal />
+
+      {/* Version info */}
       <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-6 shadow-panel">
         <div className="text-sm font-semibold">系統版本資訊</div>
         <div className="mt-4 grid grid-cols-2 md:grid-cols-4 gap-4 text-xs">
           <div className="space-y-1">
             <div className="text-slate-400">前端版本</div>
-            <div className="text-slate-300">v1.0.0 (Sprint 1)</div>
+            <div className="text-slate-300">v4.0.0</div>
           </div>
           <div className="space-y-1">
             <div className="text-slate-400">後端版本</div>
             <div className="text-slate-300">v4.0.0</div>
           </div>
           <div className="space-y-1">
-            <div className="text-slate-400">最後部署</div>
-            <div className="text-slate-300">2026-02-28 19:15</div>
+            <div className="text-slate-400">DB WAL</div>
+            <div className="text-slate-300">
+              {health?.db_health?.wal_size_bytes != null
+                ? `${(health.db_health.wal_size_bytes / 1024).toFixed(1)} KB`
+                : '—'}
+            </div>
           </div>
           <div className="space-y-1">
-            <div className="text-slate-400">開發模式</div>
-            <div className="text-slate-300">24/7 極限開發</div>
+            <div className="text-slate-400">寫入延遲 P99</div>
+            <div className="text-slate-300">
+              {health?.db_health?.write_latency_p99_ms != null
+                ? `${health.db_health.write_latency_p99_ms} ms`
+                : '—'}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **F-1 (#107)**：System.jsx 從靜態 hardcode 升級為全動態監控
- **Bug #70**：shioaji 可選依賴處理改善

## 變更說明

### F-1 System.jsx 動態化
- 新增 `systemApi.js`：4 個 React hooks（Health/Quota/Risk/Events）
- `ServiceStatusPanel`：每 5s 拉取 `/api/system/health`，根據 status 顯示綠/黃/紅燈
- `SentinelPanel`：顯示最後心跳時間 + 今日熔斷次數（超 60s 紅色告警）
- `QuotaPanel`：API 配額進度條（超 80% 黃色警告）
- `ResourcePanel`：CPU/記憶體/磁碟 進度條（超 80% 紅色）
- `RiskPanel`：月度回撤進度條 + 今日損益 + 連續虧損天數
- `EventsPanel`：事件時間軸（最新 20 筆）

### Bug #70 修復
- `requirements.txt`：移除硬依賴 `shioaji>=1.0`（避免 CI 環境安裝失敗），改為 comment 說明
- 新增 `psutil>=5.9`（系統資源監控必要）
- 清除重複依賴行
- `shioaji_service.py`：`ImportError` 改為友善的 RuntimeError，引導用戶安裝

## Test plan

- [x] System.jsx 編譯無錯誤
- [x] 4 個 API endpoints 已在 system.py 實作（/health, /quota, /risk, /events）
- [x] Mock 資料下顯示正確（無 shioaji 也不影響）
- [x] requirements.txt 清潔，CI 不因 shioaji 失敗

Closes #107
Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)