### PR TITLE
chore: 移除 datetime.utcnow() 棄用警告

### DIFF
--- a/src/openclaw/authority.py
+++ b/src/openclaw/authority.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import sqlite3
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List
 from enum import IntEnum
 
@@ -89,7 +89,7 @@ class AuthorityEngine:
             self._ensure_table_exists(conn)
             
             # Update level
-            now = datetime.utcnow().isoformat()
+            now = datetime.now(timezone.utc).isoformat()
             conn.execute(
                 """
                 INSERT OR REPLACE INTO authority_policy (id, level, changed_by, reason, effective_from, updated_at)

--- a/src/openclaw/proposal_engine.py
+++ b/src/openclaw/proposal_engine.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from enum import Enum
 
@@ -67,7 +67,7 @@ class StrategyProposal:
     
     # Timestamps
     expires_at: Optional[int] = None
-    created_at: int = field(default_factory=lambda: int(datetime.utcnow().timestamp() * 1000))
+    created_at: int = field(default_factory=lambda: int(datetime.now(timezone.utc).timestamp() * 1000))
     decided_at: Optional[int] = None
     
     # Metadata
@@ -95,7 +95,7 @@ def create_proposal(
     proposal_id = f"prop_{uuid.uuid4().hex[:12]}"
     
     # Calculate expiration (default 7 days)
-    expires_at = int((datetime.utcnow() + timedelta(days=expires_days)).timestamp() * 1000)
+    expires_at = int((datetime.now(timezone.utc) + timedelta(days=expires_days)).timestamp() * 1000)
     
     # Determine if human approval required
     requires_human = not _check_auto_approve_eligibility(
@@ -219,12 +219,12 @@ def approve_proposal(
         return {"success": False, "reason": f"INVALID_STATUS_{proposal['status']}"}
     
     # Check expiration
-    if proposal["expires_at"] and proposal["expires_at"] < int(datetime.utcnow().timestamp() * 1000):
+    if proposal["expires_at"] and proposal["expires_at"] < int(datetime.now(timezone.utc).timestamp() * 1000):
         _expire_proposal(conn, proposal_id)
         return {"success": False, "reason": "PROPOSAL_EXPIRED"}
     
     # Update status
-    now = int(datetime.utcnow().timestamp() * 1000)
+    now = int(datetime.now(timezone.utc).timestamp() * 1000)
     conn.execute(
         """
         UPDATE strategy_proposals 
@@ -252,7 +252,7 @@ def reject_proposal(
     if proposal["status"] != "pending":
         return {"success": False, "reason": f"INVALID_STATUS_{proposal['status']}"}
     
-    now = int(datetime.utcnow().timestamp() * 1000)
+    now = int(datetime.now(timezone.utc).timestamp() * 1000)
     conn.execute(
         """
         UPDATE strategy_proposals 
@@ -268,7 +268,7 @@ def reject_proposal(
 
 def _expire_proposal(conn: sqlite3.Connection, proposal_id: str) -> None:
     """Expire a proposal (internal)."""
-    now = int(datetime.utcnow().timestamp() * 1000)
+    now = int(datetime.now(timezone.utc).timestamp() * 1000)
     conn.execute(
         """
         UPDATE strategy_proposals 
@@ -282,7 +282,7 @@ def _expire_proposal(conn: sqlite3.Connection, proposal_id: str) -> None:
 
 def expire_old_proposals(conn: sqlite3.Connection) -> int:
     """Expire all pending proposals past their expiration time."""
-    now = int(datetime.utcnow().timestamp() * 1000)
+    now = int(datetime.now(timezone.utc).timestamp() * 1000)
     cursor = conn.execute(
         """
         UPDATE strategy_proposals 
@@ -353,7 +353,7 @@ def insert_strategy_proposal(conn: sqlite3.Connection, p: Any) -> None:
     
     proposal_id = getattr(p, 'proposal_id', f'prop_{uuid.uuid4().hex[:12]}')
     # expires_at as YYYY-MM-DD string (legacy schema expects TEXT)
-    expires_at = (datetime.utcnow() + timedelta(days=7)).strftime('%Y-%m-%d')
+    expires_at = (datetime.now(timezone.utc) + timedelta(days=7)).strftime('%Y-%m-%d')
     
     # Determine auto_approve eligibility
     auto_approve = getattr(p, 'auto_approve_eligible', False)
@@ -454,7 +454,7 @@ def apply_authority_decision(conn: sqlite3.Connection, proposal_id: str) -> Dict
         return {"allowed": False, "reason_code": "AUTH_NOT_PENDING"}
     if category in LEVEL3_FORBIDDEN_CATEGORIES:
         return {"allowed": False, "reason_code": "AUTH_LEVEL3_FORBIDDEN"}
-    if expires_at < datetime.utcnow().strftime("%Y-%m-%d"):
+    if expires_at < datetime.now(timezone.utc).strftime("%Y-%m-%d"):
         conn.execute("UPDATE strategy_proposals SET status='expired' WHERE proposal_id = ?", (proposal_id,))
         return {"allowed": False, "reason_code": "AUTH_PROPOSAL_EXPIRED"}
 

--- a/src/openclaw/reflection_loop.py
+++ b/src/openclaw/reflection_loop.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 import sqlite3
 import uuid
 from dataclasses import dataclass
@@ -186,7 +186,7 @@ def record_day_episode(conn: sqlite3.Connection, trade_date: str, reflection_id:
         INSERT INTO episodic_memory (episode_id, episode_type, trade_date, reflection_id, recorded_at)
         VALUES (?, ?, ?, ?, ?)
         """,
-        (episode_id, 'day', trade_date, reflection_id, datetime.utcnow().isoformat())
+        (episode_id, 'day', trade_date, reflection_id, datetime.now(timezone.utc).isoformat())
     )
     
     return episode_id

--- a/src/openclaw/strategy_registry.py
+++ b/src/openclaw/strategy_registry.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import sqlite3
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List
 from enum import Enum
 
@@ -57,14 +57,14 @@ class StrategyRegistry:
             
             # Generate version ID
             import uuid
-            version_id = f"v{datetime.utcnow().strftime('%Y%m%d')}_{uuid.uuid4().hex[:8]}"
+            version_id = f"v{datetime.now(timezone.utc).strftime('%Y%m%d')}_{uuid.uuid4().hex[:8]}"
             
             # If no version tag provided, generate one
             if not version_tag:
                 version_tag = f"Version {self._get_next_version_number(conn)}"
             
             # Prepare version data
-            now = datetime.utcnow().isoformat()
+            now = datetime.now(timezone.utc).isoformat()
             config_json = json.dumps(strategy_config, ensure_ascii=False)
             
             # Insert version
@@ -124,7 +124,7 @@ class StrategyRegistry:
             if current_active:
                 conn.execute(
                     "UPDATE strategy_versions SET status = ?, effective_to = ? WHERE version_id = ?",
-                    (VersionStatus.DEPRECATED.value, datetime.utcnow().isoformat(), current_active["version_id"])
+                    (VersionStatus.DEPRECATED.value, datetime.now(timezone.utc).isoformat(), current_active["version_id"])
                 )
                 
                 # Audit log for deactivation
@@ -138,12 +138,12 @@ class StrategyRegistry:
                         "deactivated",
                         activated_by,
                         json.dumps({"reason": "Replaced by new version", "new_version": version_id}),
-                        datetime.utcnow().isoformat()
+                        datetime.now(timezone.utc).isoformat()
                     )
                 )
             
             # Activate new version
-            now = datetime.utcnow().isoformat()
+            now = datetime.now(timezone.utc).isoformat()
             conn.execute(
                 """
                 UPDATE strategy_versions 
@@ -190,7 +190,7 @@ class StrategyRegistry:
             if current_active:
                 conn.execute(
                     "UPDATE strategy_versions SET status = ?, effective_to = ? WHERE version_id = ?",
-                    (VersionStatus.ROLLED_BACK.value, datetime.utcnow().isoformat(), current_active["version_id"])
+                    (VersionStatus.ROLLED_BACK.value, datetime.now(timezone.utc).isoformat(), current_active["version_id"])
                 )
                 
                 # Audit log for rollback deactivation
@@ -204,14 +204,14 @@ class StrategyRegistry:
                         "rolled_back",
                         rolled_back_by,
                         json.dumps({"reason": reason, "rolled_back_to": target_version_id}),
-                        datetime.utcnow().isoformat()
+                        datetime.now(timezone.utc).isoformat()
                     )
                 )
             
             # Create a copy of target version as new active version
             import uuid
-            new_version_id = f"rb_{datetime.utcnow().strftime('%Y%m%d')}_{uuid.uuid4().hex[:8]}"
-            now = datetime.utcnow().isoformat()
+            new_version_id = f"rb_{datetime.now(timezone.utc).strftime('%Y%m%d')}_{uuid.uuid4().hex[:8]}"
+            now = datetime.now(timezone.utc).isoformat()
             
             conn.execute(
                 """

--- a/src/tests/test_strategy_registry.py
+++ b/src/tests/test_strategy_registry.py
@@ -4,7 +4,7 @@ import pytest
 import tempfile
 import os
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 def test_version_status_enum():
@@ -204,7 +204,7 @@ def test_generate_monthly_report():
         registry.activate_version(v1["version_id"], "admin", "Start")
         
         # Generate report for current month
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report = registry.generate_monthly_report(now.year, now.month)
         
         assert report["year"] == now.year

--- a/tests/test_v4_26_proposal_system.py
+++ b/tests/test_v4_26_proposal_system.py
@@ -3,7 +3,7 @@
 import pytest
 import sqlite3
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 def test_proposal_status_enum():
@@ -158,7 +158,7 @@ def test_expire_old_proposals(conn):
     p2 = create_proposal(conn, "gen2", "rule2", "cat2", expires_days=7)  # Not expired
     
     # Manually set p1 to be expired (created_at - 10 days)
-    old_time = int((datetime.utcnow() - timedelta(days=10)).timestamp() * 1000)
+    old_time = int((datetime.now(timezone.utc) - timedelta(days=10)).timestamp() * 1000)
     conn.execute(
         "UPDATE strategy_proposals SET created_at = ?, expires_at = ? WHERE proposal_id = ?",
         (old_time, old_time, p1.proposal_id)

--- a/tests/test_v4_28_strategy_version.py
+++ b/tests/test_v4_28_strategy_version.py
@@ -4,7 +4,7 @@ import pytest
 import tempfile
 import os
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 def test_version_status_enum():
@@ -204,7 +204,7 @@ def test_generate_monthly_report():
         registry.activate_version(v1["version_id"], "admin", "Start")
         
         # Generate report for current month
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report = registry.generate_monthly_report(now.year, now.month)
         
         assert report["year"] == now.year


### PR DESCRIPTION
## Summary

- 全部 23 處 `datetime.utcnow()` 替換為 `datetime.now(timezone.utc)`
- 各檔 import 加入 `timezone`

## 結果

DeprecationWarning：163 → **40**（剩餘 40 個為 FastAPI `on_event` 警告，屬另一議題）

## Test plan

- [x] 335 / 335 測試通過
- [x] 無新增失敗

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)