### PR TITLE
feat(web): Agent 執行中心頁面 + RWD / safe-area 優化

### DIFF
--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>AI Trader — Command Center</title>
   </head>
   <body class="bg-slate-950 text-slate-100">

--- a/frontend/web/src/App.jsx
+++ b/frontend/web/src/App.jsx
@@ -7,6 +7,7 @@ import PortfolioPage from './pages/Portfolio'
 import TradesPage from './pages/Trades'
 import StrategyPage from './pages/Strategy'
 import SystemPage from './pages/System'
+import AgentsPage from './pages/Agents'
 import SettingsPage from './pages/Settings'
 
 /**
@@ -40,6 +41,7 @@ export default function App() {
         <Route path="/portfolio" element={<PortfolioPage />} />
         <Route path="/trades" element={<TradesPage />} />
         <Route path="/strategy" element={<StrategyPage />} />
+        <Route path="/agents" element={<AgentsPage />} />
         <Route path="/system" element={<SystemPage />} />
         <Route path="/settings" element={<SettingsPage />} />
       </Route>

--- a/frontend/web/src/components/Sidebar.jsx
+++ b/frontend/web/src/components/Sidebar.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 import {
   Briefcase, ArrowLeftRight, LineChart,
-  Settings, Package, SlidersHorizontal, LogOut, User
+  Settings, Package, SlidersHorizontal, LogOut, User, Bot
 } from 'lucide-react'
 import { logout, getToken } from '../lib/auth'
 
@@ -10,6 +10,7 @@ const nav = [
   { to: '/portfolio', label: 'Portfolio', icon: Briefcase },
   { to: '/trades', label: 'Trades', icon: ArrowLeftRight },
   { to: '/strategy', label: 'Strategy', icon: LineChart },
+  { to: '/agents', label: 'Agents', icon: Bot },
   { to: '/system', label: 'System', icon: Settings },
   { to: '/settings', label: '資金設定', icon: SlidersHorizontal },
 ]

--- a/frontend/web/src/layouts/DashboardLayout.jsx
+++ b/frontend/web/src/layouts/DashboardLayout.jsx
@@ -33,7 +33,7 @@ export default function DashboardLayout() {
           </div>
         ) : null}
 
-        <main className="flex-1 p-4 sm:p-6">
+        <main className="flex-1 p-4 sm:p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))]">
           <div className="mb-6 flex flex-col gap-3">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div className="flex items-start gap-3">

--- a/frontend/web/src/pages/Agents.jsx
+++ b/frontend/web/src/pages/Agents.jsx
@@ -1,0 +1,324 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+    Brain, RefreshCw, Play, Clock, CheckCircle, AlertCircle,
+    TrendingUp, Shield, BarChart3, Settings2, Cpu,
+    ChevronDown, ChevronUp, Zap
+} from 'lucide-react'
+import { authFetch, getApiBase } from '../lib/auth'
+
+/* ── Agent 前端元數據 ─────────────────────────────────────────────────────── */
+
+const AGENT_META = {
+    market_research: {
+        labelZh: '市場研究員',
+        icon: TrendingUp,
+        color: 'text-emerald-400',
+        ringColor: 'ring-emerald-500/20',
+        borderColor: 'border-emerald-500/20',
+        bgColor: 'bg-emerald-500/5',
+        btnColor: 'text-emerald-300 border-emerald-500/30 hover:bg-emerald-500/10',
+    },
+    portfolio_review: {
+        labelZh: 'Portfolio 審查員',
+        icon: BarChart3,
+        color: 'text-sky-400',
+        ringColor: 'ring-sky-500/20',
+        borderColor: 'border-sky-500/20',
+        bgColor: 'bg-sky-500/5',
+        btnColor: 'text-sky-300 border-sky-500/30 hover:bg-sky-500/10',
+    },
+    system_health: {
+        labelZh: '系統健康監控',
+        icon: Shield,
+        color: 'text-orange-400',
+        ringColor: 'ring-orange-500/20',
+        borderColor: 'border-orange-500/20',
+        bgColor: 'bg-orange-500/5',
+        btnColor: 'text-orange-300 border-orange-500/30 hover:bg-orange-500/10',
+    },
+    strategy_committee: {
+        labelZh: '策略小組',
+        icon: Brain,
+        color: 'text-violet-400',
+        ringColor: 'ring-violet-500/20',
+        borderColor: 'border-violet-500/20',
+        bgColor: 'bg-violet-500/5',
+        btnColor: 'text-violet-300 border-violet-500/30 hover:bg-violet-500/10',
+    },
+    system_optimization: {
+        labelZh: '系統優化員',
+        icon: Settings2,
+        color: 'text-amber-400',
+        ringColor: 'ring-amber-500/20',
+        borderColor: 'border-amber-500/20',
+        bgColor: 'bg-amber-500/5',
+        btnColor: 'text-amber-300 border-amber-500/30 hover:bg-amber-500/10',
+    },
+}
+
+/* ── 共用小元件 ──────────────────────────────────────────────────────────── */
+
+function ConfidenceBadge({ value }) {
+    if (value == null) return <span className="text-xs text-slate-600 font-mono">—</span>
+    const pct = Math.round(value * 100)
+    const cls = pct >= 70 ? 'text-emerald-400' : pct >= 40 ? 'text-amber-400' : 'text-rose-400'
+    return <span className={`text-xs font-mono font-semibold ${cls}`}>{pct}%</span>
+}
+
+function RelativeTime({ ts }) {
+    if (!ts) return <span className="text-slate-600 text-xs">從未執行</span>
+    const d = new Date(typeof ts === 'number' ? ts : ts.replace(' ', 'T') + (ts.includes('+') ? '' : 'Z'))
+    const min = Math.floor((Date.now() - d.getTime()) / 60000)
+    let label
+    if (min < 1) label = '剛剛'
+    else if (min < 60) label = `${min} 分鐘前`
+    else if (min < 1440) label = `${Math.floor(min / 60)} 小時前`
+    else label = `${Math.floor(min / 1440)} 天前`
+    return (
+        <span className="text-xs text-slate-400" title={d.toLocaleString('zh-TW')}>
+            {label}
+        </span>
+    )
+}
+
+function LatencyBadge({ ms }) {
+    if (!ms) return null
+    const s = ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`
+    return <span className="text-xs text-slate-600 font-mono">{s}</span>
+}
+
+/* ── Agent 卡片 ──────────────────────────────────────────────────────────── */
+
+function AgentCard({ agent, running, onRun }) {
+    const [histOpen, setHistOpen] = useState(false)
+    const [history, setHistory] = useState(null)
+    const [loadingHist, setLoadingHist] = useState(false)
+
+    const meta = AGENT_META[agent.name] || {}
+    const Icon = meta.icon || Cpu
+    const isRunning = running.includes(agent.name)
+
+    async function loadHistory() {
+        setLoadingHist(true)
+        try {
+            const res = await authFetch(`${getApiBase()}/api/agents/${agent.name}/history?limit=10`)
+            const data = await res.json()
+            setHistory(data.data || [])
+        } catch { /* ignore */ }
+        finally { setLoadingHist(false) }
+    }
+
+    function toggleHistory() {
+        if (!histOpen && !history) loadHistory()
+        setHistOpen(o => !o)
+    }
+
+    return (
+        <div className={`rounded-2xl border ${meta.borderColor || 'border-slate-800'} bg-slate-900/40 overflow-hidden flex flex-col`}>
+            {/* Card header */}
+            <div className={`px-5 py-4 ${meta.bgColor || ''} border-b border-slate-800/60 flex items-start justify-between gap-3`}>
+                <div className="flex items-center gap-2.5 min-w-0">
+                    <Icon className={`h-4 w-4 ${meta.color || 'text-slate-400'} shrink-0`} />
+                    <div className="min-w-0">
+                        <div className={`text-sm font-semibold ${meta.color || 'text-slate-200'} truncate`}>
+                            {meta.labelZh || agent.label}
+                        </div>
+                        <div className="text-xs text-slate-500 flex items-center gap-1 mt-0.5">
+                            <Clock className="h-3 w-3 shrink-0" />
+                            <span className="truncate">{agent.schedule}</span>
+                        </div>
+                    </div>
+                </div>
+                <button
+                    onClick={() => onRun(agent.name)}
+                    disabled={isRunning}
+                    className={`shrink-0 flex items-center gap-1.5 rounded-xl border px-3 py-1.5 text-xs font-semibold transition-all ${
+                        isRunning
+                            ? 'border-slate-700 bg-slate-800 text-slate-500 cursor-not-allowed'
+                            : `${meta.btnColor || 'text-slate-300 border-slate-700 hover:bg-slate-800'} bg-transparent`
+                    }`}
+                >
+                    {isRunning
+                        ? <><RefreshCw className="h-3 w-3 animate-spin" />執行中</>
+                        : <><Play className="h-3 w-3" />立即執行</>
+                    }
+                </button>
+            </div>
+
+            {/* Card body */}
+            <div className="px-5 py-4 space-y-3 flex-1">
+                <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                    <span className="text-slate-500">上次執行</span>
+                    <RelativeTime ts={agent.last_run_at} />
+                    <span className="text-slate-500">信心度</span>
+                    <ConfidenceBadge value={agent.last_confidence} />
+                    {agent.last_latency_ms && <>
+                        <span className="text-slate-500">耗時</span>
+                        <LatencyBadge ms={agent.last_latency_ms} />
+                    </>}
+                </div>
+
+                {agent.last_summary ? (
+                    <p className="text-xs text-slate-400 leading-relaxed line-clamp-3 rounded-xl bg-slate-950/50 border border-slate-800/60 px-3 py-2">
+                        {agent.last_summary}
+                    </p>
+                ) : (
+                    <p className="text-xs text-slate-600 italic">
+                        尚未執行，點擊「立即執行」觸發首次分析。
+                    </p>
+                )}
+            </div>
+
+            {/* History toggle */}
+            <div className="border-t border-slate-800/60">
+                <button
+                    onClick={toggleHistory}
+                    className="w-full flex items-center justify-between px-5 py-3 text-xs text-slate-500 hover:text-slate-300 hover:bg-slate-800/20 transition-colors"
+                >
+                    <span className="flex items-center gap-1.5">
+                        <Zap className="h-3 w-3" />執行歷史
+                    </span>
+                    {histOpen ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+                </button>
+
+                {histOpen && (
+                    <div className="px-5 pb-4 space-y-2 max-h-56 overflow-y-auto">
+                        {loadingHist && (
+                            <div className="flex items-center gap-2 text-xs text-slate-500 py-2">
+                                <RefreshCw className="h-3 w-3 animate-spin" />載入中...
+                            </div>
+                        )}
+                        {history && history.length === 0 && (
+                            <p className="text-xs text-slate-600 py-2 italic">無歷史記錄</p>
+                        )}
+                        {history && history.map((h, i) => (
+                            <div
+                                key={h.trace_id || i}
+                                className="rounded-xl border border-slate-800/60 bg-slate-950/30 px-3 py-2 space-y-1"
+                            >
+                                <div className="flex items-center justify-between gap-2">
+                                    <RelativeTime ts={h.created_at} />
+                                    <div className="flex items-center gap-2">
+                                        <LatencyBadge ms={h.latency_ms} />
+                                        <ConfidenceBadge value={h.confidence} />
+                                    </div>
+                                </div>
+                                {h.summary && (
+                                    <p className="text-xs text-slate-500 line-clamp-2">{h.summary}</p>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}
+
+/* ── 主頁面 ──────────────────────────────────────────────────────────────── */
+
+export default function AgentsPage() {
+    const [agents, setAgents] = useState([])
+    const [running, setRunning] = useState([])
+    const [error, setError] = useState(null)
+    const [toast, setToast] = useState(null)
+
+    const load = useCallback(async () => {
+        try {
+            const res = await authFetch(`${getApiBase()}/api/agents`)
+            const data = await res.json()
+            setAgents(data.data || [])
+            setRunning(data.running || [])
+            setError(null)
+        } catch (e) {
+            setError(e.message)
+        }
+    }, [])
+
+    // 一般輪詢
+    useEffect(() => {
+        load()
+        const id = setInterval(load, 15000)
+        return () => clearInterval(id)
+    }, [load])
+
+    // 執行中時加速輪詢
+    useEffect(() => {
+        if (running.length === 0) return
+        const id = setInterval(load, 3000)
+        return () => clearInterval(id)
+    }, [running.length, load])
+
+    async function handleRun(agentName) {
+        try {
+            const res = await authFetch(`${getApiBase()}/api/agents/${agentName}/run`, { method: 'POST' })
+            if (!res.ok) {
+                const b = await res.json().catch(() => ({}))
+                throw new Error(b.detail || `HTTP ${res.status}`)
+            }
+            const meta = AGENT_META[agentName]
+            setToast(`${meta?.labelZh || agentName} 已啟動`)
+            setTimeout(() => setToast(null), 4000)
+            setTimeout(load, 500)
+        } catch (e) {
+            setError(e.message)
+            setTimeout(() => setError(null), 6000)
+        }
+    }
+
+    const totalRuns = agents.filter(a => a.last_run_at).length
+
+    return (
+        <div className="space-y-6">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold text-slate-100 tracking-tight">Agent 執行中心</h1>
+                    <p className="mt-1 text-sm text-slate-400">
+                        監控各 AI Agent 執行狀態，或手動觸發分析任務。
+                        {totalRuns > 0 && <span className="ml-2 text-slate-500">{totalRuns}/{agents.length} 個 Agent 已執行過</span>}
+                    </p>
+                </div>
+                <button
+                    onClick={load}
+                    className="flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900/40 px-3 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors"
+                >
+                    <RefreshCw className="h-4 w-4" />刷新
+                </button>
+            </div>
+
+            {/* Toast / Error */}
+            {error && (
+                <div className="flex items-center gap-3 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+                    <AlertCircle className="h-4 w-4 shrink-0" />{error}
+                </div>
+            )}
+            {toast && (
+                <div className="flex items-center gap-3 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-300">
+                    <CheckCircle className="h-4 w-4 shrink-0" />{toast}
+                </div>
+            )}
+
+            {/* Running banner */}
+            {running.length > 0 && (
+                <div className="flex items-center gap-2 rounded-xl border border-violet-500/20 bg-violet-500/5 px-4 py-2.5 text-xs text-violet-300">
+                    <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                    執行中：{running.map(n => AGENT_META[n]?.labelZh || n).join('、')}（每 3 秒自動刷新）
+                </div>
+            )}
+
+            {/* Agent grid */}
+            {agents.length === 0 && !error && (
+                <div className="flex items-center gap-3 text-sm text-slate-400 py-12">
+                    <RefreshCw className="h-4 w-4 animate-spin" />載入中...
+                </div>
+            )}
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
+                {agents.map(agent => (
+                    <AgentCard key={agent.name} agent={agent} running={running} onRun={handleRun} />
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/frontend/web/src/pages/Settings.jsx
+++ b/frontend/web/src/pages/Settings.jsx
@@ -357,7 +357,7 @@ export default function SettingsPage() {
                 </div>
             )}
 
-            <div className="grid grid-cols-2 gap-6 items-start">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
                 {/* 0. Watchlist */}
                 <WatchlistSection />
 
@@ -405,7 +405,7 @@ export default function SettingsPage() {
                         {[1, 2, 3].map(lv => (
                             <div key={lv} className="rounded-xl border border-slate-800/60 bg-slate-950/30 px-4 py-3 space-y-2">
                                 <div className="text-xs font-semibold text-slate-300 uppercase tracking-wider">Level {lv}</div>
-                                <div className="grid grid-cols-2 gap-3">
+                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                                     <PctField label="單筆風險上限（% NAV）"
                                         value={limits.data[`level_${lv}_max_risk_pct`]}
                                         onChange={v => limits.set({ [`level_${lv}_max_risk_pct`]: v })} />


### PR DESCRIPTION
Closes #136

## 變更摘要

- **新頁面** `/agents`：5 個 Gemini Agent 卡片，可查看執行狀態 / 信心度 / 摘要，並手動觸發
- 雙速輪詢：靜默 15s、有 Agent 執行中時 3s
- 可展開執行歷史（lazy load，最近 10 筆）
- **RWD**：Settings grid 加 `md:` / `sm:` breakpoint，手機單欄
- **Safe-area**：`viewport-fit=cover` + `env(safe-area-inset-*)` 支援 iPhone 劉海 / Home bar

## 測試計畫

- [ ] CI green（vitest + build）
- [ ] `/agents` 頁面正確顯示 5 個 Agent
- [ ] 手機版 Settings 呈現單欄