### PR TITLE
feat(ux): 替換原生 dialog → ConfirmDialog；統一 Toast；Agents 全部執行

### DIFF
--- a/frontend/web/src/components/GlobalControlBar.jsx
+++ b/frontend/web/src/components/GlobalControlBar.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useControlStatus } from '../lib/controlApi'
 import { useToast } from './ToastProvider'
 
@@ -19,6 +19,58 @@ function Pill({ tone = 'slate', dotClassName = '', className = '', children, tit
   )
 }
 
+/** Styled confirmation dialog — replaces window.confirm / window.prompt */
+function ConfirmDialog({ open, title, message, dangerous, inputLabel, inputDefault, onConfirm, onCancel }) {
+  const [val, setVal] = useState(inputDefault || '')
+  if (!open) return null
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={onCancel}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl border border-slate-700 bg-slate-900 p-6 shadow-2xl"
+        onMouseDown={e => e.stopPropagation()}
+      >
+        <div className={`mb-2 text-base font-semibold ${dangerous ? 'text-rose-300' : 'text-slate-100'}`}>
+          {title}
+        </div>
+        <p className="text-sm text-slate-400 leading-relaxed mb-5 whitespace-pre-wrap">{message}</p>
+
+        {inputLabel && (
+          <div className="mb-5">
+            <label className="block text-xs text-slate-400 mb-1.5">{inputLabel}</label>
+            <input
+              autoFocus
+              value={val}
+              onChange={e => setVal(e.target.value)}
+              className="w-full rounded-lg border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-200 focus:border-slate-500 focus:outline-none"
+            />
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-xl border border-slate-700 py-2.5 text-sm font-medium text-slate-300 hover:bg-slate-800 transition-colors"
+          >
+            取消
+          </button>
+          <button
+            autoFocus={!inputLabel}
+            onClick={() => onConfirm(val)}
+            className={`flex-1 rounded-xl py-2.5 text-sm font-semibold text-white transition-colors ${
+              dangerous ? 'bg-rose-600 hover:bg-rose-500' : 'bg-emerald-600 hover:bg-emerald-500'
+            }`}
+          >
+            確認
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 const ACT_LABELS = {
   '/enable': '✅ 自動交易已啟用',
   '/disable': '⏸️ 自動交易已停用',
@@ -29,8 +81,9 @@ const ACT_LABELS = {
 }
 
 export default function GlobalControlBar() {
-  const { status, error, loading, lastAction, act } = useControlStatus({ pollMs: 5000 })
+  const { status, error, loading, act } = useControlStatus({ pollMs: 5000 })
   const toast = useToast()
+  const [dlg, setDlg] = useState(null)
 
   const isEmergency = Boolean(status?.emergency_stop)
   const isAutoTradingEnabled = Boolean(status?.auto_trading_enabled)
@@ -45,11 +98,25 @@ export default function GlobalControlBar() {
     }
   }
 
-  const handleEnable = () => {
+  /** Open a styled confirm/input dialog; resolves { ok, val } */
+  function ask(cfg) {
+    return new Promise(resolve => {
+      setDlg({
+        ...cfg,
+        _key: Date.now(),
+        onConfirm: val => { setDlg(null); resolve({ ok: true, val }) },
+        onCancel:  ()  => { setDlg(null); resolve({ ok: false }) },
+      })
+    })
+  }
+
+  const handleEnable = async () => {
     if (status?.simulation_mode === false) {
-      const ok = window.confirm(
-        '⚠️ 警告：您目前處於實際盤模式。啟用自動交易將使用真實資金進行交易。\n\n確定要啟用自動交易嗎？'
-      )
+      const { ok } = await ask({
+        title: '⚠️ 啟用自動交易',
+        message: '您目前處於實際盤模式。啟用自動交易將使用真實資金進行交易。\n\n確定要啟用嗎？',
+        dangerous: true,
+      })
       if (!ok) return
     }
     runAct('/enable')
@@ -58,16 +125,25 @@ export default function GlobalControlBar() {
   const handleDisable = () => runAct('/disable')
   const handleSwitchToSimulation = () => runAct('/simulation')
 
-  const handleSwitchToLive = () => {
-    const ok = window.confirm(
-      '🚨 極度危險警告 🚨\n\n您即將切換到實際盤模式，所有交易將使用真實資金。\n\n確定要切換到實際盤嗎？'
-    )
+  const handleSwitchToLive = async () => {
+    const { ok } = await ask({
+      title: '🚨 切換至實際盤',
+      message: '您即將切換到實際盤模式，所有交易將使用真實資金。\n\n此操作無法自動撤銷，請謹慎確認。',
+      dangerous: true,
+    })
     if (ok) runAct('/live')
   }
 
-  const handleEmergencyStop = () => {
-    const reason = prompt('請輸入緊急停止原因（可選）:', '手動緊急停止')
-    runAct('/stop', { method: 'POST', body: { reason: reason || 'User initiated manual stop' } })
+  const handleEmergencyStop = async () => {
+    const { ok, val } = await ask({
+      title: '🚨 緊急停止',
+      message: '即將觸發緊急停止，所有自動交易將立即暫停。',
+      dangerous: true,
+      inputLabel: '停止原因（可選）',
+      inputDefault: '手動緊急停止',
+    })
+    if (!ok) return
+    runAct('/stop', { method: 'POST', body: { reason: val || 'User initiated manual stop' } })
   }
 
   const handleResume = () => runAct('/resume')
@@ -198,6 +274,21 @@ export default function GlobalControlBar() {
             {error}
           </div>
         </div>
+      )}
+
+      {/* Styled confirm / input dialog */}
+      {dlg && (
+        <ConfirmDialog
+          key={dlg._key}
+          open
+          title={dlg.title}
+          message={dlg.message}
+          dangerous={dlg.dangerous}
+          inputLabel={dlg.inputLabel}
+          inputDefault={dlg.inputDefault}
+          onConfirm={dlg.onConfirm}
+          onCancel={dlg.onCancel}
+        />
       )}
     </div>
   )

--- a/frontend/web/src/pages/Agents.jsx
+++ b/frontend/web/src/pages/Agents.jsx
@@ -249,6 +249,13 @@ export default function AgentsPage() {
         return () => clearInterval(id)
     }, [running.length, load])
 
+    async function handleRunAll() {
+        const toRun = agents.filter(a => !running.includes(a.name))
+        for (const agent of toRun) {
+            await handleRun(agent.name)
+        }
+    }
+
     async function handleRun(agentName) {
         try {
             const res = await authFetch(`${getApiBase()}/api/agents/${agentName}/run`, { method: 'POST' })
@@ -279,12 +286,22 @@ export default function AgentsPage() {
                         {totalRuns > 0 && <span className="ml-2 text-slate-500">{totalRuns}/{agents.length} 個 Agent 已執行過</span>}
                     </p>
                 </div>
-                <button
-                    onClick={load}
-                    className="flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900/40 px-3 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors"
-                >
-                    <RefreshCw className="h-4 w-4" />刷新
-                </button>
+                <div className="flex items-center gap-2">
+                    <button
+                        onClick={handleRunAll}
+                        disabled={agents.length === 0 || running.length === agents.length}
+                        title="觸發所有未執行中的 Agent"
+                        className="flex items-center gap-2 rounded-xl border border-violet-500/30 bg-violet-500/10 px-3 py-2 text-sm text-violet-300 hover:bg-violet-500/15 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                        <Zap className="h-4 w-4" />全部執行
+                    </button>
+                    <button
+                        onClick={load}
+                        className="flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900/40 px-3 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors"
+                    >
+                        <RefreshCw className="h-4 w-4" />刷新
+                    </button>
+                </div>
             </div>
 
             {/* Toast / Error */}

--- a/frontend/web/src/pages/Portfolio.jsx
+++ b/frontend/web/src/pages/Portfolio.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Lock, TrendingDown } from 'lucide-react'
+import { useToast } from '../components/ToastProvider'
 import PmStatusCard from '../components/PmStatusCard'
 import KpiCard from '../components/KpiCard'
 import AllocationDonut from '../components/charts/AllocationDonut'
@@ -135,10 +136,10 @@ export default function PortfolioPage() {
   // Drawer state — design doc §4.1
   const [drawerSymbol, setDrawerSymbol] = useState(null)
   const [drawerPosition, setDrawerPosition] = useState(null)
+  const toast = useToast()
   // Close position state
   const [closeTarget, setCloseTarget] = useState(null)   // position object
   const [closeBusy, setCloseBusy] = useState(false)
-  const [closeResult, setCloseResult] = useState(null)   // { ok, msg }
 
   const [equitySeries, setEquitySeries] = useState([])
   const [equitySource, setEquitySource] = useState('讀取中...')
@@ -198,14 +199,13 @@ export default function PortfolioPage() {
   async function handleCloseConfirm() {
     if (!closeTarget) return
     setCloseBusy(true)
-    setCloseResult(null)
     try {
       const res = await closePosition(closeTarget.symbol)
-      setCloseResult({ ok: true, msg: `已平倉 ${res.qty_closed} 股 @ ${formatCurrency(res.sell_price)}` })
+      toast.success(`已平倉 ${res.qty_closed} 股 @ ${formatCurrency(res.sell_price)}`)
       setCloseTarget(null)
       await load(preferApi)   // refresh positions
     } catch (e) {
-      setCloseResult({ ok: false, msg: String(e?.message || e) })
+      toast.error(String(e?.message || e))
       setCloseTarget(null)
     } finally {
       setCloseBusy(false)
@@ -396,18 +396,6 @@ export default function PortfolioPage() {
         onCancel={() => setCloseTarget(null)}
         busy={closeBusy}
       />
-
-      {/* Close result toast */}
-      {closeResult && (
-        <div className={`fixed bottom-6 right-6 z-50 max-w-sm rounded-xl border px-4 py-3 text-sm shadow-lg ${
-          closeResult.ok
-            ? 'border-emerald-700 bg-emerald-900/80 text-emerald-200'
-            : 'border-rose-700 bg-rose-900/80 text-rose-200'
-        }`}>
-          {closeResult.msg}
-          <button onClick={() => setCloseResult(null)} className="ml-3 opacity-60 hover:opacity-100">✕</button>
-        </div>
-      )}
 
       {/* Position Detail Drawer — design doc §4.1 */}
       {drawerSymbol && (

--- a/frontend/web/src/pages/Portfolio.test.jsx
+++ b/frontend/web/src/pages/Portfolio.test.jsx
@@ -4,14 +4,17 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { axe } from 'jest-axe'
 import { ThemeProvider } from '../lib/theme'
+import { ToastProvider } from '../components/ToastProvider'
 import PortfolioPage from './Portfolio'
 
 function renderPage() {
   return render(
     <ThemeProvider defaultTheme="dark">
-      <MemoryRouter initialEntries={['/portfolio']}>
-        <PortfolioPage />
-      </MemoryRouter>
+      <ToastProvider>
+        <MemoryRouter initialEntries={['/portfolio']}>
+          <PortfolioPage />
+        </MemoryRouter>
+      </ToastProvider>
     </ThemeProvider>
   )
 }

--- a/frontend/web/src/pages/Strategy.jsx
+++ b/frontend/web/src/pages/Strategy.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState, Fragment } from 'react'
 import { useStreamApiBase, useStrategyData } from '../lib/strategyApi'
-import { CheckCircle2, XCircle, Clock, ChevronDown, ChevronRight, MessageSquare, Target, Save, FileSignature, ShieldAlert, Cpu } from 'lucide-react'
+import { CheckCircle2, XCircle, Clock, ChevronDown, ChevronRight, MessageSquare, Target, Save, FileSignature, ShieldAlert, Cpu, Copy, Check } from 'lucide-react'
 import { authFetch, getApiBase, getToken } from '../lib/auth'
+import { useToast } from '../components/ToastProvider'
 
 function formatUnixSec(sec) {
   const n = Number(sec)
@@ -393,8 +394,11 @@ export default function StrategyPage() {
   const { proposals, logs, marketRating, semanticMemory, debates, error, loading, act, refreshProposals, refreshSemanticMemory } = useStrategyData({ pollMs: 10000 })
   const STREAM_BASE = useStreamApiBase()
 
+  const toast = useToast()
   const [selected, setSelected] = useState(null)
   const [modalOpen, setModalOpen] = useState(false)
+  const [pendingAct, setPendingAct] = useState(null)  // { type: 'approve'|'reject', proposal }
+  const [copiedId, setCopiedId] = useState(null)
 
   const [memOrder, setMemOrder] = useState('desc')
 
@@ -452,20 +456,34 @@ export default function StrategyPage() {
     setModalOpen(false)
   }
 
-  const doApprove = async p => {
+  const doApprove = (p) => {
     if (!p?.proposal_id) return
-    const ok = window.confirm(`確定批准提案 ${p.proposal_id}？`)
-    if (!ok) return
-    await act('approve', p.proposal_id, { actor: 'operator', reason: 'manual approve via UI' })
-    setModalOpen(false)
+    setPendingAct({ type: 'approve', proposal: p })
   }
 
-  const doReject = async p => {
+  const doReject = (p) => {
     if (!p?.proposal_id) return
-    const ok = window.confirm(`確定拒絕提案 ${p.proposal_id}？`)
-    if (!ok) return
-    await act('reject', p.proposal_id, { actor: 'operator', reason: 'manual reject via UI' })
+    setPendingAct({ type: 'reject', proposal: p })
+  }
+
+  const confirmAct = async () => {
+    if (!pendingAct) return
+    const { type, proposal: p } = pendingAct
+    setPendingAct(null)
     setModalOpen(false)
+    try {
+      await act(type, p.proposal_id, { actor: 'operator', reason: `manual ${type} via UI` })
+      toast.success(type === 'approve' ? `提案 ${p.proposal_id} 已批准` : `提案 ${p.proposal_id} 已拒絕`)
+    } catch (e) {
+      toast.error(`操作失敗：${e?.message || e}`)
+    }
+  }
+
+  function copyId(id) {
+    navigator.clipboard.writeText(id).then(() => {
+      setCopiedId(id)
+      setTimeout(() => setCopiedId(null), 2000)
+    })
   }
 
   return (
@@ -510,9 +528,20 @@ export default function StrategyPage() {
                     <tr key={p.proposal_id} className="hover:bg-slate-950/30">
                       <td className="px-4 py-3 text-slate-300 whitespace-nowrap">{p._ts}</td>
                       <td className="px-4 py-3">
-                        <button onClick={() => openDetail(p)} className="text-slate-200 hover:text-white underline underline-offset-2">
-                          {p.proposal_id}
-                        </button>
+                        <div className="flex items-center gap-1.5">
+                          <button onClick={() => openDetail(p)} className="text-slate-200 hover:text-white underline underline-offset-2">
+                            {p.proposal_id}
+                          </button>
+                          <button
+                            onClick={e => { e.stopPropagation(); copyId(p.proposal_id) }}
+                            title="複製 Proposal ID"
+                            className="text-slate-600 hover:text-slate-300 transition-colors"
+                          >
+                            {copiedId === p.proposal_id
+                              ? <Check className="h-3 w-3 text-emerald-400" />
+                              : <Copy className="h-3 w-3" />}
+                          </button>
+                        </div>
                       </td>
                       <td className="px-4 py-3 text-slate-300">{p._symbol}</td>
                       <td className="px-4 py-3 text-slate-300">{p._side}</td>
@@ -591,6 +620,44 @@ export default function StrategyPage() {
 
       {/* ── PM LLM Trace ─────────────────────────────────────────────── */}
       <PmTracePanel />
+
+      {/* ── Approve / Reject 確認 Dialog ──────────────────────────────── */}
+      {pendingAct && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4"
+          onMouseDown={() => setPendingAct(null)}
+        >
+          <div
+            className="w-full max-w-xs rounded-2xl border border-slate-700 bg-slate-900 p-5 shadow-2xl"
+            onMouseDown={e => e.stopPropagation()}
+          >
+            <div className={`text-sm font-semibold mb-2 ${pendingAct.type === 'approve' ? 'text-emerald-300' : 'text-rose-300'}`}>
+              確認{pendingAct.type === 'approve' ? '批准' : '拒絕'}提案
+            </div>
+            <div className="text-xs text-slate-500 mb-1">Proposal ID</div>
+            <div className="text-xs text-slate-200 font-mono bg-slate-950/60 rounded-lg px-3 py-2 mb-4 break-all">
+              {pendingAct.proposal?.proposal_id}
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setPendingAct(null)}
+                className="flex-1 rounded-xl border border-slate-700 py-2 text-sm font-medium text-slate-300 hover:bg-slate-800 transition-colors"
+              >
+                取消
+              </button>
+              <button
+                autoFocus
+                onClick={confirmAct}
+                className={`flex-1 rounded-xl py-2 text-sm font-semibold text-white transition-colors ${
+                  pendingAct.type === 'approve' ? 'bg-emerald-600 hover:bg-emerald-500' : 'bg-rose-600 hover:bg-rose-500'
+                }`}
+              >
+                確認
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Closes #138

## 變更摘要

- **ConfirmDialog**（GlobalControlBar）：取代 `window.confirm/prompt`，支援 dangerous 模式與 input 欄位
- **Strategy**：批准/拒絕改用頁內 dialog + `useToast()` 結果通知 + Proposal ID 複製按鈕
- **Portfolio**：平倉 toast 統一用 `useToast()`，移除舊 `closeResult` state
- **Agents**：新增「全部執行」按鈕（依序觸發所有未執行 Agent）

## 測試計畫

- [ ] CI green
- [ ] 緊急停止 / 切換實際盤 → styled dialog 正確顯示
- [ ] 批准 / 拒絕提案 → 頁內 dialog + toast 回報
- [ ] Agents 全部執行按鈕正常 disabled 邏輯