### PR TITLE
feat: Telegram 提案通知+inline核准 + 全站股票名稱顯示

### DIFF
--- a/frontend/backend/app/api/portfolio.py
+++ b/frontend/backend/app/api/portfolio.py
@@ -70,16 +70,22 @@ def portfolio_positions(simulation: Optional[bool] = None):
     try:
         with get_conn() as conn:
             rows = conn.execute(
-                "SELECT symbol, quantity, avg_price, current_price, "
-                "unrealized_pnl, chip_health_score, sector "
-                "FROM positions WHERE quantity > 0 ORDER BY symbol"
+                "SELECT p.symbol, p.quantity, p.avg_price, p.current_price, "
+                "p.unrealized_pnl, p.chip_health_score, p.sector, "
+                "e.name AS stock_name "
+                "FROM positions p "
+                "LEFT JOIN (SELECT symbol, name FROM eod_prices "
+                "           WHERE name IS NOT NULL "
+                "           GROUP BY symbol HAVING trade_date=MAX(trade_date)) e "
+                "ON p.symbol = e.symbol "
+                "WHERE p.quantity > 0 ORDER BY p.symbol"
             ).fetchall()
         if rows:
             locked_set = set(_read_locked())
             positions = [
                 {
                     "symbol": r["symbol"],
-                    "name": r["symbol"],
+                    "name": r["stock_name"] if r["stock_name"] and r["stock_name"] != r["symbol"] else None,
                     "qty": int(r["quantity"]),
                     "avg_price": float(r["avg_price"] or 0),
                     "last_price": float(r["current_price"]) if r["current_price"] else None,
@@ -984,3 +990,15 @@ def get_kline(symbol: str, days: int = 60):
         ).fetchall()
     data = [dict(r) for r in reversed(rows)]
     return {"symbol": symbol, "data": data}
+
+
+@router.get("/symbol-names")
+def get_symbol_names():
+    """回傳所有已知股票代號→名稱對照表（來源：eod_prices 最新一筆）。"""
+    with get_conn() as conn:
+        rows = conn.execute(
+            "SELECT symbol, name FROM eod_prices "
+            "WHERE name IS NOT NULL "
+            "GROUP BY symbol HAVING trade_date=MAX(trade_date)"
+        ).fetchall()
+    return {"names": {r["symbol"]: r["name"] for r in rows if r["name"]}}

--- a/frontend/web/src/lib/symbolNames.js
+++ b/frontend/web/src/lib/symbolNames.js
@@ -1,0 +1,43 @@
+/**
+ * symbolNames.js — 全域股票代號→名稱對照表
+ *
+ * 用法：
+ *   import { useSymbolNames, formatSymbol } from '../lib/symbolNames'
+ *
+ *   const names = useSymbolNames()         // React hook，自動快取
+ *   const label = formatSymbol('3008', names)  // "3008 大立光"
+ */
+import { useEffect, useState } from 'react'
+import { authFetch, getApiBase } from './auth'
+
+let _cache = null   // module-level cache; refreshed per page load
+
+export function useSymbolNames() {
+  const [names, setNames] = useState(_cache || {})
+
+  useEffect(() => {
+    if (_cache) return
+    authFetch(`${getApiBase()}/api/portfolio/symbol-names`)
+      .then(r => r.ok ? r.json() : null)
+      .then(d => {
+        if (d?.names) {
+          _cache = d.names
+          setNames(d.names)
+        }
+      })
+      .catch(() => {})
+  }, [])
+
+  return names
+}
+
+/**
+ * Returns "3008 大立光" if name is known, or just "3008" otherwise.
+ * @param {string} symbol
+ * @param {Record<string,string>} names   — from useSymbolNames()
+ */
+export function formatSymbol(symbol, names) {
+  if (!symbol) return symbol
+  const name = names?.[symbol]
+  return name && name !== symbol ? `${symbol} ${name}` : symbol
+}

--- a/frontend/web/src/pages/Portfolio.jsx
+++ b/frontend/web/src/pages/Portfolio.jsx
@@ -82,7 +82,9 @@ function ClosePositionModal({ position, onConfirm, onCancel, busy }) {
         <div className="rounded-xl border border-slate-800 bg-slate-950/50 p-4 space-y-2 text-xs mb-5">
           <div className="flex justify-between">
             <span className="text-slate-400">標的</span>
-            <span className="text-slate-100 font-mono font-semibold">{position.symbol}</span>
+            <span className="text-slate-100 font-mono font-semibold">
+              {position.symbol}{position.name && position.name !== position.symbol ? ` ${position.name}` : ''}
+            </span>
           </div>
           <div className="flex justify-between">
             <span className="text-slate-400">賣出數量</span>

--- a/frontend/web/src/pages/Strategy.jsx
+++ b/frontend/web/src/pages/Strategy.jsx
@@ -3,11 +3,14 @@ import { useStreamApiBase, useStrategyData } from '../lib/strategyApi'
 import { CheckCircle2, XCircle, Clock, ChevronDown, ChevronRight, MessageSquare, Target, Save, FileSignature, ShieldAlert, Cpu, Copy, Check } from 'lucide-react'
 import { authFetch, getApiBase, getToken } from '../lib/auth'
 import { useToast } from '../components/ToastProvider'
+import { useSymbolNames, formatSymbol } from '../lib/symbolNames'
 
 function formatUnixSec(sec) {
   const n = Number(sec)
   if (!Number.isFinite(n) || n <= 0) return ''
-  return new Date(n * 1000).toLocaleString('zh-TW', { hour12: false })
+  // If n > 1e12 it's already milliseconds; otherwise treat as seconds
+  const ms = n > 1e12 ? n : n * 1000
+  return new Date(ms).toLocaleString('zh-TW', { hour12: false })
 }
 
 function safeJsonParse(s) {
@@ -109,7 +112,7 @@ function PmTracePanel() {
               {/* Header row */}
               <div className="flex flex-wrap items-center gap-3 px-4 py-2.5 bg-slate-950/50 text-[11px] text-slate-400">
                 <span className="font-mono text-slate-300">{t.trace_id}</span>
-                <span>{new Date((t.created_at || 0) * 1000).toLocaleString('zh-TW', { hour12: false })}</span>
+                <span>{formatUnixSec(t.created_at)}</span>
                 <span className="text-indigo-300">{t.model}</span>
                 {t.latency_ms != null && <span>{t.latency_ms} ms</span>}
               </div>
@@ -218,7 +221,7 @@ function DebatePanel() {
             <div key={d.id || i} className="rounded-xl border border-slate-800 overflow-hidden">
               {d.summary && (
                 <div className="px-4 py-2 bg-slate-950/50 text-[11px] text-slate-400 border-b border-slate-800">
-                  {new Date((d.timestamp || 0) * 1000).toLocaleString('zh-TW', { hour12: false })}
+                  {formatUnixSec(d.timestamp)}
                   {' — '}{d.summary}
                 </div>
               )}
@@ -393,6 +396,7 @@ function SemanticMemoryTable({ data }) {
 export default function StrategyPage() {
   const { proposals, logs, marketRating, semanticMemory, debates, error, loading, act, refreshProposals, refreshSemanticMemory } = useStrategyData({ pollMs: 10000 })
   const STREAM_BASE = useStreamApiBase()
+  const symbolNames = useSymbolNames()
 
   const toast = useToast()
   const [selected, setSelected] = useState(null)
@@ -440,12 +444,12 @@ export default function StrategyPage() {
       const side = payload?.side || payload?.direction || payload?.action || ''
       return {
         ...p,
-        _symbol: symbol || '-',
+        _symbol: symbol ? formatSymbol(symbol, symbolNames) : '-',
         _side: side || '-',
         _ts: formatUnixSec(p?.created_at) || '-'
       }
     })
-  }, [proposals])
+  }, [proposals, symbolNames])
 
   const openDetail = p => {
     setSelected(p)

--- a/frontend/web/src/pages/Trades.jsx
+++ b/frontend/web/src/pages/Trades.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { formatCurrency, formatNumber, formatPercent } from '../lib/format'
 import { downloadTextFile, fetchTrades, fetchTradeCausalChain, mockTrades, tradesToCsv, tradesToExcelXml } from '../lib/trades'
 import { authFetch, getApiBase } from '../lib/auth'
+import { useSymbolNames, formatSymbol } from '../lib/symbolNames'
 
 function toIsoDate(d) {
   if (!d) return ''
@@ -89,6 +90,7 @@ function MonthlySummaryPanel() {
 }
 
 export default function TradesPage() {
+  const symbolNames = useSymbolNames()
   const [items, setItems] = useState([])
   const [total, setTotal] = useState(0)
   const [source, setSource] = useState('loading')
@@ -373,7 +375,7 @@ export default function TradesPage() {
                     onClick={() => handleTradeSelect(t)}
                   >
                     <td className="px-4 py-3 font-medium text-slate-100">{toTWN(t.timestamp)}</td>
-                    <td className="px-4 py-3 text-slate-200">{t.symbol}</td>
+                    <td className="px-4 py-3 text-slate-200">{formatSymbol(t.symbol, symbolNames)}</td>
                     <td className={`px-4 py-3 font-medium ${sideTone}`}>{String(t.action).toUpperCase()}</td>
                     <td className="px-4 py-3 text-right text-slate-200">
                       {formatNumber(qty, { maximumFractionDigits: 4 })}

--- a/src/openclaw/proposal_reviewer.py
+++ b/src/openclaw/proposal_reviewer.py
@@ -143,10 +143,12 @@ def auto_review_pending_proposals(conn: sqlite3.Connection) -> int:
             conn.commit()
 
             # Telegram 通知
+            from openclaw.tg_approver import _fmt_symbol
+            sym_display = _fmt_symbol(conn, symbol)
             icon = "✅" if new_status == "approved" else "🚫"
             msg = (
                 f"{icon} <b>[盤中策略審查]</b>\n"
-                f"標的：<b>{symbol}</b> | 規則：{target_rule}\n"
+                f"標的：<b>{sym_display}</b> | 規則：{target_rule}\n"
                 f"決定：<b>{'核准減倉' if new_status == 'approved' else '拒絕'}</b>"
                 f"（信心 {confidence:.0%}）\n"
                 f"建議減倉：{reduce_pct:.1%}　目前比重：{weight:.1%}\n"

--- a/src/openclaw/tg_approver.py
+++ b/src/openclaw/tg_approver.py
@@ -1,0 +1,272 @@
+"""tg_approver.py — Telegram 策略提案通知與 inline 核准
+
+功能：
+    - notify_pending_proposals(conn)  : 掃描 pending 提案，發 Telegram inline 按鈕
+    - poll_approval_callbacks(conn)   : 處理 ✅/🚫 按鈕按下，更新 DB 狀態
+
+狀態持久化：
+    working_memory 表，scope='tg_approver'
+      key='notified_ids'   → JSON 陣列，已發通知的 proposal_id
+      key='update_offset'  → int，Telegram getUpdates offset
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import urllib.request
+import uuid
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_CHAT_ID = "1017252031"
+_NOTIFIABLE_RULES = {"POSITION_REBALANCE", "SECTOR_FOCUS"}
+
+
+# ── 內部工具 ──────────────────────────────────────────────────────────────────
+
+def _token() -> str:
+    return os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+
+
+def _chat_id() -> str:
+    return os.environ.get("TELEGRAM_CHAT_ID", _DEFAULT_CHAT_ID)
+
+
+def _symbol_name(conn: sqlite3.Connection, symbol: str) -> str:
+    """查 eod_prices 取得股票名稱，找不到就回傳 symbol 本身。"""
+    try:
+        row = conn.execute(
+            "SELECT name FROM eod_prices WHERE symbol=? AND name IS NOT NULL"
+            " ORDER BY trade_date DESC LIMIT 1",
+            (symbol,),
+        ).fetchone()
+        name = row["name"] if row else None
+        return name if name and name != symbol else symbol
+    except Exception:
+        return symbol
+
+
+def _fmt_symbol(conn: sqlite3.Connection, symbol: str) -> str:
+    """回傳 '3008 大立光' 或單獨 '3008'（若查無名稱）。"""
+    if not symbol:
+        return symbol
+    name = _symbol_name(conn, symbol)
+    return f"{symbol} {name}" if name != symbol else symbol
+
+
+def _wm_get(conn: sqlite3.Connection, key: str):
+    """從 working_memory (scope='tg_approver') 讀取 JSON 值，找不到回傳 None。"""
+    row = conn.execute(
+        "SELECT value_json FROM working_memory"
+        " WHERE scope='tg_approver' AND key=?",
+        (key,),
+    ).fetchone()
+    return json.loads(row["value_json"]) if row else None
+
+
+def _wm_set(conn: sqlite3.Connection, key: str, value) -> None:
+    """Upsert working_memory (scope='tg_approver', key=key)。"""
+    now_ms = "CAST(strftime('%s','now') AS INTEGER)*1000"
+    wm_id = f"tg_approver:{key}"
+    conn.execute(
+        f"""INSERT INTO working_memory
+               (wm_id, session_date, scope, key, value_json, importance, created_at, updated_at)
+             VALUES (?, date('now','+8 hours'), 'tg_approver', ?, ?, 3,
+                     {now_ms}, {now_ms})
+             ON CONFLICT(wm_id) DO UPDATE SET
+               value_json=excluded.value_json,
+               updated_at={now_ms}""",
+        (wm_id, key, json.dumps(value)),
+    )
+    conn.commit()
+
+
+def _answer_callback(token: str, callback_query_id: str, text: str) -> None:
+    """回應 Telegram callback_query，消除按鈕 loading 圈。"""
+    url = f"https://api.telegram.org/bot{token}/answerCallbackQuery"
+    payload = json.dumps({
+        "callback_query_id": callback_query_id,
+        "text": text,
+    }).encode()
+    try:
+        req = urllib.request.Request(
+            url, data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        urllib.request.urlopen(req, timeout=5)
+    except Exception as e:
+        log.debug("answerCallbackQuery failed: %s", e)
+
+
+# ── 公開 API ──────────────────────────────────────────────────────────────────
+
+def notify_pending_proposals(conn: sqlite3.Connection) -> int:
+    """掃描 pending 提案，對尚未通知的發送 Telegram inline 訊息。
+
+    Returns:
+        發送通知的數量（0 表示無新提案或 token 未設定）
+    """
+    from openclaw.tg_notify import send_message_with_buttons  # lazy import
+
+    tok = _token()
+    if not tok:
+        return 0
+
+    notified: set = set(_wm_get(conn, "notified_ids") or [])
+    rows = conn.execute(
+        """SELECT proposal_id, target_rule, proposed_value, confidence
+             FROM strategy_proposals
+            WHERE status='pending'
+              AND target_rule IN ('POSITION_REBALANCE', 'SECTOR_FOCUS')
+            ORDER BY created_at DESC""",
+    ).fetchall()
+
+    sent = 0
+    for row in rows:
+        pid = row["proposal_id"]
+        if pid in notified:
+            continue
+
+        rule = row["target_rule"]
+        conf = row["confidence"] or 0.0
+
+        # 解析 proposed_value
+        try:
+            pv = json.loads(row["proposed_value"])
+        except Exception:
+            pv = {}
+
+        symbol   = pv.get("symbol", "")
+        action   = pv.get("action", "")
+        qty      = pv.get("quantity", "")
+        price    = pv.get("target_price", "")
+
+        sym_display = _fmt_symbol(conn, symbol) if symbol else ""
+
+        emoji = "🔄" if rule == "POSITION_REBALANCE" else "🎯"
+        lines = [f"{emoji} <b>策略提案審查</b>", f"類型：{rule}"]
+        if sym_display:
+            lines.append(f"標的：{sym_display}")
+        if action:
+            lines.append(f"動作：{action}")
+        if qty:
+            lines.append(f"數量：{qty} 股")
+        if price:
+            lines.append(f"目標價：{price}")
+        lines.append(f"信心度：{conf:.0%}")
+        lines.append(f"\n<i>ID：{pid[:8]}…</i>")
+
+        buttons = [[
+            {"text": "✅ 核准", "callback_data": f"approve:{pid}"},
+            {"text": "🚫 拒絕", "callback_data": f"reject:{pid}"},
+        ]]
+
+        ok = send_message_with_buttons("\n".join(lines), buttons)
+        if ok:
+            notified.add(pid)
+            sent += 1
+            log.info("[tg_approver] Notified proposal %s (%s)", pid[:8], rule)
+
+    if sent > 0:
+        _wm_set(conn, "notified_ids", list(notified))
+
+    return sent
+
+
+def poll_approval_callbacks(conn: sqlite3.Connection) -> int:
+    """Poll Telegram getUpdates，處理 ✅/🚫 callback_query，更新提案狀態。
+
+    Returns:
+        處理的 callback 數量
+    """
+    from openclaw.tg_notify import send_message  # lazy import
+
+    tok = _token()
+    if not tok:
+        return 0
+
+    offset = int(_wm_get(conn, "update_offset") or 0)
+    url = (
+        f"https://api.telegram.org/bot{tok}/getUpdates"
+        f"?offset={offset}&limit=10&timeout=1"
+        f'&allowed_updates=["callback_query"]'
+    )
+
+    try:
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req, timeout=8) as resp:
+            data = json.loads(resp.read())
+    except Exception as e:
+        log.debug("Telegram getUpdates error: %s", e)
+        return 0
+
+    if not data.get("ok"):
+        log.warning("getUpdates not ok: %s", data)
+        return 0
+
+    updates = data.get("result", [])
+    processed = 0
+    new_offset = offset
+
+    for upd in updates:
+        uid = upd["update_id"]
+        new_offset = uid + 1
+        cb = upd.get("callback_query")
+        if not cb:
+            continue
+
+        cb_id = cb["id"]
+        cb_data = cb.get("data", "")
+
+        if ":" not in cb_data:
+            _answer_callback(tok, cb_id, "無效指令")
+            continue
+
+        action, proposal_id = cb_data.split(":", 1)
+        if action == "approve":
+            new_status, reply = "approved", "✅ 已核准"
+        elif action == "reject":
+            new_status, reply = "rejected", "🚫 已拒絕"
+        else:
+            _answer_callback(tok, cb_id, "未知指令")
+            continue
+
+        cur = conn.execute(
+            "SELECT proposal_id, target_rule, proposed_value"
+            " FROM strategy_proposals WHERE proposal_id=?",
+            (proposal_id,),
+        ).fetchone()
+
+        if not cur:
+            _answer_callback(tok, cb_id, "找不到提案")
+            continue
+
+        conn.execute(
+            "UPDATE strategy_proposals SET status=? WHERE proposal_id=?",
+            (new_status, proposal_id),
+        )
+        conn.commit()
+
+        rule = cur["target_rule"]
+        try:
+            pv = json.loads(cur["proposed_value"])
+            symbol = pv.get("symbol", "")
+            sym_display = _fmt_symbol(conn, symbol) if symbol else ""
+        except Exception:
+            sym_display = ""
+
+        confirm = f"{reply} — {rule}"
+        if sym_display:
+            confirm += f"（{sym_display}）"
+        send_message(confirm)
+
+        _answer_callback(tok, cb_id, reply)
+        log.info("[tg_approver] %s proposal %s (%s)", new_status, proposal_id[:8], rule)
+        processed += 1
+
+    if new_offset > offset:
+        _wm_set(conn, "update_offset", new_offset)
+
+    return processed

--- a/src/openclaw/tg_notify.py
+++ b/src/openclaw/tg_notify.py
@@ -20,6 +20,47 @@ log = logging.getLogger(__name__)
 _DEFAULT_CHAT_ID = "1017252031"
 
 
+def send_message_with_buttons(
+    text: str,
+    buttons: list,
+    chat_id: str | None = None,
+) -> bool:
+    """發送帶 inline keyboard 的 Telegram 訊息。
+
+    Args:
+        text:    訊息內容（支援 HTML 格式）
+        buttons: list of rows，每 row 為 list of {"text": "...", "callback_data": "..."}
+        chat_id: 目標 chat；None 時使用環境變數或預設值
+
+    Returns:
+        True = 發送成功；False = 失敗（不拋例外）
+    """
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+    if not token:
+        log.debug("TELEGRAM_BOT_TOKEN 未設定，跳過通知")
+        return False
+
+    target = chat_id or os.environ.get("TELEGRAM_CHAT_ID", _DEFAULT_CHAT_ID)
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = json.dumps({
+        "chat_id": target,
+        "text": text,
+        "parse_mode": "HTML",
+        "reply_markup": {"inline_keyboard": buttons},
+    }).encode()
+
+    try:
+        req = urllib.request.Request(
+            url, data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        urllib.request.urlopen(req, timeout=10)
+        return True
+    except Exception as e:
+        log.warning("Telegram inline 通知失敗: %s", e)
+        return False
+
+
 def send_message(text: str, chat_id: str | None = None) -> bool:
     """發送 Telegram 訊息。
 

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -911,6 +911,18 @@ def run_watcher() -> None:
             except Exception as _rv:
                 log.warning("[reviewer] proposal reviewer error: %s", _rv)
 
+            # ── Telegram 提案通知 + 老闆 inline 核准 ──────────────────────────
+            try:
+                from openclaw.tg_approver import notify_pending_proposals, poll_approval_callbacks
+                n_notify = notify_pending_proposals(conn)
+                if n_notify > 0:
+                    log.info("[tg_approver] Sent %d proposal notifications", n_notify)
+                n_cb = poll_approval_callbacks(conn)
+                if n_cb > 0:
+                    log.info("[tg_approver] Processed %d approval callbacks", n_cb)
+            except Exception as _ta:
+                log.warning("[tg_approver] error: %s", _ta)
+
         except Exception as e:
             log.error("Scan cycle error: %s", e, exc_info=True)
         finally:

--- a/src/tests/test_tg_approver.py
+++ b/src/tests/test_tg_approver.py
@@ -1,0 +1,351 @@
+"""Tests for tg_approver.py."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import types
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openclaw.tg_approver import (
+    _fmt_symbol,
+    _symbol_name,
+    _wm_get,
+    _wm_set,
+    notify_pending_proposals,
+    poll_approval_callbacks,
+)
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS eod_prices (
+            trade_date TEXT NOT NULL,
+            market TEXT NOT NULL DEFAULT 'TWSE',
+            symbol TEXT NOT NULL,
+            name TEXT,
+            close REAL,
+            source_url TEXT NOT NULL DEFAULT '',
+            ingested_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (trade_date, market, symbol)
+        );
+        CREATE TABLE IF NOT EXISTS strategy_proposals (
+            proposal_id   TEXT PRIMARY KEY,
+            generated_by  TEXT,
+            target_rule   TEXT NOT NULL,
+            rule_category TEXT,
+            current_value TEXT,
+            proposed_value TEXT,
+            supporting_evidence TEXT,
+            confidence    REAL DEFAULT 0,
+            requires_human_approval INTEGER DEFAULT 0,
+            status        TEXT NOT NULL DEFAULT 'pending',
+            proposal_json TEXT,
+            created_at    INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS working_memory (
+            wm_id        TEXT PRIMARY KEY,
+            session_date TEXT NOT NULL,
+            scope        TEXT NOT NULL,
+            key          TEXT NOT NULL,
+            value_json   TEXT NOT NULL,
+            importance   REAL NOT NULL DEFAULT 0.5,
+            created_at   INTEGER NOT NULL,
+            updated_at   INTEGER NOT NULL
+        );
+    """)
+    return conn
+
+
+@pytest.fixture
+def conn():
+    c = _make_conn()
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def conn_with_data(conn):
+    """Conn pre-loaded with eod_prices + 2 pending proposals."""
+    conn.execute(
+        "INSERT INTO eod_prices(trade_date, symbol, name, close, market) VALUES(?,?,?,?,?)",
+        ("2026-03-05", "3008", "大立光", 2500.0, "TWSE"),
+    )
+    pid1 = str(uuid.uuid4())
+    pid2 = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO strategy_proposals VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+        (pid1, "concentration_guard", "POSITION_REBALANCE", None, None,
+         json.dumps({"symbol": "3008", "action": "sell", "quantity": 10,
+                     "target_price": 2450.0, "reduce_pct": 0.2}),
+         "超過 40% 集中度上限", 0.85, 1, "pending", "{}", 1772700000000),
+    )
+    conn.execute(
+        "INSERT INTO strategy_proposals VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+        (pid2, "system_health", "SECTOR_FOCUS", None, None,
+         json.dumps({"sector": "電子", "bias": "overweight"}),
+         "電子板塊強勢", 0.7, 1, "pending", "{}", 1772701000000),
+    )
+    conn.commit()
+    return conn, pid1, pid2
+
+
+# ── _symbol_name / _fmt_symbol ────────────────────────────────────────────────
+
+def test_symbol_name_found(conn):
+    conn.execute("INSERT INTO eod_prices VALUES(?,?,?,?,?,?,?)",
+                 ("2026-03-05", "TWSE", "2330", "台積電", 900.0, "", "now"))
+    conn.commit()
+    assert _symbol_name(conn, "2330") == "台積電"
+
+
+def test_symbol_name_not_found(conn):
+    assert _symbol_name(conn, "9999") == "9999"
+
+
+def test_fmt_symbol_with_name(conn):
+    conn.execute("INSERT INTO eod_prices VALUES(?,?,?,?,?,?,?)",
+                 ("2026-03-05", "TWSE", "3008", "大立光", 2500.0, "", "now"))
+    conn.commit()
+    assert _fmt_symbol(conn, "3008") == "3008 大立光"
+
+
+def test_fmt_symbol_no_name(conn):
+    assert _fmt_symbol(conn, "9999") == "9999"
+
+
+def test_fmt_symbol_empty(conn):
+    assert _fmt_symbol(conn, "") == ""
+
+
+# ── _wm_get / _wm_set ─────────────────────────────────────────────────────────
+
+def test_wm_get_missing(conn):
+    assert _wm_get(conn, "nonexistent") is None
+
+
+def test_wm_set_and_get(conn):
+    _wm_set(conn, "test_key", [1, 2, 3])
+    assert _wm_get(conn, "test_key") == [1, 2, 3]
+
+
+def test_wm_set_upsert(conn):
+    _wm_set(conn, "my_key", {"v": 1})
+    _wm_set(conn, "my_key", {"v": 2})
+    assert _wm_get(conn, "my_key") == {"v": 2}
+
+
+# ── notify_pending_proposals ──────────────────────────────────────────────────
+
+def test_notify_no_token(conn_with_data, monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    c, pid1, pid2 = conn_with_data
+    assert notify_pending_proposals(c) == 0
+
+
+def test_notify_sends_for_new_proposals(conn_with_data, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    c, pid1, pid2 = conn_with_data
+
+    with patch("openclaw.tg_notify.send_message_with_buttons", return_value=True) as mock_send:
+        n = notify_pending_proposals(c)
+
+    assert n == 2
+    assert mock_send.call_count == 2
+
+
+def test_notify_skips_already_notified(conn_with_data, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    c, pid1, pid2 = conn_with_data
+
+    # Pre-populate notified IDs
+    _wm_set(c, "notified_ids", [pid1, pid2])
+
+    with patch("openclaw.tg_notify.send_message_with_buttons", return_value=True) as mock_send:
+        n = notify_pending_proposals(c)
+
+    assert n == 0
+    assert mock_send.call_count == 0
+
+
+def test_notify_saves_notified_ids(conn_with_data, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    c, pid1, pid2 = conn_with_data
+
+    with patch("openclaw.tg_notify.send_message_with_buttons", return_value=True):
+        notify_pending_proposals(c)
+
+    saved = _wm_get(c, "notified_ids")
+    assert set(saved) == {pid1, pid2}
+
+
+def test_notify_message_includes_symbol_name(conn_with_data, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    c, pid1, pid2 = conn_with_data
+
+    call_texts = []
+
+    def fake_send(text, buttons, chat_id=None):
+        call_texts.append(text)
+        return True
+
+    with patch("openclaw.tg_notify.send_message_with_buttons", side_effect=fake_send):
+        notify_pending_proposals(c)
+
+    # One of the messages should include "3008 大立光" (POSITION_REBALANCE)
+    assert any("3008 大立光" in t for t in call_texts)
+
+
+def test_notify_skips_strategy_direction(conn, monkeypatch):
+    """STRATEGY_DIRECTION proposals should NOT be notified."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    conn.execute(
+        "INSERT INTO strategy_proposals VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+        (str(uuid.uuid4()), "agents", "STRATEGY_DIRECTION", None, None,
+         json.dumps({"direction": "bullish"}), "reason", 0.8, 0, "pending", "{}", 1772700000000),
+    )
+    conn.commit()
+
+    with patch("openclaw.tg_notify.send_message_with_buttons", return_value=True) as mock_send:
+        n = notify_pending_proposals(conn)
+
+    assert n == 0
+    assert mock_send.call_count == 0
+
+
+# ── poll_approval_callbacks ───────────────────────────────────────────────────
+
+def _make_callback_update(update_id: int, cb_id: str, data: str) -> dict:
+    return {
+        "update_id": update_id,
+        "callback_query": {
+            "id": cb_id,
+            "data": data,
+            "from": {"id": 123, "first_name": "Boss"},
+            "message": {"chat": {"id": 1017252031}},
+        },
+    }
+
+
+def test_poll_no_token(conn, monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    assert poll_approval_callbacks(conn) == 0
+
+
+def test_poll_approve_updates_status(conn_with_data, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    c, pid1, _ = conn_with_data
+
+    updates_resp = {"ok": True, "result": [
+        _make_callback_update(100, "cb1", f"approve:{pid1}"),
+    ]}
+
+    with patch("urllib.request.urlopen") as mock_urlopen, \
+         patch("openclaw.tg_notify.send_message", return_value=True):
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = json.dumps(updates_resp).encode()
+        resp_mock.__enter__ = lambda s: s
+        resp_mock.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = resp_mock
+
+        n = poll_approval_callbacks(c)
+
+    assert n == 1
+    row = c.execute("SELECT status FROM strategy_proposals WHERE proposal_id=?", (pid1,)).fetchone()
+    assert row["status"] == "approved"
+
+
+def test_poll_reject_updates_status(conn_with_data, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    c, _, pid2 = conn_with_data
+
+    updates_resp = {"ok": True, "result": [
+        _make_callback_update(200, "cb2", f"reject:{pid2}"),
+    ]}
+
+    with patch("urllib.request.urlopen") as mock_urlopen, \
+         patch("openclaw.tg_notify.send_message", return_value=True):
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = json.dumps(updates_resp).encode()
+        resp_mock.__enter__ = lambda s: s
+        resp_mock.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = resp_mock
+
+        n = poll_approval_callbacks(c)
+
+    assert n == 1
+    row = c.execute("SELECT status FROM strategy_proposals WHERE proposal_id=?", (pid2,)).fetchone()
+    assert row["status"] == "rejected"
+
+
+def test_poll_advances_offset(conn_with_data, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    c, pid1, _ = conn_with_data
+
+    updates_resp = {"ok": True, "result": [
+        _make_callback_update(300, "cb3", f"approve:{pid1}"),
+    ]}
+
+    with patch("urllib.request.urlopen") as mock_urlopen, \
+         patch("openclaw.tg_notify.send_message", return_value=True):
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = json.dumps(updates_resp).encode()
+        resp_mock.__enter__ = lambda s: s
+        resp_mock.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = resp_mock
+
+        poll_approval_callbacks(c)
+
+    assert _wm_get(c, "update_offset") == 301
+
+
+def test_poll_empty_updates(conn, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    updates_resp = {"ok": True, "result": []}
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = json.dumps(updates_resp).encode()
+        resp_mock.__enter__ = lambda s: s
+        resp_mock.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = resp_mock
+
+        n = poll_approval_callbacks(conn)
+
+    assert n == 0
+
+
+def test_poll_network_error(conn, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+
+    with patch("urllib.request.urlopen", side_effect=Exception("timeout")):
+        n = poll_approval_callbacks(conn)
+
+    assert n == 0
+
+
+def test_poll_unknown_proposal_id(conn, monkeypatch):
+    """Callback referencing non-existent proposal returns 0 processed."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    fake_id = str(uuid.uuid4())
+    updates_resp = {"ok": True, "result": [
+        _make_callback_update(400, "cb4", f"approve:{fake_id}"),
+    ]}
+
+    with patch("urllib.request.urlopen") as mock_urlopen, \
+         patch("openclaw.tg_approver._answer_callback"):
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = json.dumps(updates_resp).encode()
+        resp_mock.__enter__ = lambda s: s
+        resp_mock.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = resp_mock
+
+        n = poll_approval_callbacks(conn)
+
+    assert n == 0


### PR DESCRIPTION
## Summary

- 新增 `tg_approver.py`：POSITION_REBALANCE/SECTOR_FOCUS 提案自動發 Telegram 通知（含 ✅/🚫 inline 按鈕）；老闆按鈕直接核准/拒絕，更新 DB 狀態
- `tg_notify.py` 新增 `send_message_with_buttons()` 支援 inline keyboard
- 全站股票代號顯示名稱：新增 `/api/portfolio/symbol-names` + `symbolNames.js` hook；Portfolio/Strategy/Trades 頁面均改用 `formatSymbol(symbol, names)`
- 修復 Strategy.jsx timestamp 顯示 58145 年的 bug（ms vs seconds 自動偵測）
- 21 新測試（test_tg_approver.py）

## Test Plan
- [x] 1282 Python tests passed
- [x] 36 JS tests passed