### PR TITLE
fix(tg_approver): approve/reject 端對端修復 + 通知發送至群組

### DIFF
--- a/frontend/backend/app/api/strategy.py
+++ b/frontend/backend/app/api/strategy.py
@@ -360,7 +360,7 @@ def approve_proposal_url(proposal_id: str, token: str = Query(...)):
     import os
     if token != os.environ.get("AUTH_TOKEN", ""):
         return HTMLResponse("<h2>❌ 無效 token</h2>", status_code=403)
-    with db.get_conn() as conn:
+    with db.get_conn_rw() as conn:
         row = conn.execute(
             "SELECT proposal_id, target_rule, status FROM strategy_proposals WHERE proposal_id=?",
             (proposal_id,)
@@ -376,7 +376,7 @@ def approve_proposal_url(proposal_id: str, token: str = Query(...)):
         conn.commit()
     try:
         from openclaw.tg_notify import send_message
-        send_message(f"✅ 已核准 — {row['target_rule']}（{proposal_id[:8]}…）")
+        send_message(f"✅ 已核准 — {row['target_rule']}（{proposal_id[:8]}…）", chat_id=os.environ.get("TELEGRAM_CHAT_ID", "-1003772422881"))
     except Exception:
         pass
     return HTMLResponse("<h2>✅ 提案已核准</h2><p>可關閉此頁面。</p>")
@@ -388,7 +388,7 @@ def reject_proposal_url(proposal_id: str, token: str = Query(...)):
     import os
     if token != os.environ.get("AUTH_TOKEN", ""):
         return HTMLResponse("<h2>❌ 無效 token</h2>", status_code=403)
-    with db.get_conn() as conn:
+    with db.get_conn_rw() as conn:
         row = conn.execute(
             "SELECT proposal_id, target_rule, status FROM strategy_proposals WHERE proposal_id=?",
             (proposal_id,)
@@ -404,7 +404,7 @@ def reject_proposal_url(proposal_id: str, token: str = Query(...)):
         conn.commit()
     try:
         from openclaw.tg_notify import send_message
-        send_message(f"🚫 已拒絕 — {row['target_rule']}（{proposal_id[:8]}…）")
+        send_message(f"🚫 已拒絕 — {row['target_rule']}（{proposal_id[:8]}…）", chat_id=os.environ.get("TELEGRAM_CHAT_ID", "-1003772422881"))
     except Exception:
         pass
     return HTMLResponse("<h2>🚫 提案已拒絕</h2><p>可關閉此頁面。</p>")

--- a/frontend/backend/app/middleware/auth.py
+++ b/frontend/backend/app/middleware/auth.py
@@ -77,7 +77,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
         
         if auth_header.startswith("Bearer "):
             provided_token = auth_header[7:]
-        elif path.startswith("/api/stream/"):
+        elif path.startswith("/api/stream/") or "/proposals/" in path:
+            # SSE streams and proposal approve/reject URL buttons use token query param
             provided_token = request.query_params.get("token", "")
 
         if not provided_token:

--- a/frontend/backend/tests/test_portfolio_api.py
+++ b/frontend/backend/tests/test_portfolio_api.py
@@ -98,6 +98,22 @@ def _init_full_db(path):
             metrics_json TEXT
         )
     """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS eod_prices (
+            trade_date TEXT NOT NULL,
+            market TEXT NOT NULL DEFAULT 'TWSE',
+            symbol TEXT NOT NULL,
+            name TEXT,
+            open REAL,
+            high REAL,
+            low REAL,
+            close REAL,
+            volume REAL,
+            source_url TEXT NOT NULL DEFAULT '',
+            ingested_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (trade_date, market, symbol)
+        )
+    """)
     conn.commit()
     conn.close()
 

--- a/src/openclaw/tg_approver.py
+++ b/src/openclaw/tg_approver.py
@@ -26,7 +26,7 @@ import uuid
 
 log = logging.getLogger(__name__)
 
-_DEFAULT_CHAT_ID = "1017252031"
+_DEFAULT_CHAT_ID = "-1003772422881"
 _NOTIFIABLE_RULES = {"POSITION_REBALANCE", "SECTOR_FOCUS"}
 
 
@@ -217,7 +217,7 @@ def notify_pending_proposals(conn: sqlite3.Connection) -> int:
             {"text": "🚫 拒絕", "url": f"{base}/api/strategy/proposals/{pid}/reject?token={auth}"},
         ]]
 
-        ok = send_message_with_buttons("\n".join(lines), buttons)
+        ok = send_message_with_buttons("\n".join(lines), buttons, chat_id=_chat_id())
         if ok:
             notified.add(pid)
             sent += 1

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -94,6 +94,20 @@ def _init_db(p: Path) -> None:
             created_at INTEGER,
             updated_at INTEGER
         );
+        CREATE TABLE IF NOT EXISTS eod_prices (
+            trade_date TEXT NOT NULL,
+            market TEXT NOT NULL DEFAULT 'TWSE',
+            symbol TEXT NOT NULL,
+            name TEXT,
+            open REAL,
+            high REAL,
+            low REAL,
+            close REAL,
+            volume REAL,
+            source_url TEXT NOT NULL DEFAULT '',
+            ingested_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (trade_date, market, symbol)
+        );
     """)
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary

- auth middleware 擴展 `/proposals/` 路徑接受 `token` query param（URL 按鈕瀏覽器請求無 Authorization header）
- approve/reject endpoint 改用 `get_conn_rw()`（`get_conn()` 是 readonly pool，無法執行 UPDATE）
- `tg_approver` 通知改發至群組 `-1003772422881`，並確保 `chat_id` 正確傳入
- `test_portfolio_api` 補建 `eod_prices` 表（positions LEFT JOIN 需要，修復 `test_positions_with_data` 失敗）

Closes #153

## Test plan

- [x] 484 backend tests passed
- [x] 16 tg_approver tests passed
- [x] curl 端對端：approve endpoint 回傳 `✅ 提案已核准`，DB status 更新為 `approved`
- [x] Telegram 群組 `-1003772422881` 收到 4 則提案通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)