### PR TITLE
fix: reports API real_holdings empty + margin data lag

### DIFF
--- a/frontend/backend/.env.example
+++ b/frontend/backend/.env.example
@@ -22,3 +22,9 @@ AUTH_ENABLED=true
 AUTH_TOKEN=change-me-generate-with-command-above
 AUTH_USERNAME=admin
 AUTH_PASSWORD=change-me-strong-password
+
+# ── Investment Report Context API ───────────────────────────────────────────
+# Path to real brokerage holdings JSON file (workspace-finance/portfolio.json)
+# Used by /api/reports/context to populate real_holdings in investment reports.
+# If not set, real_holdings will return an empty list.
+PORTFOLIO_JSON_PATH=/path/to/workspace-finance/portfolio.json

--- a/frontend/backend/run.sh
+++ b/frontend/backend/run.sh
@@ -15,6 +15,14 @@ if [ -f "$OPENCLAW_ENV" ]; then
     set +a
 fi
 
+# Load local backend .env (PORTFOLIO_JSON_PATH, AUTH_TOKEN etc.)
+LOCAL_ENV="$SCRIPT_DIR/.env"
+if [ -f "$LOCAL_ENV" ]; then
+    set -a
+    source "$LOCAL_ENV"
+    set +a
+fi
+
 export PYTHONPATH="${PYTHONPATH:-$REPO/src:$REPO/frontend/backend}"
 export DB_PATH="${DB_PATH:-$REPO/data/sqlite/trades.db}"
 


### PR DESCRIPTION
## Problem

Two bugs caused missing data in `/api/reports/context` (used by OpenClaw investment report agents):

### Bug 1: `real_holdings` always returned empty
`run.sh` only sourced `~/.openclaw/.env` (global API keys) but skipped `frontend/backend/.env`, which contains `PORTFOLIO_JSON_PATH`. Because `PORTFOLIO_JSON_PATH` was never exported to the process environment, `reports.py` fell back to an empty string path and silently returned `[]`.

### Bug 2: `margin_balance` all null
`eod_margin_data` was one day behind `eod_institution_flows` (only had data up to 2026-03-05 vs 2026-03-06). The LEFT JOIN in `_get_institution_summary` therefore returned `null` for every symbol's `margin_balance` and `short_balance`.

## Fix

| File | Change |
|------|--------|
| `frontend/backend/run.sh` | Added `source $SCRIPT_DIR/.env` block after the global `.env` load |
| `frontend/backend/.env.example` | Documented `PORTFOLIO_JSON_PATH` variable |

The margin data gap was fixed by running `eod_ingest --trade-date 2026-03-06` (backfilled 1,251 rows).

## Verification

After restart, `GET /api/reports/context?type=evening` returns:
- ✅ `real_holdings`: 11 entries (was 0)
- ✅ `institution_chips._trade_date`: 2026-03-06
- ✅ `margin_balance`: no nulls (was all null)