### PR TITLE
docs: adopt issue-first GitHub workflow and add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-task.md
+++ b/.github/ISSUE_TEMPLATE/feature-task.md
@@ -1,0 +1,41 @@
+---
+name: Feature or Task
+about: Track implementation work using the issue-first workflow
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+
+Describe the work in one short paragraph.
+
+## Why
+
+- What problem does this solve?
+- Why now?
+
+## Scope
+
+- In scope:
+- Out of scope:
+
+## Acceptance Criteria
+
+- [ ] Behavior is implemented
+- [ ] Tests are added or updated
+- [ ] Docs / runbook updates are included if needed
+- [ ] PR link is added back to this issue
+
+## Implementation Notes
+
+- Branch name suggestion: `codex/<short-topic>`
+- Status: set label `in-progress` when work starts
+
+## Validation
+
+- Commands to run:
+
+## PR
+
+- PR: 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+- 
+
+## Related Issue
+
+- Closes #
+
+## Testing
+
+- [ ] Tests run locally
+- [ ] Not run (explain why)
+
+Commands:
+
+```bash
+```
+
+## Risk
+
+- 
+
+## Docs / Ops Impact
+
+- [ ] No doc changes needed
+- [ ] `AGENTS.md` updated
+- [ ] `progress.md` high-level status updated
+- [ ] Runbook / operator notes updated
+
+## Issue Linkback
+
+- [ ] PR link added back to the related issue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,23 @@
 **分支策略（Branching）**：
 - `main` 是目前 **唯一運行中且活躍的主線（sole active line）**。所有其他的 `codex/*` 實驗分支已經被合併或刪除，請直接對 `main` 操作。
 
+### GitHub Issue / PR Workflow Policy
+
+從 2026-03-08 起，GitHub Issues 與 PR 是**唯一正式**的開發任務追蹤機制；`progress.md` 只保留高階 handoff / 狀態摘要，不再作為 detailed backlog source of truth。
+
+**預設流程**：
+1. 先檢查 GitHub 是否已有對應 issue。
+2. 若是新工作，先建立 issue，再標記為 `in-progress`。
+3. 從 `main` 切出開發分支（建議 `codex/<short-topic>`）。
+4. 完成實作、測試、push、建立 PR。
+5. 將 PR 連結回填到 issue；issue 與 PR 必須互相可追溯。
+
+**執行規則**：
+- 不要直接用 `progress.md` 新增/維護細項 checklist 來取代 GitHub issue。
+- 任何 meaningful code/doc change 都應該能對應到一張 issue 或既有 PR。
+- 若 issue 不存在，先建 issue，再開始做事。
+- PR 說明必須至少包含：scope、tests、risk、related issue。
+
 ---
 
 ## 二、系統安全模型

--- a/doc/plans/2026-03-08-github-issue-pr-workflow-playbook.md
+++ b/doc/plans/2026-03-08-github-issue-pr-workflow-playbook.md
@@ -1,0 +1,278 @@
+# GitHub Issue + PR Workflow Playbook
+
+## Purpose
+
+Use GitHub Issues and Pull Requests as the primary development management system.
+Do not use ad hoc local files as the source of truth for detailed task tracking.
+
+This playbook is designed for:
+- human developers
+- AI coding agents
+- multi-agent / multi-branch parallel execution
+
+## Core Principle
+
+**Issue = task record**
+
+**Branch = implementation workspace**
+
+**PR = delivery and review record**
+
+**Main = only stable integration line**
+
+## Why This Works Better Than Local Progress Files
+
+Problems with local progress files:
+- easy to drift from real code state
+- no enforced status lifecycle
+- weak traceability between task, code, review, and tests
+- easy for multiple AI sessions to overwrite or misread status
+- hard to audit who changed what and why
+
+Benefits of GitHub-native workflow:
+- each task has a durable ID
+- issue, branch, commit, PR, review, and CI are linkable
+- open vs in-progress vs done is visible
+- easier to parallelize work safely
+- better audit trail for later debugging and handoff
+
+## Standard Workflow
+
+### 1. Check for an Existing Issue
+
+Before starting work:
+- search GitHub issues
+- do not start coding if the work is already tracked
+- if an existing issue matches, use that issue
+
+### 2. Create an Issue for New Work
+
+If no issue exists:
+- create a new issue first
+- define scope, acceptance criteria, risks, and validation
+- apply labels
+
+Recommended labels:
+- `backend`
+- `frontend`
+- `ops`
+- `documentation`
+- `process`
+- `enhancement`
+- `bug`
+- `in-progress`
+
+### 3. Mark the Issue In Progress
+
+When work actually starts:
+- add `in-progress`
+- optionally assign the developer / owner
+- leave a short comment if needed:
+  - branch name
+  - intended scope
+  - dependencies or blockers
+
+### 4. Create a Dedicated Branch From Main
+
+Rules:
+- branch from latest `main`
+- one issue per branch whenever possible
+- do not mix unrelated work
+
+Suggested naming:
+- `codex/<short-topic>`
+- `fix/<short-topic>`
+- `feat/<short-topic>`
+
+Examples:
+- `codex/pm-review-history-api`
+- `codex/dashboard-stress-test`
+- `fix/reports-context-auth`
+
+### 5. Implement and Test
+
+While working:
+- keep scope aligned with the issue
+- update tests with the code change
+- avoid unrelated cleanup unless explicitly included in scope
+- do not silently expand work beyond the issue
+
+Minimum expectations:
+- code change
+- test evidence or explicit reason tests were not run
+- docs/runbook updates if behavior changed
+
+### 6. Push and Open a PR
+
+PR must include:
+- summary
+- related issue
+- tests run
+- risks / rollout notes
+- operational or documentation impact
+
+Recommended pattern:
+- `Closes #<issue>`
+
+This ensures merge automatically closes the issue when appropriate.
+
+### 7. Link the PR Back to the Issue
+
+Every in-progress issue should contain:
+- PR URL
+- current implementation status if useful
+
+This is critical for AI handoff and cross-session continuity.
+
+### 8. Review, Merge, Clean Up
+
+After approval:
+- merge into `main`
+- delete merged branch
+- prune local/remote stale branches
+- remove `in-progress` from issue if not auto-closed
+
+## Roles of Each Artifact
+
+### GitHub Issue
+
+Use for:
+- problem statement
+- scope
+- acceptance criteria
+- priority
+- dependencies
+- execution status
+
+Do not use issue for:
+- storing full patch details
+- long changelog-style code narration
+
+### Branch
+
+Use for:
+- isolated implementation of one task
+
+Do not use branch for:
+- tracking task status
+- long-lived mixed-purpose work
+
+### PR
+
+Use for:
+- implementation summary
+- code review
+- test evidence
+- merge gate
+
+Do not use PR for:
+- replacing issue definition
+- carrying unrelated follow-up tasks
+
+### Local Status File (`progress.md` or equivalent)
+
+Use for:
+- high-level current state
+- handoff summary
+- mainline policy
+- immediate next recommended task
+
+Do not use it for:
+- detailed backlog
+- authoritative completion tracking
+- per-subtask truth
+
+## Recommended Repo Conventions
+
+### Labels
+
+At minimum:
+- `bug`
+- `enhancement`
+- `documentation`
+- `backend`
+- `frontend`
+- `ops`
+- `process`
+- `in-progress`
+
+### Templates
+
+Recommended:
+- issue template for feature/task work
+- PR template with:
+  - summary
+  - related issue
+  - testing
+  - risk
+  - docs/ops impact
+  - issue linkback check
+
+### Mainline Policy
+
+Recommended policy:
+- `main` is the only active integration branch
+- all work starts from `main`
+- merged branches should be deleted
+- stale merged branches should be periodically pruned
+
+## AI Agent Rules
+
+For AI sessions, enforce these rules:
+
+1. Check GitHub issues before starting work.
+2. If no issue exists, create one before coding.
+3. Mark the issue `in-progress` when implementation begins.
+4. Create a dedicated branch from `main`.
+5. Push changes and open a PR.
+6. Add the PR link back to the issue.
+7. Do not use local progress files as the detailed backlog source of truth.
+8. Only update local handoff files with high-level state, not full task management.
+
+## Example Operating Loop
+
+1. Review open GitHub issues.
+2. Choose one issue.
+3. Add `in-progress`.
+4. Create branch from `main`.
+5. Implement.
+6. Run tests.
+7. Push branch.
+8. Open PR.
+9. Comment PR link on issue.
+10. Merge after review.
+11. Delete merged branch.
+12. Return to step 1.
+
+## Migration Plan for Existing Projects
+
+If a project currently uses a local tracking file:
+
+1. Keep the file, but reduce it to summary/handoff only.
+2. Create GitHub issues for all still-meaningful backlog items.
+3. Add labels and templates.
+4. Update project instructions (`AGENTS.md`, `CONTRIBUTING.md`, runbooks).
+5. Enforce issue-first behavior for all new work.
+6. Periodically prune merged branches.
+
+## Anti-Patterns
+
+Avoid:
+- starting work without an issue
+- one branch covering multiple unrelated tasks
+- PRs with no linked issue
+- local checklist files acting as the true backlog
+- keeping merged branches around indefinitely
+- reopening old stale branches instead of rebasing fresh from `main`
+- AI sessions inventing task state that is not reflected in GitHub
+
+## Minimal Policy You Can Reuse Across Projects
+
+Copy this into any project:
+
+> We use GitHub Issues and PRs as the primary development workflow.
+> Before starting work, check for an existing issue.
+> If none exists, create one and mark it `in-progress` when implementation starts.
+> Create a dedicated branch from `main`, complete the work, run tests, push, and open a PR.
+> Add the PR link back to the issue.
+> Local progress files may be used only for high-level handoff summaries, not as the detailed source of truth.

--- a/doc/plans/2026-03-08-github-issue-pr-workflow-playbook.md
+++ b/doc/plans/2026-03-08-github-issue-pr-workflow-playbook.md
@@ -276,3 +276,69 @@ Copy this into any project:
 > Create a dedicated branch from `main`, complete the work, run tests, push, and open a PR.
 > Add the PR link back to the issue.
 > Local progress files may be used only for high-level handoff summaries, not as the detailed source of truth.
+
+## Reusable Versions
+
+### 1. AI Short Version
+
+Use this in a global AI instruction file or a lightweight project-level rule block:
+
+```md
+We use GitHub Issues and PRs as the primary development workflow.
+
+1. Check for an existing GitHub issue before starting work.
+2. If none exists, create one and mark it `in-progress` when implementation starts.
+3. Create a dedicated branch from `main`.
+4. Complete the work, run tests, push, and open a PR.
+5. Add the PR link back to the issue.
+6. Local progress files may be used only for high-level handoff summaries, not as the detailed source of truth.
+```
+
+### 2. README / CONTRIBUTING Version
+
+Use this in `README.md` or `CONTRIBUTING.md` for human contributors:
+
+```md
+## Development Workflow
+
+We manage development through GitHub Issues and Pull Requests.
+
+- Check for an existing issue before starting work.
+- If the task is new, create an issue first.
+- Mark the issue `in-progress` when implementation begins.
+- Create a dedicated branch from `main`.
+- Keep the branch scoped to that issue.
+- Run the relevant tests before opening a PR.
+- Open a PR and link it to the issue.
+- Add the PR URL back to the issue for traceability.
+
+Local progress files may be used for handoff notes or project status summaries, but they are not the detailed source of truth for task management.
+```
+
+### 3. AGENTS.md Strong Enforcement Version
+
+Use this in repo-level `AGENTS.md` when you want AI agents to follow the workflow strictly:
+
+```md
+## GitHub Issue / PR Workflow Policy
+
+GitHub Issues and PRs are the only official task tracking system for this repository.
+Local progress files may be used for high-level handoff only and must not be treated as the detailed backlog source of truth.
+
+### Required Workflow
+1. Check GitHub for an existing matching issue before starting work.
+2. If no issue exists, create one first.
+3. Mark the issue `in-progress` when implementation begins.
+4. Create a dedicated branch from `main`.
+5. Implement the scoped work.
+6. Run relevant tests.
+7. Push the branch and open a PR.
+8. Add the PR link back to the issue.
+
+### Enforcement Rules
+- Do not start meaningful code or doc work without an issue.
+- Do not track detailed task state only in local markdown files.
+- Do not mix unrelated work in one branch or PR.
+- Every PR must identify its related issue.
+- Every in-progress issue should point to its active PR.
+```

--- a/progress.md
+++ b/progress.md
@@ -4,10 +4,10 @@ Last updated: 2026-03-08 00:20 Asia/Taipei
 
 ## Coordination
 
-- Primary coordination file for parallel AI work.
-- Update this file after every meaningful batch.
+- High-level coordination file for parallel AI work.
 - Keep entries factual: branch, worktree, scope, tests, commit, next step.
-- **Checklist format**: `[x]` = done, `[ ]` = pending. Sub-tasks indented under parent.
+- Detailed task tracking now lives in GitHub Issues and PRs, not in this file.
+- Do not add new detailed checklists here unless the user explicitly asks for a temporary local planning note.
 
 ## Active Branch
 
@@ -17,7 +17,22 @@ Last updated: 2026-03-08 00:20 Asia/Taipei
 - runtime config stash has been dropped (all obsolete)
 - branch audit (2026-03-08): local branches already merged into `main` were deleted from the primary worktree
 - remaining non-merged local branches are legacy snapshots or side experiments; do **not** auto-merge them into `main` without a fresh review/rebase
-- only active PR at audit time: dependabot `#164` (`dependabot/npm_and_yarn/frontend/web/multi-65dc50f05c`)
+- GitHub Issues are now the primary backlog / execution tracker
+
+## Active Backlog (GitHub)
+
+- `#169` Adopt GitHub issue + PR workflow as the primary development process
+- `#167` Workstream I follow-up: verify dashboard throughput and evaluate API polling strategy
+- `#168` Workstream J backend: persist PM reviews in DB and expose history API
+- `#170` Workstream J frontend and CLI: PM review observability, history UI, and trigger hardening
+- `#166` Workstream K: add process liveness and alert threshold monitoring to ops summary
+
+## Current Rule
+
+- Before starting work, check GitHub for an existing issue.
+- New work starts by creating or claiming an issue and marking it `in-progress`.
+- Implementation happens on a dedicated branch from `main`.
+- Every PR must link back to its issue, and every in-progress issue should link to its PR.
 
 ## Completed Checklist
 
@@ -243,43 +258,6 @@ Last updated: 2026-03-08 00:20 Asia/Taipei
 
 ---
 
-## Pending Checklist
-
-### Workstream I: Dashboard Throughput Optimization
-- [ ] **SSE Stream Throttling**
-  - [x] audit `LogTerminal` and `QuotePanel` for high-frequency DOM updates
-  - [x] implement `requestAnimationFrame` throttling for log and quote rendering
-- [ ] **State Update Consolidation**
-  - [x] implement `useReducer` in `PortfolioPage` to avoid cascaded re-renders
-  - [ ] evaluate `TanStack Query` (React Query) for API polling instead of manual `useEffect`
-- [ ] **Stress Testing**
-  - [ ] build `tools/stress_test_sse.py` to emit 200+ events/sec
-  - [ ] verify browser memory usage remains stable during 10-minute soak test
-  - [ ] verify UI lag / interaction responsiveness on low-CPU throttling
-
-### Workstream J: PM Review Persistence & Observability
-- [ ] **Database Schema Upgrade**
-  - [ ] add `pm_reviews` table: `timestamp`, `date`, `approved`, `reason`, `confidence`, `raw_payload`
-  - [ ] add index on `date` for fast historical lookup
-- [ ] **Agent Integration**
-  - [ ] modify `src/openclaw/agents/daily_pm_review.py` to use `DB.get_conn_rw()`
-  - [ ] transition from `daily_pm_state.json` fallback to DB query
-- [ ] **Operator Observability**
-  - [ ] `GET /api/pm/history`: implement paginated review history endpoint
-  - [ ] `System.jsx`: add "Review History" modal or tab with trend visualization (Confidence %)
-- [ ] **CLI Hardening**
-  - [ ] add `--persist` flag to `tools/trigger_pm_review.py`
-  - [ ] add retry logic (exp-backoff) for network-induced review failures
-
-### Workstream K: Sentinel & Health Monitoring V2
-- [ ] **Process Liveness Checks**
-  - [ ] integrate PM2 status check into `ops-summary` (detect if `watcher` is errored/stopped)
-- [ ] **Alert Thresholds**
-  - [ ] implement configurable slack/telegram alerts for persistent high CPU/Disk usage
-
-
----
-
 ## Verified Test Commands
 
 ```bash
@@ -308,14 +286,14 @@ bin/venv/bin/python -m pytest -q \
 cd frontend/web && npm test -- --run && npm run build
 ```
 
-## Handoff Notes (Batch 25)
+## Handoff Notes
 
 - branch: `main` — sole active line
 - 0 open incidents in DB
 - **Workstream G completed**: Simulation-mode reconciliation bypassed by default (`da72c03`).
 - **Workstream H completed**: Frontend React warnings eliminated (`54dfdf5`).
 - **Workstream I partially completed**: rAF throttling and `useReducer` landed (`fc279d5`).
-- next task: complete Workstream I verification (`stress_test_sse.py`, soak test, low-CPU validation) or start Workstream J.
+- next task: pick an open GitHub issue (`#167`, `#168`, `#170`, `#166`) and follow the issue-first / PR-linked workflow.
 - last batch (Batch 25) completed successfully.
 - last batch:
   - `fc279d5` — throttle dashboard SSE updates and consolidate portfolio state
@@ -330,9 +308,12 @@ cd frontend/web && npm test -- --run && npm run build
 
 - do not modify runtime files (`config/system_state.json`) unless the task explicitly requires it
 - do not revert unrelated user changes in the main worktree
-- prefer isolated worktrees for independent streams
-- update this file after each batch:
-  - move `[ ]` → `[x]` for completed items
-  - add commit hash
-  - add test results
-  - note any remaining risk
+- prefer isolated worktrees for independent streams when multiple tasks run in parallel
+- do not use this file as the detailed backlog
+- before coding:
+  - check whether a matching GitHub issue already exists
+  - if not, create one
+  - mark the issue `in-progress`
+  - work on a dedicated branch from `main`
+  - open a PR and add the PR link back to the issue
+- update this file only for high-level status, handoff notes, and branch / workflow policy changes


### PR DESCRIPTION
## Summary
- document GitHub issue + PR as the primary development workflow
- downgrade `progress.md` to high-level handoff/status only
- add issue and PR templates for repeatable execution
- create and seed initial backlog issues for Workstreams I, J, and K

## Related Issue
- Closes #169

## Testing
- [x] Not run (docs/templates only)

## Risk
- low; process/documentation only

## Docs / Ops Impact
- `AGENTS.md` updated
- `progress.md` updated
- GitHub templates added