### PR TITLE
feat: PM review history UI + trigger retry

### DIFF
--- a/frontend/web/src/components/KlineChart.test.jsx
+++ b/frontend/web/src/components/KlineChart.test.jsx
@@ -124,9 +124,11 @@ describe('KlineChart — single candle edge case', () => {
   it('renders correctly with a single candle', async () => {
     authFetch.mockReturnValue(makeOkResponse([upCandle]))
     const { container } = render(<KlineChart symbol="2330" />)
-    await waitFor(() => screen.getByText('K 線圖'))
-    expect(container.querySelector('svg')).toBeTruthy()
-    expect(screen.getByText(/2026-01-02/)).toBeTruthy()
+    await waitFor(() => {
+      expect(screen.getByText('K 線圖')).toBeTruthy()
+      expect(container.querySelector('svg')).toBeTruthy()
+      expect(container.textContent).toContain('2026-01-02')
+    })
   })
 })
 

--- a/frontend/web/src/components/KlineChart.test.jsx
+++ b/frontend/web/src/components/KlineChart.test.jsx
@@ -204,21 +204,21 @@ describe('KlineChart — candle color logic', () => {
   it('up candle (close >= open) uses green', async () => {
     authFetch.mockReturnValue(makeOkResponse([upCandle]))
     const { container } = render(<KlineChart symbol="2330" />)
-    await waitFor(() => screen.getByText('K 線圖'))
-    // Green emerald color: #10b981
-    const rects = Array.from(container.querySelectorAll('rect'))
-    const greenRects = rects.filter(r => r.getAttribute('fill') === '#10b981')
-    expect(greenRects.length).toBeGreaterThan(0)
+    await waitFor(() => {
+      const rects = Array.from(container.querySelectorAll('rect'))
+      const greenRects = rects.filter(r => r.getAttribute('fill') === '#10b981')
+      expect(greenRects.length).toBeGreaterThan(0)
+    })
   })
 
   it('down candle (close < open) uses red', async () => {
     authFetch.mockReturnValue(makeOkResponse([downCandle]))
     const { container } = render(<KlineChart symbol="2330" />)
-    await waitFor(() => screen.getByText('K 線圖'))
-    // Red rose color: #f43f5e
-    const rects = Array.from(container.querySelectorAll('rect'))
-    const redRects = rects.filter(r => r.getAttribute('fill') === '#f43f5e')
-    expect(redRects.length).toBeGreaterThan(0)
+    await waitFor(() => {
+      const rects = Array.from(container.querySelectorAll('rect'))
+      const redRects = rects.filter(r => r.getAttribute('fill') === '#f43f5e')
+      expect(redRects.length).toBeGreaterThan(0)
+    })
   })
 
   it('zero-volume candle renders without crash (min height=1)', async () => {

--- a/frontend/web/src/components/PmReviewHistoryPanel.jsx
+++ b/frontend/web/src/components/PmReviewHistoryPanel.jsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useState, useCallback } from 'react'
+import { History, ChevronDown, ChevronRight, ShieldCheck, ShieldOff, RefreshCw } from 'lucide-react'
+import { fetchPmHistory } from '../lib/pmApi'
+
+const PAGE_SIZE = 10
+
+export default function PmReviewHistoryPanel() {
+  const [reviews, setReviews] = useState([])
+  const [total, setTotal] = useState(0)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [expanded, setExpanded] = useState(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    const { data, pagination } = await fetchPmHistory({ limit: PAGE_SIZE, offset })
+    setReviews(data)
+    setTotal(pagination.total)
+    setLoading(false)
+  }, [offset])
+
+  useEffect(() => { load() }, [load])
+
+  function toggle(id) {
+    setExpanded(prev => (prev === id ? null : id))
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/20 p-5 shadow-panel">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <History className="h-4 w-4 text-violet-400" />
+          <span className="text-sm font-semibold text-slate-200">PM 審核歷史</span>
+          <span className="text-xs text-slate-500">({total} 筆)</span>
+        </div>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-800 hover:text-slate-200"
+          title="重新整理"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
+
+      {loading && reviews.length === 0 ? (
+        <div className="text-xs text-slate-500">讀取中…</div>
+      ) : reviews.length === 0 ? (
+        <div className="text-xs text-slate-500">尚無審核紀錄</div>
+      ) : (
+        <div className="space-y-2">
+          {reviews.map(r => {
+            const isExpanded = expanded === r.review_id
+            const approved = !!r.approved
+            const ts = r.reviewed_at
+              ? new Date(r.reviewed_at).toLocaleString('zh-TW', { hour12: false })
+              : ''
+            const consensus = tryParseJson(r.consensus_points)
+            const divergence = tryParseJson(r.divergence_points)
+
+            return (
+              <div
+                key={r.review_id}
+                className="rounded-xl border border-slate-800/60 bg-slate-900/40"
+              >
+                <button
+                  onClick={() => toggle(r.review_id)}
+                  className="flex w-full items-center gap-3 px-4 py-2.5 text-left"
+                >
+                  {isExpanded
+                    ? <ChevronDown className="h-3.5 w-3.5 text-slate-500 flex-shrink-0" />
+                    : <ChevronRight className="h-3.5 w-3.5 text-slate-500 flex-shrink-0" />}
+                  {approved
+                    ? <ShieldCheck className="h-4 w-4 text-emerald-400 flex-shrink-0" />
+                    : <ShieldOff className="h-4 w-4 text-rose-400 flex-shrink-0" />}
+                  <span className="text-xs font-medium text-slate-300">{r.review_date}</span>
+                  <span className={`text-xs ${approved ? 'text-emerald-400' : 'text-rose-400'}`}>
+                    {approved ? '授權' : '封鎖'}
+                  </span>
+                  <span className="text-xs text-slate-500">
+                    信心 {((r.confidence || 0) * 100).toFixed(0)}%
+                  </span>
+                  <span className="ml-auto text-xs text-slate-600">
+                    {r.source === 'manual' ? '人工' : r.source === 'llm' ? 'LLM' : r.source}
+                  </span>
+                </button>
+
+                {isExpanded && (
+                  <div className="border-t border-slate-800/40 px-4 py-3 space-y-2">
+                    {r.reason && (
+                      <div className="text-xs text-slate-400">
+                        <span className="text-slate-500">理由：</span>{r.reason}
+                      </div>
+                    )}
+                    {r.recommended_action && (
+                      <div className="text-xs text-slate-400">
+                        <span className="text-slate-500">建議：</span>{r.recommended_action}
+                      </div>
+                    )}
+                    {(r.bull_case || r.bear_case || r.neutral_case) && (
+                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 pt-1">
+                        {r.bull_case && (
+                          <div>
+                            <div className="text-xs font-medium text-emerald-400">多方</div>
+                            <div className="mt-0.5 text-xs text-slate-500 line-clamp-3">{r.bull_case}</div>
+                          </div>
+                        )}
+                        {r.bear_case && (
+                          <div>
+                            <div className="text-xs font-medium text-rose-400">空方</div>
+                            <div className="mt-0.5 text-xs text-slate-500 line-clamp-3">{r.bear_case}</div>
+                          </div>
+                        )}
+                        {r.neutral_case && (
+                          <div>
+                            <div className="text-xs font-medium text-slate-400">中立</div>
+                            <div className="mt-0.5 text-xs text-slate-500 line-clamp-3">{r.neutral_case}</div>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                    {consensus.length > 0 && (
+                      <div className="text-xs">
+                        <span className="text-slate-500">共識：</span>
+                        <span className="text-slate-400">{consensus.join('、')}</span>
+                      </div>
+                    )}
+                    {divergence.length > 0 && (
+                      <div className="text-xs">
+                        <span className="text-slate-500">分歧：</span>
+                        <span className="text-slate-400">{divergence.join('、')}</span>
+                      </div>
+                    )}
+                    {ts && (
+                      <div className="text-xs text-slate-600">審核時間：{ts}</div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {total > PAGE_SIZE && (
+        <div className="mt-3 flex items-center justify-between text-xs">
+          <button
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            disabled={offset === 0}
+            className="rounded px-2 py-1 text-slate-400 hover:bg-slate-800 disabled:opacity-30"
+          >
+            ← 上一頁
+          </button>
+          <span className="text-slate-500">{currentPage} / {totalPages}</span>
+          <button
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+            disabled={offset + PAGE_SIZE >= total}
+            className="rounded px-2 py-1 text-slate-400 hover:bg-slate-800 disabled:opacity-30"
+          >
+            下一頁 →
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function tryParseJson(val) {
+  if (Array.isArray(val)) return val
+  if (typeof val === 'string') {
+    try { return JSON.parse(val) } catch { return [] }
+  }
+  return []
+}

--- a/frontend/web/src/components/PmReviewHistoryPanel.test.jsx
+++ b/frontend/web/src/components/PmReviewHistoryPanel.test.jsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+
+const mockFetchPmHistory = vi.fn()
+
+vi.mock('../lib/pmApi', () => ({
+  fetchPmHistory: (...args) => mockFetchPmHistory(...args),
+}))
+
+import PmReviewHistoryPanel from './PmReviewHistoryPanel'
+
+describe('PmReviewHistoryPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders empty state when no reviews', async () => {
+    mockFetchPmHistory.mockResolvedValue({
+      data: [],
+      pagination: { total: 0, limit: 10, offset: 0 },
+    })
+    render(<PmReviewHistoryPanel />)
+    await waitFor(() => {
+      expect(screen.getByText('尚無審核紀錄')).toBeInTheDocument()
+    })
+  })
+
+  it('renders review records', async () => {
+    mockFetchPmHistory.mockResolvedValue({
+      data: [
+        {
+          review_id: 'pm_2026-03-09_abc',
+          review_date: '2026-03-09',
+          approved: 1,
+          confidence: 0.85,
+          source: 'llm',
+          reason: 'Market bullish',
+          recommended_action: 'BUY',
+          bull_case: 'Strong earnings',
+          bear_case: 'Inflation risk',
+          neutral_case: '',
+          consensus_points: '["Growth"]',
+          divergence_points: '[]',
+          reviewed_at: 1741478400000,
+        },
+      ],
+      pagination: { total: 1, limit: 10, offset: 0 },
+    })
+
+    render(<PmReviewHistoryPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByText('2026-03-09')).toBeInTheDocument()
+    })
+    expect(screen.getByText('授權')).toBeInTheDocument()
+    expect(screen.getByText('LLM')).toBeInTheDocument()
+    expect(screen.getByText('(1 筆)')).toBeInTheDocument()
+  })
+
+  it('expands review to show details', async () => {
+    mockFetchPmHistory.mockResolvedValue({
+      data: [
+        {
+          review_id: 'pm_2026-03-09_abc',
+          review_date: '2026-03-09',
+          approved: 0,
+          confidence: 0.4,
+          source: 'manual',
+          reason: '市場不穩定',
+          recommended_action: '觀望',
+          bull_case: '',
+          bear_case: '下行風險',
+          neutral_case: '',
+          consensus_points: '[]',
+          divergence_points: '[]',
+          reviewed_at: 1741478400000,
+        },
+      ],
+      pagination: { total: 1, limit: 10, offset: 0 },
+    })
+
+    render(<PmReviewHistoryPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByText('2026-03-09')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('2026-03-09').closest('button'))
+
+    expect(screen.getByText('市場不穩定', { exact: false })).toBeInTheDocument()
+    expect(screen.getByText('下行風險')).toBeInTheDocument()
+  })
+
+  it('shows loading text initially', () => {
+    mockFetchPmHistory.mockReturnValue(new Promise(() => {}))
+    render(<PmReviewHistoryPanel />)
+    expect(screen.getByText('讀取中…')).toBeInTheDocument()
+  })
+
+  it('renders rejected review with correct styling', async () => {
+    mockFetchPmHistory.mockResolvedValue({
+      data: [
+        {
+          review_id: 'pm_2026-03-08_def',
+          review_date: '2026-03-08',
+          approved: 0,
+          confidence: 0.3,
+          source: 'llm',
+          reason: 'Bear outlook',
+          reviewed_at: 1741392000000,
+        },
+      ],
+      pagination: { total: 1, limit: 10, offset: 0 },
+    })
+
+    render(<PmReviewHistoryPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByText('封鎖')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/web/src/lib/pmApi.js
+++ b/frontend/web/src/lib/pmApi.js
@@ -40,3 +40,16 @@ export async function pmTriggerReview() {
   if (!res.ok) throw new Error('AI 審核失敗')
   return (await res.json()).data
 }
+
+export async function fetchPmHistory({ limit = 30, offset = 0 } = {}) {
+  try {
+    const res = await authFetch(
+      `${getApiBase()}/api/pm/history?limit=${limit}&offset=${offset}`
+    )
+    if (res.ok) {
+      const body = await res.json()
+      return { data: body.data || [], pagination: body.pagination || { total: 0, limit, offset } }
+    }
+  } catch { /* ignore */ }
+  return { data: [], pagination: { total: 0, limit, offset } }
+}

--- a/frontend/web/src/pages/System.jsx
+++ b/frontend/web/src/pages/System.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ControlPanel from '../components/ControlPanel'
+import PmReviewHistoryPanel from '../components/PmReviewHistoryPanel'
 import LogTerminal from '../components/LogTerminal'
 import { useSearchParams } from 'react-router-dom'
 import {
@@ -783,6 +784,7 @@ export default function SystemPage() {
         {/* 左欄：操作控制 + 事件時間軸 */}
         <div className="space-y-6">
           <ControlPanel />
+          <PmReviewHistoryPanel />
           <OperatorSnapshotPanel
             quarantineStatus={quarantineStatus}
             quarantinePlan={quarantinePlan}

--- a/frontend/web/src/pages/System.test.jsx
+++ b/frontend/web/src/pages/System.test.jsx
@@ -33,6 +33,10 @@ vi.mock('../components/ControlPanel', () => ({
   default: () => <div>ControlPanel Mock</div>,
 }))
 
+vi.mock('../components/PmReviewHistoryPanel', () => ({
+  default: () => <div>PmReviewHistoryPanel Mock</div>,
+}))
+
 vi.mock('../components/LogTerminal', () => ({
   default: () => <div>LogTerminal Mock</div>,
 }))

--- a/tools/trigger_pm_review.py
+++ b/tools/trigger_pm_review.py
@@ -45,6 +45,9 @@ _ssl_ctx.check_hostname = False
 _ssl_ctx.verify_mode = ssl.CERT_NONE
 
 
+_RETRY_WAITS = [5, 15, 30]  # seconds between retries
+
+
 def call_pm_review() -> dict:
     url = f"{API_BASE}/api/pm/review"
     req = urllib.request.Request(
@@ -60,10 +63,26 @@ def call_pm_review() -> dict:
         return json.loads(resp.read().decode())
 
 
+def call_with_retry() -> dict:
+    """Call PM review API with exponential backoff on network/server errors."""
+    import time
+    last_exc = None
+    for attempt, wait in enumerate([0] + _RETRY_WAITS, start=1):
+        if wait:
+            print(f"[PM Review] 重試 {attempt}/{len(_RETRY_WAITS) + 1}，等待 {wait}s…")
+            time.sleep(wait)
+        try:
+            return call_pm_review()
+        except Exception as exc:
+            last_exc = exc
+            print(f"[PM Review] 第 {attempt} 次失敗：{exc}", file=sys.stderr)
+    raise last_exc  # type: ignore[misc]
+
+
 if __name__ == "__main__":
     print(f"[PM Review] 呼叫 {API_BASE}/api/pm/review ...")
     try:
-        result = call_pm_review()
+        result = call_with_retry()
         data = result.get("data", {})
         approved = data.get("approved", False)
         reason   = data.get("reason", "")
@@ -73,5 +92,5 @@ if __name__ == "__main__":
         print(f"[PM Review] {status} | 信心 {conf:.0%} | {reason} ({source})")
         sys.exit(0)
     except Exception as e:
-        print(f"[PM Review] 錯誤：{e}", file=sys.stderr)
+        print(f"[PM Review] 所有重試失敗：{e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- Add `PmReviewHistoryPanel` component — expandable list with pagination, integrated into System page
- Add `fetchPmHistory()` API function in `pmApi.js`
- Add retry/backoff (3 retries: 5s/15s/30s) to `tools/trigger_pm_review.py`
- Fix KlineChart.test.jsx CI flake (date text assertion timing issue)

## Dependencies
- Backend persistence API from #168 (PR #172) — UI gracefully shows "尚無審核紀錄" until merged

## Test plan
- [x] 5 new PmReviewHistoryPanel tests (empty, records, expand, loading, rejected)
- [x] System.test.jsx updated with mock
- [x] All 129 frontend tests pass
- [x] All 295 backend tests pass
- [ ] Visual verification: System page shows PM 審核歷史 panel

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)