### PR TITLE
fix(api): fallback to EOD close when current_price is NULL

### DIFF
--- a/frontend/backend/app/api/portfolio.py
+++ b/frontend/backend/app/api/portfolio.py
@@ -72,12 +72,14 @@ def portfolio_positions(simulation: Optional[bool] = None):
             rows = conn.execute(
                 "SELECT p.symbol, p.quantity, p.avg_price, p.current_price, "
                 "p.unrealized_pnl, p.chip_health_score, p.sector, "
-                "e.name AS stock_name "
+                "e.name AS stock_name, e.close AS eod_close "
                 "FROM positions p "
-                "LEFT JOIN (SELECT symbol, name FROM eod_prices "
-                "           WHERE name IS NOT NULL "
-                "           GROUP BY symbol HAVING trade_date=MAX(trade_date)) e "
-                "ON p.symbol = e.symbol "
+                "LEFT JOIN ("
+                "  SELECT ep.symbol, ep.name, ep.close "
+                "  FROM eod_prices ep "
+                "  JOIN (SELECT symbol, MAX(trade_date) AS trade_date FROM eod_prices GROUP BY symbol) latest "
+                "    ON ep.symbol = latest.symbol AND ep.trade_date = latest.trade_date"
+                ") e ON p.symbol = e.symbol "
                 "WHERE p.quantity > 0 ORDER BY p.symbol"
             ).fetchall()
         if rows:
@@ -88,8 +90,24 @@ def portfolio_positions(simulation: Optional[bool] = None):
                     "name": r["stock_name"] if r["stock_name"] and r["stock_name"] != r["symbol"] else None,
                     "qty": int(r["quantity"]),
                     "avg_price": float(r["avg_price"] or 0),
-                    "last_price": float(r["current_price"]) if r["current_price"] else None,
-                    "unrealized_pnl": float(r["unrealized_pnl"]) if r["unrealized_pnl"] else None,
+                    "last_price": (
+                        float(r["current_price"])
+                        if r["current_price"] is not None
+                        else (float(r["eod_close"]) if r["eod_close"] is not None else None)
+                    ),
+                    "unrealized_pnl": (
+                        float(r["unrealized_pnl"])
+                        if r["unrealized_pnl"] is not None
+                        else (
+                            round(
+                                ((float(r["current_price"]) if r["current_price"] is not None else float(r["eod_close"])) - float(r["avg_price"] or 0))
+                                * int(r["quantity"]),
+                                2,
+                            )
+                            if (r["current_price"] is not None or r["eod_close"] is not None)
+                            else None
+                        )
+                    ),
                     "chip_health_score": r["chip_health_score"],
                     "sector": r["sector"],
                     "locked": r["symbol"].upper() in locked_set,

--- a/frontend/backend/app/api/reports.py
+++ b/frontend/backend/app/api/reports.py
@@ -56,12 +56,14 @@ def _get_sim_positions(conn: sqlite3.Connection) -> List[Dict[str, Any]]:
         rows = conn.execute(
             "SELECT p.symbol, p.quantity, p.avg_price, p.current_price, "
             "p.unrealized_pnl, p.state, p.high_water_mark, p.entry_trading_day, "
-            "e.name AS stock_name "
+            "e.name AS stock_name, e.close AS eod_close "
             "FROM positions p "
-            "LEFT JOIN (SELECT symbol, name FROM eod_prices "
-            "           WHERE name IS NOT NULL "
-            "           GROUP BY symbol HAVING trade_date=MAX(trade_date)) e "
-            "ON p.symbol = e.symbol "
+            "LEFT JOIN ("
+            "  SELECT ep.symbol, ep.name, ep.close "
+            "  FROM eod_prices ep "
+            "  JOIN (SELECT symbol, MAX(trade_date) AS trade_date FROM eod_prices GROUP BY symbol) latest "
+            "    ON ep.symbol = latest.symbol AND ep.trade_date = latest.trade_date"
+            ") e ON p.symbol = e.symbol "
             "WHERE p.quantity > 0 ORDER BY p.symbol"
         ).fetchall()
         return [
@@ -70,8 +72,24 @@ def _get_sim_positions(conn: sqlite3.Connection) -> List[Dict[str, Any]]:
                 "name": r["stock_name"] or r["symbol"],
                 "quantity": int(r["quantity"]),
                 "avg_price": float(r["avg_price"] or 0),
-                "current_price": float(r["current_price"]) if r["current_price"] else None,
-                "unrealized_pnl": float(r["unrealized_pnl"]) if r["unrealized_pnl"] else None,
+                "current_price": (
+                    float(r["current_price"])
+                    if r["current_price"] is not None
+                    else (float(r["eod_close"]) if r["eod_close"] is not None else None)
+                ),
+                "unrealized_pnl": (
+                    float(r["unrealized_pnl"])
+                    if r["unrealized_pnl"] is not None
+                    else (
+                        round(
+                            ((float(r["current_price"]) if r["current_price"] is not None else float(r["eod_close"])) - float(r["avg_price"] or 0))
+                            * int(r["quantity"]),
+                            2,
+                        )
+                        if (r["current_price"] is not None or r["eod_close"] is not None)
+                        else None
+                    )
+                ),
                 "state": r["state"],
                 "high_water_mark": float(r["high_water_mark"]) if r["high_water_mark"] else None,
                 "entry_trading_day": r["entry_trading_day"],

--- a/frontend/backend/tests/test_portfolio_api.py
+++ b/frontend/backend/tests/test_portfolio_api.py
@@ -211,6 +211,27 @@ class TestPortfolioPositions:
         r = c.get("/api/portfolio/positions")
         assert r.status_code == 401
 
+    def test_positions_fallbacks_to_latest_eod_close_when_current_price_missing(self, full_client):
+        c, db_path = full_client
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO positions VALUES (?,?,?,?,?,?,?)",
+            ("3008", 135, 379.6, None, None, 8, "Optics")
+        )
+        conn.execute(
+            "INSERT INTO eod_prices(trade_date, market, symbol, name, close, source_url) VALUES (?,?,?,?,?,?)",
+            ("2026-03-12", "TWSE", "3008", "大立光", 2390.0, "test")
+        )
+        conn.commit()
+        conn.close()
+
+        r = c.get("/api/portfolio/positions", headers=_AUTH)
+        assert r.status_code == 200
+        positions = r.json()["positions"]
+        p3008 = next(p for p in positions if p["symbol"] == "3008")
+        assert p3008["last_price"] == 2390.0
+        assert p3008["unrealized_pnl"] == 271404.0
+
 
 class TestListTrades:
     def test_trades_returns_ok(self, full_client):

--- a/frontend/backend/tests/test_reports_api.py
+++ b/frontend/backend/tests/test_reports_api.py
@@ -204,6 +204,31 @@ def test_reports_context_tolerates_missing_optional_sources(tmp_path, monkeypatc
     assert payload["simulated_positions"]["positions"][0]["symbol"] == "2330"
 
 
+def test_reports_context_fallbacks_to_latest_eod_close_when_current_price_missing(tmp_path, monkeypatch):
+    with _make_client(tmp_path, monkeypatch) as client:
+        import app.db as db
+
+        with db.get_conn_rw() as conn:
+            conn.execute("DELETE FROM positions")
+            conn.execute(
+                """
+                INSERT INTO positions(symbol, quantity, avg_price, current_price, unrealized_pnl, state, high_water_mark, entry_trading_day)
+                VALUES ('3008', 135, 379.6, NULL, NULL, 'HOLDING', NULL, '2026-03-01')
+                """
+            )
+            conn.execute(
+                "INSERT INTO eod_prices(trade_date, symbol, name, close) VALUES ('2026-03-12', '3008', '大立光', 2390.0)"
+            )
+
+        r = client.get("/api/reports/context?type=morning", headers=_AUTH)
+
+    assert r.status_code == 200
+    payload = r.json()
+    p3008 = next(p for p in payload["simulated_positions"]["positions"] if p["symbol"] == "3008")
+    assert p3008["current_price"] == 2390.0
+    assert p3008["unrealized_pnl"] == 271404.0
+
+
 def test_reports_context_invalid_type_rejected(tmp_path, monkeypatch):
     """Query param type must be morning/evening/weekly — invalid value is rejected."""
     with _make_client(tmp_path, monkeypatch) as client:


### PR DESCRIPTION
## Summary
- When `positions.current_price` is NULL (simulation mode, no real-time quotes), portfolio and reports APIs now fallback to latest `eod_prices.close`
- Computes `unrealized_pnl` from fallback price when original is also NULL
- Fixes unreliable `GROUP BY ... HAVING` subquery → proper `JOIN` on `MAX(trade_date)`

Closes #180

## Test plan
- [x] `test_positions_fallbacks_to_latest_eod_close_when_current_price_missing` (portfolio API)
- [x] `test_reports_context_fallbacks_to_latest_eod_close_when_current_price_missing` (reports API)
- [x] All existing portfolio + reports tests still pass (69 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)