### PR TITLE
refactor: add SignalPipeline facade for unified signal generation (#221)

### DIFF
--- a/src/openclaw/signal_pipeline.py
+++ b/src/openclaw/signal_pipeline.py
@@ -1,0 +1,238 @@
+"""signal_pipeline.py — Unified signal pipeline facade for the AI Trader system.
+
+Consolidates signal generation, caching, and retrieval into a single entry point.
+This is a FACADE: delegates to signal_generator and lm_signal_cache — no logic replication.
+
+Usage:
+    from openclaw.signal_pipeline import SignalPipeline, PipelineSignalResult
+
+    pipeline = SignalPipeline()
+    result = pipeline.compute_signals(conn, symbol="2330", position_avg_price=None,
+                                      high_water_mark=None)
+    # result.direction: "buy" | "sell" | "flat"
+    # result.signals: {"technical": "buy", "llm_score": 0.7, "llm_direction": "bull"}
+    # result.source: "technical" | "llm" | "combined"
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineSignalResult:
+    """Result from SignalPipeline computation.
+
+    Attributes:
+        symbol:    Stock symbol (e.g. "2330")
+        direction: Consolidated direction — "buy", "sell", or "flat"
+        strength:  Confidence proxy in [0.0, 1.0]:
+                     buy  → 1.0, flat → 0.5, sell → 0.0
+        signals:   Raw sub-signal values for transparency/logging
+        source:    Which sub-system produced the final answer:
+                     "technical" | "llm" | "combined"
+    """
+    symbol: str
+    direction: str          # "buy" | "sell" | "flat"
+    strength: float         # 0.0 to 1.0
+    signals: Dict[str, Any]
+    source: str             # "technical" | "llm" | "combined"
+
+    # Convenience map used internally
+    _DIRECTION_TO_STRENGTH: Dict[str, float] = field(
+        default_factory=lambda: {"buy": 1.0, "flat": 0.5, "sell": 0.0},
+        init=False, repr=False, compare=False,
+    )
+
+    @classmethod
+    def from_technical(
+        cls,
+        symbol: str,
+        technical_signal: str,
+        llm_cache: Optional[Dict[str, Any]] = None,
+    ) -> "PipelineSignalResult":
+        """Build a result from a technical signal string."""
+        _map = {"buy": 1.0, "flat": 0.5, "sell": 0.0}
+        signals: Dict[str, Any] = {"technical": technical_signal}
+        if llm_cache:
+            signals["llm_score"] = llm_cache.get("score")
+            signals["llm_direction"] = llm_cache.get("direction")
+            signals["llm_source"] = llm_cache.get("source")
+            source = "combined"
+        else:
+            source = "technical"
+        return cls(
+            symbol=symbol,
+            direction=technical_signal,
+            strength=_map.get(technical_signal, 0.5),
+            signals=signals,
+            source=source,
+        )
+
+
+class SignalPipeline:
+    """Unified entry point for signal generation.
+
+    Acts as a FACADE over:
+    - openclaw.signal_generator  (technical signals: MA cross / RSI / trailing stop)
+    - openclaw.lm_signal_cache   (LLM sentiment signals written by strategy_committee)
+
+    The pipeline does NOT duplicate calculation logic; all computation is
+    delegated to the existing modules.
+
+    Dependency injection is supported for testing:
+        pipeline = SignalPipeline(signal_generator=mock_gen, cache=mock_cache)
+    """
+
+    def __init__(
+        self,
+        signal_generator=None,
+        cache=None,
+    ):
+        """Initialize with optional injected dependencies.
+
+        Args:
+            signal_generator: Module or object with ``compute_signal(conn, symbol,
+                              position_avg_price, high_water_mark)`` and
+                              ``fetch_candles(conn, symbol, days)`` callables.
+                              Defaults to the real openclaw.signal_generator module.
+            cache:            Module or object with ``read_cache_with_fallback(conn,
+                              symbol)`` callable.
+                              Defaults to the real openclaw.lm_signal_cache module.
+        """
+        if signal_generator is None:
+            from openclaw import signal_generator as _sg
+            signal_generator = _sg
+        if cache is None:
+            from openclaw import lm_signal_cache as _lc
+            cache = _lc
+
+        self._generator = signal_generator
+        self._cache = cache
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def compute_signals(
+        self,
+        conn: sqlite3.Connection,
+        symbol: str,
+        position_avg_price: Optional[float],
+        high_water_mark: Optional[float],
+        trailing_pct: Optional[float] = None,
+    ) -> PipelineSignalResult:
+        """Compute technical signals and annotate with LLM cache if available.
+
+        This method:
+        1. Delegates to signal_generator.compute_signal() for the technical signal.
+        2. Looks up lm_signal_cache for supplementary LLM context.
+        3. Returns a PipelineSignalResult (technical signal is authoritative for direction).
+
+        Args:
+            conn:                 SQLite connection (read-only is sufficient).
+            symbol:               Stock symbol, e.g. "2330".
+            position_avg_price:   Average cost of current position, or None if flat.
+            high_water_mark:      Highest price since entry, or None.
+            trailing_pct:         Override default trailing-stop percentage.
+
+        Returns:
+            PipelineSignalResult with direction, strength, and sub-signal details.
+        """
+        # Delegate to the real signal_generator
+        kwargs: Dict[str, Any] = {}
+        if trailing_pct is not None:
+            kwargs["trailing_pct"] = trailing_pct
+
+        technical_signal: str = self._generator.compute_signal(
+            conn,
+            symbol,
+            position_avg_price,
+            high_water_mark,
+            **kwargs,
+        )
+
+        # Enrich with LLM cache (non-blocking — failures → no enrichment)
+        llm_cache: Optional[Dict[str, Any]] = None
+        try:
+            llm_cache = self._cache.read_cache_with_fallback(conn, symbol)
+        except Exception as exc:
+            logger.warning(
+                "SignalPipeline: lm_signal_cache lookup failed for %s: %s",
+                symbol, exc,
+            )
+
+        result = PipelineSignalResult.from_technical(symbol, technical_signal, llm_cache)
+        logger.debug(
+            "SignalPipeline.compute_signals: symbol=%s direction=%s source=%s signals=%s",
+            symbol, result.direction, result.source, result.signals,
+        )
+        return result
+
+    def get_cached_or_compute(
+        self,
+        conn: sqlite3.Connection,
+        symbol: str,
+        candles: Optional[List[Dict[str, Any]]] = None,
+        position_avg_price: Optional[float] = None,
+        high_water_mark: Optional[float] = None,
+    ) -> PipelineSignalResult:
+        """Return from LLM cache if available, otherwise compute technical signals.
+
+        The LLM cache (written by strategy_committee) reflects a longer-horizon
+        market view. When present, this method surfaces it directly; when absent
+        (cache miss), it falls back to compute_signals().
+
+        Args:
+            conn:               SQLite connection.
+            symbol:             Stock symbol.
+            candles:            Unused; kept for API symmetry. Candles are
+                                fetched from DB by signal_generator.
+            position_avg_price: Average cost of current position, or None.
+            high_water_mark:    Highest price since entry, or None.
+
+        Returns:
+            PipelineSignalResult — source will be "llm" on cache hit, or the
+            value from compute_signals() on cache miss.
+        """
+        # Try LLM cache first
+        llm_cache: Optional[Dict[str, Any]] = None
+        try:
+            llm_cache = self._cache.read_cache_with_fallback(conn, symbol)
+        except Exception as exc:
+            logger.warning(
+                "SignalPipeline: lm_signal_cache lookup failed for %s: %s",
+                symbol, exc,
+            )
+
+        if llm_cache is not None:
+            _dir_map = {"bull": "buy", "neutral": "flat", "bear": "sell"}
+            direction = _dir_map.get(llm_cache.get("direction", "neutral"), "flat")
+            _strength_map = {"buy": 1.0, "flat": 0.5, "sell": 0.0}
+            signals: Dict[str, Any] = {
+                "llm_score": llm_cache.get("score"),
+                "llm_direction": llm_cache.get("direction"),
+                "llm_source": llm_cache.get("source"),
+            }
+            logger.debug(
+                "SignalPipeline.get_cached_or_compute: cache hit symbol=%s direction=%s",
+                symbol, direction,
+            )
+            return PipelineSignalResult(
+                symbol=symbol,
+                direction=direction,
+                strength=_strength_map.get(direction, 0.5),
+                signals=signals,
+                source="llm",
+            )
+
+        # Cache miss — fall through to technical computation
+        logger.debug(
+            "SignalPipeline.get_cached_or_compute: cache miss for %s, computing technical",
+            symbol,
+        )
+        return self.compute_signals(conn, symbol, position_avg_price, high_water_mark)

--- a/tests/test_signal_pipeline.py
+++ b/tests/test_signal_pipeline.py
@@ -1,0 +1,281 @@
+"""tests/test_signal_pipeline.py — Unit tests for SignalPipeline facade.
+
+Tests verify:
+1. PipelineSignalResult creation and field values
+2. SignalPipeline delegates compute_signals to signal_generator correctly
+3. SignalPipeline enriches results with lm_signal_cache when available
+4. get_cached_or_compute returns LLM cache on hit and falls back to technical on miss
+5. Cache errors are handled gracefully (non-fatal)
+"""
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openclaw.signal_pipeline import PipelineSignalResult, SignalPipeline
+
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+def _make_conn() -> sqlite3.Connection:
+    """In-memory DB with minimal schema for tests that need a real connection."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("""CREATE TABLE IF NOT EXISTS lm_signal_cache (
+        cache_id TEXT PRIMARY KEY, symbol TEXT, score REAL NOT NULL,
+        source TEXT NOT NULL, direction TEXT, raw_json TEXT,
+        created_at INTEGER NOT NULL, expires_at INTEGER NOT NULL
+    )""")
+    conn.execute("""CREATE TABLE IF NOT EXISTS eod_prices (
+        trade_date TEXT, symbol TEXT, open REAL, high REAL,
+        low REAL, close REAL, volume INTEGER
+    )""")
+    conn.commit()
+    return conn
+
+
+def _mock_generator(signal: str = "flat"):
+    """Return a mock object that simulates openclaw.signal_generator."""
+    gen = MagicMock()
+    gen.compute_signal.return_value = signal
+    gen.fetch_candles.return_value = []
+    return gen
+
+
+def _mock_cache(result: Optional[Dict[str, Any]] = None):
+    """Return a mock object that simulates openclaw.lm_signal_cache."""
+    cache = MagicMock()
+    cache.read_cache_with_fallback.return_value = result
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# 1. PipelineSignalResult
+# ---------------------------------------------------------------------------
+
+class TestPipelineSignalResult:
+    def test_from_technical_buy_no_llm(self):
+        result = PipelineSignalResult.from_technical("2330", "buy")
+        assert result.symbol == "2330"
+        assert result.direction == "buy"
+        assert result.strength == 1.0
+        assert result.signals["technical"] == "buy"
+        assert result.source == "technical"
+
+    def test_from_technical_sell_no_llm(self):
+        result = PipelineSignalResult.from_technical("2317", "sell")
+        assert result.direction == "sell"
+        assert result.strength == 0.0
+        assert result.source == "technical"
+
+    def test_from_technical_flat_no_llm(self):
+        result = PipelineSignalResult.from_technical("2330", "flat")
+        assert result.direction == "flat"
+        assert result.strength == 0.5
+        assert result.source == "technical"
+
+    def test_from_technical_with_llm_cache(self):
+        llm = {"score": 0.8, "direction": "bull", "source": "strategy_committee"}
+        result = PipelineSignalResult.from_technical("2330", "buy", llm_cache=llm)
+        assert result.direction == "buy"
+        assert result.signals["llm_score"] == 0.8
+        assert result.signals["llm_direction"] == "bull"
+        assert result.signals["llm_source"] == "strategy_committee"
+        assert result.source == "combined"
+
+    def test_direct_construction(self):
+        r = PipelineSignalResult(
+            symbol="1301",
+            direction="flat",
+            strength=0.5,
+            signals={"technical": "flat"},
+            source="technical",
+        )
+        assert r.symbol == "1301"
+        assert r.strength == 0.5
+
+
+# ---------------------------------------------------------------------------
+# 2. SignalPipeline.compute_signals — delegates to generator
+# ---------------------------------------------------------------------------
+
+class TestSignalPipelineComputeSignals:
+    def test_delegates_to_generator_buy(self):
+        gen = _mock_generator("buy")
+        cache = _mock_cache(None)
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        result = pipeline.compute_signals(conn, "2330", None, None)
+
+        gen.compute_signal.assert_called_once_with(conn, "2330", None, None)
+        assert result.direction == "buy"
+        assert result.source == "technical"
+
+    def test_delegates_to_generator_sell(self):
+        gen = _mock_generator("sell")
+        cache = _mock_cache(None)
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        result = pipeline.compute_signals(conn, "2454", 1200.0, 1250.0)
+
+        gen.compute_signal.assert_called_once_with(conn, "2454", 1200.0, 1250.0)
+        assert result.direction == "sell"
+
+    def test_trailing_pct_forwarded(self):
+        gen = _mock_generator("flat")
+        cache = _mock_cache(None)
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        pipeline.compute_signals(conn, "2330", 900.0, 950.0, trailing_pct=0.03)
+
+        gen.compute_signal.assert_called_once_with(conn, "2330", 900.0, 950.0, trailing_pct=0.03)
+
+    def test_no_trailing_pct_not_forwarded(self):
+        """When trailing_pct is None, it should NOT be passed as kwarg."""
+        gen = _mock_generator("flat")
+        cache = _mock_cache(None)
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        pipeline.compute_signals(conn, "2330", None, None)
+
+        # trailing_pct should NOT appear in the call kwargs
+        call_kwargs = gen.compute_signal.call_args[1]
+        assert "trailing_pct" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# 3. SignalPipeline cache integration
+# ---------------------------------------------------------------------------
+
+class TestSignalPipelineCacheIntegration:
+    def test_llm_cache_hit_enriches_result(self):
+        gen = _mock_generator("buy")
+        llm_data = {"score": 0.75, "direction": "bull", "source": "strategy_committee"}
+        cache = _mock_cache(llm_data)
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        result = pipeline.compute_signals(conn, "2330", None, None)
+
+        assert result.direction == "buy"
+        assert result.source == "combined"
+        assert result.signals["llm_score"] == 0.75
+        assert result.signals["llm_direction"] == "bull"
+
+    def test_llm_cache_miss_yields_technical_source(self):
+        gen = _mock_generator("flat")
+        cache = _mock_cache(None)
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        result = pipeline.compute_signals(conn, "2330", None, None)
+
+        assert result.source == "technical"
+        assert "llm_score" not in result.signals
+
+    def test_cache_error_is_non_fatal(self):
+        gen = _mock_generator("buy")
+        cache = MagicMock()
+        cache.read_cache_with_fallback.side_effect = Exception("DB error")
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        # Should not raise, should still return a result
+        result = pipeline.compute_signals(conn, "2330", None, None)
+        assert result.direction == "buy"
+        assert result.source == "technical"
+
+
+# ---------------------------------------------------------------------------
+# 4. SignalPipeline.get_cached_or_compute
+# ---------------------------------------------------------------------------
+
+class TestGetCachedOrCompute:
+    def test_returns_llm_direction_on_cache_hit_bull(self):
+        gen = _mock_generator("flat")  # technical says flat
+        llm_data = {"score": 0.9, "direction": "bull", "source": "strategy_committee"}
+        cache = _mock_cache(llm_data)
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        result = pipeline.get_cached_or_compute(conn, "2330")
+
+        assert result.direction == "buy"
+        assert result.source == "llm"
+        # Should NOT have called compute_signals (no generator call)
+        gen.compute_signal.assert_not_called()
+
+    def test_returns_llm_direction_on_cache_hit_bear(self):
+        llm_data = {"score": 0.1, "direction": "bear", "source": "pm_review"}
+        cache = _mock_cache(llm_data)
+        gen = _mock_generator("flat")
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        result = pipeline.get_cached_or_compute(conn, "2317")
+
+        assert result.direction == "sell"
+        assert result.source == "llm"
+        assert result.signals["llm_direction"] == "bear"
+
+    def test_returns_llm_direction_on_cache_hit_neutral(self):
+        llm_data = {"score": 0.5, "direction": "neutral", "source": "pm_review"}
+        cache = _mock_cache(llm_data)
+        gen = _mock_generator("buy")
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        result = pipeline.get_cached_or_compute(conn, "2330")
+
+        assert result.direction == "flat"
+        assert result.source == "llm"
+
+    def test_falls_back_to_technical_on_cache_miss(self):
+        gen = _mock_generator("buy")
+        cache = _mock_cache(None)
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        result = pipeline.get_cached_or_compute(conn, "2330", position_avg_price=None,
+                                                high_water_mark=None)
+
+        assert result.direction == "buy"
+        assert result.source == "technical"
+        gen.compute_signal.assert_called_once()
+
+    def test_cache_error_falls_back_to_technical(self):
+        gen = _mock_generator("sell")
+        cache = MagicMock()
+        cache.read_cache_with_fallback.side_effect = RuntimeError("cache down")
+        pipeline = SignalPipeline(signal_generator=gen, cache=cache)
+        conn = _make_conn()
+
+        result = pipeline.get_cached_or_compute(conn, "2330", position_avg_price=900.0,
+                                                high_water_mark=950.0)
+
+        assert result.direction == "sell"
+        assert result.source == "technical"
+
+
+# ---------------------------------------------------------------------------
+# 5. Default dependency injection (real modules loaded)
+# ---------------------------------------------------------------------------
+
+class TestDefaultDependencyLoading:
+    def test_default_init_loads_real_modules(self):
+        """Ensure SignalPipeline can be instantiated without injected deps."""
+        pipeline = SignalPipeline()
+        # Should have loaded real modules
+        import openclaw.signal_generator as sg
+        import openclaw.lm_signal_cache as lc
+        assert pipeline._generator is sg
+        assert pipeline._cache is lc


### PR DESCRIPTION
## Summary

- Introduces `SignalPipeline` as a **FACADE** over `signal_generator` and `lm_signal_cache` — no calculation logic duplicated
- Adds `PipelineSignalResult` dataclass with `direction`, `strength`, `signals`, and `source` fields for signal transparency
- Updates `ticker_watcher.py` is **not required** — `SignalPipeline` is additive and backward-compatible; existing callers are unaffected
- 18 new unit tests in `tests/test_signal_pipeline.py` cover delegation, LLM cache enrichment, cache miss fallback, and error resilience

## Test plan

- [x] `pytest tests/test_signal_pipeline.py -v` — 18/18 passed
- [x] `pytest -q --ignore=tests/test_property_based.py` — all pre-existing failures confirmed pre-existing (`pydantic_settings` / `hypothesis` not installed in this environment); no regressions introduced

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)