### PR TITLE
test: add broker_reconciliation, correlation_guard, and proposal_executor tests (#218)

### DIFF
--- a/tests/test_v4_30_broker_reconciliation.py
+++ b/tests/test_v4_30_broker_reconciliation.py
@@ -1,0 +1,319 @@
+"""Tests for broker_reconciliation module.
+
+Covers:
+- Partial fill mismatch detection (broker shows different qty than DB)
+- Multi-symbol reconciliation (multiple positions checked)
+- Simulation mode handling (broker empty is expected)
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from openclaw.broker_reconciliation import reconcile_broker_state
+
+
+# ---------------------------------------------------------------------------
+# Helper: build minimal in-memory DB
+# ---------------------------------------------------------------------------
+
+def _make_db(
+    *,
+    positions: list[tuple] | None = None,
+    orders: list[tuple] | None = None,
+) -> sqlite3.Connection:
+    """Return an in-memory SQLite DB with the tables reconciliation needs."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE positions (
+            symbol TEXT PRIMARY KEY,
+            quantity REAL,
+            current_price REAL,
+            state TEXT,
+            avg_price REAL,
+            unrealized_pnl REAL,
+            high_water_mark REAL,
+            entry_trading_day TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE orders (
+            order_id TEXT PRIMARY KEY,
+            broker_order_id TEXT,
+            symbol TEXT,
+            side TEXT,
+            qty REAL,
+            price REAL,
+            status TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE incidents (
+            incident_id TEXT PRIMARY KEY,
+            ts TEXT,
+            severity TEXT,
+            source TEXT,
+            code TEXT,
+            detail_json TEXT,
+            resolved INTEGER DEFAULT 0
+        )
+        """
+    )
+    if positions:
+        conn.executemany(
+            "INSERT INTO positions (symbol, quantity, current_price) VALUES (?,?,?)",
+            positions,
+        )
+    if orders:
+        conn.executemany(
+            "INSERT INTO orders (order_id, broker_order_id, symbol, side, status) VALUES (?,?,?,?,?)",
+            orders,
+        )
+    conn.commit()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Tests: no mismatch (clean)
+# ---------------------------------------------------------------------------
+
+class TestCleanReconciliation:
+    def test_no_positions_no_broker_is_ok(self):
+        conn = _make_db()
+        report = reconcile_broker_state(conn, broker_positions=[])
+        assert report["ok"] is True
+        assert report["mismatch_count"] == 0
+
+    def test_matching_single_position_is_ok(self):
+        conn = _make_db(positions=[("2330", 1000, 500.0)])
+        report = reconcile_broker_state(
+            conn,
+            broker_positions=[{"symbol": "2330", "quantity": 1000, "current_price": 500.0}],
+        )
+        assert report["ok"] is True
+        assert report["mismatch_count"] == 0
+
+    def test_matching_multi_symbol_is_ok(self):
+        conn = _make_db(
+            positions=[("2330", 1000, 500.0), ("0050", 500, 150.0), ("2317", 200, 80.0)]
+        )
+        broker_positions = [
+            {"symbol": "2330", "quantity": 1000, "current_price": 500.0},
+            {"symbol": "0050", "quantity": 500, "current_price": 150.0},
+            {"symbol": "2317", "quantity": 200, "current_price": 80.0},
+        ]
+        report = reconcile_broker_state(conn, broker_positions=broker_positions)
+        assert report["ok"] is True
+        assert report["mismatch_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: partial fill / quantity mismatch
+# ---------------------------------------------------------------------------
+
+class TestQuantityMismatch:
+    def test_partial_fill_mismatch_detected(self):
+        """Broker shows 600 shares; DB has 1000 → quantity_mismatch."""
+        conn = _make_db(positions=[("2330", 1000, 500.0)])
+        report = reconcile_broker_state(
+            conn,
+            broker_positions=[{"symbol": "2330", "quantity": 600, "current_price": 500.0}],
+        )
+        assert report["ok"] is False
+        assert report["mismatch_count"] > 0
+        qty_mismatches = report["mismatches"]["quantity_mismatch"]
+        assert len(qty_mismatches) == 1
+        m = qty_mismatches[0]
+        assert m["symbol"] == "2330"
+        assert m["local"]["quantity"] == 1000
+        assert m["broker"]["quantity"] == 600
+
+    def test_multi_symbol_partial_mismatch(self):
+        """Two symbols; one has quantity mismatch, one is correct."""
+        conn = _make_db(
+            positions=[("2330", 1000, 500.0), ("0050", 500, 150.0)]
+        )
+        broker_positions = [
+            {"symbol": "2330", "quantity": 800, "current_price": 500.0},  # mismatch
+            {"symbol": "0050", "quantity": 500, "current_price": 150.0},  # ok
+        ]
+        report = reconcile_broker_state(conn, broker_positions=broker_positions)
+        assert report["ok"] is False
+        qty_mismatches = report["mismatches"]["quantity_mismatch"]
+        assert any(m["symbol"] == "2330" for m in qty_mismatches)
+        # 0050 should not appear in mismatches
+        assert not any(m["symbol"] == "0050" for m in qty_mismatches)
+
+    def test_report_saved_to_db(self):
+        """After reconciliation, a report row should exist in reconciliation_reports."""
+        conn = _make_db(positions=[("2330", 1000, 500.0)])
+        report = reconcile_broker_state(
+            conn,
+            broker_positions=[{"symbol": "2330", "quantity": 700, "current_price": 500.0}],
+        )
+        rows = conn.execute("SELECT report_id, mismatch_count FROM reconciliation_reports").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == report["report_id"]
+        assert rows[0][1] == report["mismatch_count"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: missing positions
+# ---------------------------------------------------------------------------
+
+class TestMissingPositions:
+    def test_broker_has_position_not_in_db(self):
+        """Broker reports a symbol DB has no record of → missing_local_position."""
+        conn = _make_db()
+        report = reconcile_broker_state(
+            conn,
+            broker_positions=[{"symbol": "2330", "quantity": 500, "current_price": 500.0}],
+        )
+        assert report["ok"] is False
+        assert len(report["mismatches"]["missing_local_position"]) == 1
+        assert report["mismatches"]["missing_local_position"][0]["symbol"] == "2330"
+
+    def test_db_has_position_not_in_broker(self):
+        """DB has a position that broker doesn't report → missing_broker_position."""
+        conn = _make_db(positions=[("2330", 1000, 500.0)])
+        report = reconcile_broker_state(conn, broker_positions=[])
+        assert report["ok"] is False
+        missing = report["mismatches"]["missing_broker_position"]
+        assert any(m["symbol"] == "2330" for m in missing)
+
+
+# ---------------------------------------------------------------------------
+# Tests: multi-symbol reconciliation
+# ---------------------------------------------------------------------------
+
+class TestMultiSymbolReconciliation:
+    def test_all_three_mismatches_detected(self):
+        """Three symbols: qty mismatch, missing local, missing broker."""
+        conn = _make_db(
+            positions=[
+                ("2330", 1000, 500.0),  # will have qty mismatch
+                ("0050", 300, 150.0),   # will be missing from broker
+            ]
+        )
+        broker_positions = [
+            {"symbol": "2330", "quantity": 500, "current_price": 500.0},  # qty mismatch
+            {"symbol": "2317", "quantity": 200, "current_price": 80.0},   # missing local
+        ]
+        report = reconcile_broker_state(conn, broker_positions=broker_positions)
+        assert report["ok"] is False
+        assert report["mismatch_count"] >= 3
+        assert len(report["mismatches"]["quantity_mismatch"]) >= 1
+        assert len(report["mismatches"]["missing_local_position"]) >= 1
+        assert len(report["mismatches"]["missing_broker_position"]) >= 1
+
+    def test_mismatch_count_matches_sum_of_categories(self):
+        """mismatch_count should equal sum of all mismatch category lengths."""
+        conn = _make_db(
+            positions=[("2330", 1000, 500.0), ("0050", 200, 150.0)]
+        )
+        broker_positions = [
+            {"symbol": "2330", "quantity": 999, "current_price": 500.0},
+        ]
+        report = reconcile_broker_state(conn, broker_positions=broker_positions)
+        total = sum(len(v) for v in report["mismatches"].values())
+        assert report["mismatch_count"] == total
+
+
+# ---------------------------------------------------------------------------
+# Tests: simulation mode handling
+# ---------------------------------------------------------------------------
+
+class TestSimulationMode:
+    def test_simulation_mode_broker_empty_suppresses_incident(self):
+        """When resolved_simulation=True and broker is empty, no incident should be created."""
+        conn = _make_db(positions=[("2330", 1000, 500.0)])
+        broker_context = {"resolved_simulation": True, "requested_simulation": True}
+        report = reconcile_broker_state(
+            conn,
+            broker_positions=[],
+            broker_context=broker_context,
+        )
+        # Mismatch should be detected (broker empty while local has position)
+        assert report["mismatch_count"] > 0
+        # Diagnostics should flag MODE_OR_ACCOUNT_MISMATCH_SUSPECTED
+        assert "MODE_OR_ACCOUNT_MISMATCH_SUSPECTED" in report["diagnostics"]["diagnosis_codes"]
+        # resolved_simulation should be True
+        assert report["diagnostics"]["resolved_simulation"] is True
+        # No incident should be inserted (simulation_expected suppresses it)
+        incident_rows = conn.execute(
+            "SELECT * FROM incidents WHERE source='broker_reconciliation'"
+        ).fetchall()
+        assert len(incident_rows) == 0
+
+    def test_non_simulation_mode_mismatch_creates_incident(self):
+        """Real mode with missing broker position should log an incident."""
+        conn = _make_db(positions=[("2330", 1000, 500.0)])
+        broker_context = {"resolved_simulation": False}
+        report = reconcile_broker_state(
+            conn,
+            broker_positions=[],
+            broker_context=broker_context,
+        )
+        assert report["mismatch_count"] > 0
+        # An incident should have been inserted
+        incident_rows = conn.execute(
+            "SELECT code FROM incidents WHERE source='broker_reconciliation'"
+        ).fetchall()
+        assert len(incident_rows) >= 1
+        assert incident_rows[0][0] == "RECONCILIATION_MISMATCH"
+
+    def test_simulation_broker_empty_no_positions_is_ok(self):
+        """Simulation with no local positions and empty broker snapshot is clean."""
+        conn = _make_db()
+        broker_context = {"resolved_simulation": True}
+        report = reconcile_broker_state(
+            conn,
+            broker_positions=[],
+            broker_context=broker_context,
+        )
+        assert report["ok"] is True
+        assert report["mismatch_count"] == 0
+
+    def test_diagnostics_broker_accounts_sorted(self):
+        """broker_accounts in diagnostics should be sorted."""
+        conn = _make_db()
+        broker_context = {"broker_accounts": ["C", "A", "B"]}
+        report = reconcile_broker_state(conn, broker_positions=[], broker_context=broker_context)
+        accounts = report["diagnostics"]["broker_accounts"]
+        assert accounts == sorted(accounts)
+
+
+# ---------------------------------------------------------------------------
+# Tests: open order reconciliation
+# ---------------------------------------------------------------------------
+
+class TestOpenOrderReconciliation:
+    def test_local_order_missing_from_broker_flagged(self):
+        """A submitted local order whose broker_order_id is not in broker snapshot → missing_broker_order."""
+        conn = _make_db(
+            orders=[("ord-001", "BRK-999", "2330", "buy", "submitted")]
+        )
+        # broker_open_orders does not include BRK-999
+        report = reconcile_broker_state(
+            conn,
+            broker_positions=[],
+            broker_open_orders=[{"broker_order_id": "BRK-111"}],
+        )
+        missing_orders = report["mismatches"]["missing_broker_order"]
+        assert any(m["broker_order_id"] == "BRK-999" for m in missing_orders)
+
+    def test_order_with_no_broker_order_id_not_flagged(self):
+        """A local order without a broker_order_id should not be flagged as missing."""
+        conn = _make_db(
+            orders=[("ord-002", "", "0050", "buy", "submitted")]
+        )
+        report = reconcile_broker_state(conn, broker_positions=[], broker_open_orders=[])
+        missing_orders = report["mismatches"]["missing_broker_order"]
+        assert len(missing_orders) == 0

--- a/tests/test_v4_30_correlation_guard.py
+++ b/tests/test_v4_30_correlation_guard.py
@@ -1,0 +1,380 @@
+"""Extended tests for correlation_guard module.
+
+Covers:
+- Zero variance input (all prices identical) — should not crash
+- Single symbol — should skip correlation check
+- Known correlation values with pre-computed expected results
+"""
+from __future__ import annotations
+
+import math
+import sqlite3
+
+import pytest
+
+from openclaw.correlation_guard import (
+    CorrelationGuardDecision,
+    CorrelationGuardPolicy,
+    apply_correlation_guard_to_limits,
+    compute_correlation_matrix,
+    evaluate_correlation_risk,
+    log_correlation_incident,
+    pearson_corr,
+    render_correlation_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests: zero-variance inputs (should not crash)
+# ---------------------------------------------------------------------------
+
+class TestZeroVariance:
+    def test_pearson_corr_zero_variance_xs_returns_zero(self):
+        """If xs has zero variance, pearson_corr must return 0.0, not raise."""
+        xs = [1.0] * 15  # constant
+        ys = [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01, 0.02, -0.01, 0.01, 0.0, -0.01]
+        result = pearson_corr(xs, ys)
+        assert result == 0.0
+
+    def test_pearson_corr_zero_variance_ys_returns_zero(self):
+        """If ys has zero variance, pearson_corr must return 0.0, not raise."""
+        xs = [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01, 0.02, -0.01, 0.01, 0.0, -0.01]
+        ys = [0.0] * 15  # constant
+        result = pearson_corr(xs, ys)
+        assert result == 0.0
+
+    def test_pearson_corr_both_zero_variance_returns_zero(self):
+        """Both sequences constant → correlation undefined → 0.0."""
+        xs = [5.0] * 12
+        ys = [5.0] * 12
+        result = pearson_corr(xs, ys)
+        assert result == 0.0
+
+    def test_compute_correlation_matrix_constant_series_excluded(self):
+        """A constant series has zero std, so it must not produce NaN in the matrix."""
+        returns = {
+            "A": [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01],
+            "B": [0.0] * 10,  # constant — zero variance
+        }
+        matrix = compute_correlation_matrix(returns, window=20, min_points=5)
+        # B is included (has enough points) but correlation with A must be 0.0, not NaN
+        if "B" in matrix and "A" in matrix.get("B", {}):
+            val = matrix["B"]["A"]
+            assert math.isfinite(val)
+            assert val == 0.0
+
+    def test_evaluate_correlation_risk_all_constant_does_not_crash(self):
+        """All symbols with constant prices → evaluate must not raise."""
+        returns = {
+            "A": [0.0] * 15,
+            "B": [0.0] * 15,
+        }
+        weights = {"A": 0.5, "B": 0.5}
+        # Should not raise, even though all variances are zero
+        decision = evaluate_correlation_risk(
+            returns_by_symbol=returns,
+            weights_by_symbol=weights,
+        )
+        assert isinstance(decision.ok, bool)
+        assert math.isfinite(decision.max_pair_abs_corr)
+        assert math.isfinite(decision.weighted_avg_abs_corr)
+
+
+# ---------------------------------------------------------------------------
+# Tests: single symbol
+# ---------------------------------------------------------------------------
+
+class TestSingleSymbol:
+    def test_single_symbol_compute_matrix_returns_diagonal_only(self):
+        """With one symbol, the matrix should contain only the diagonal (self = 1.0)."""
+        returns = {"A": [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01]}
+        matrix = compute_correlation_matrix(returns, window=20, min_points=5)
+        assert "A" in matrix
+        assert matrix["A"]["A"] == 1.0
+        # No off-diagonal entries since there is only one symbol
+        assert len(matrix) == 1
+
+    def test_single_symbol_evaluate_is_ok(self):
+        """Single symbol cannot form pairs → correlation guard passes."""
+        returns = {"A": [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01]}
+        weights = {"A": 1.0}
+        decision = evaluate_correlation_risk(
+            returns_by_symbol=returns,
+            weights_by_symbol=weights,
+        )
+        assert decision.ok is True
+        assert decision.reason_code == "CORR_OK"
+        assert decision.max_pair_abs_corr == 0.0
+        assert decision.weighted_avg_abs_corr == 0.0
+        assert decision.top_pairs == []
+        assert decision.n_symbols <= 1
+
+    def test_single_symbol_no_suggestions(self):
+        """Single symbol → no reduce suggestions."""
+        returns = {"A": [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01]}
+        weights = {"A": 1.0}
+        decision = evaluate_correlation_risk(
+            returns_by_symbol=returns,
+            weights_by_symbol=weights,
+        )
+        assert decision.suggestions == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: known correlation values
+# ---------------------------------------------------------------------------
+
+class TestKnownCorrelationValues:
+    def test_perfectly_positively_correlated(self):
+        """Identical series → correlation == 1.0."""
+        r = [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01]
+        result = pearson_corr(r, r)
+        assert abs(result - 1.0) < 1e-9
+
+    def test_perfectly_negatively_correlated(self):
+        """Negated series → correlation == -1.0."""
+        r = [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01]
+        neg_r = [-x for x in r]
+        result = pearson_corr(r, neg_r)
+        assert abs(result - (-1.0)) < 1e-9
+
+    def test_orthogonal_series_near_zero(self):
+        """Alternating +/- vs constant-offset alternating → correlation should be near ±1 or 0 depending on series."""
+        xs = [1.0, -1.0] * 10  # alternating
+        ys = [-1.0, 1.0] * 10  # opposite alternating
+        result = pearson_corr(xs, ys)
+        assert abs(result - (-1.0)) < 1e-9
+
+    def test_evaluate_perfectly_correlated_pair_breaches(self):
+        """Two identical return series must breach max_pair_abs_corr threshold."""
+        r = [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01]
+        returns = {"A": r, "B": r}
+        weights = {"A": 0.5, "B": 0.5}
+        pol = CorrelationGuardPolicy(
+            window=20, min_points=5, max_pair_abs_corr=0.80, max_weighted_avg_abs_corr=0.90
+        )
+        decision = evaluate_correlation_risk(
+            returns_by_symbol=returns, weights_by_symbol=weights, policy=pol
+        )
+        assert decision.ok is False
+        assert decision.reason_code == "CORR_MAX_PAIR_EXCEEDED"
+        assert decision.max_pair_abs_corr >= 0.99
+
+    def test_evaluate_uncorrelated_pair_passes(self):
+        """Two truly uncorrelated series should pass the default policy."""
+        # Orthogonal pattern: A moves up-down, B constant → corr ~ 0
+        r_a = [0.01, -0.01, 0.02, -0.02, 0.01, -0.01, 0.02, -0.02, 0.01, -0.01,
+               0.01, -0.01, 0.02, -0.02, 0.01]
+        r_b = [0.0] * 15  # constant — zero variance → corr forced to 0
+        returns = {"A": r_a, "B": r_b}
+        weights = {"A": 0.5, "B": 0.5}
+        decision = evaluate_correlation_risk(
+            returns_by_symbol=returns, weights_by_symbol=weights
+        )
+        # max_pair_abs_corr must be 0.0 (constant B → pearson returns 0)
+        assert decision.max_pair_abs_corr == 0.0
+
+    def test_evaluate_top_pairs_sorted_by_abs_corr_desc(self):
+        """top_pairs should be ordered by |correlation| descending."""
+        r_high = [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01]
+        r_low  = [0.01, 0.01, -0.01, 0.01, -0.01, 0.01, -0.01, 0.01, 0.01, -0.01]
+        returns = {"A": r_high, "B": r_high, "C": r_low}  # A-B perfectly corr; A-C partially
+        weights = {"A": 0.4, "B": 0.4, "C": 0.2}
+        decision = evaluate_correlation_risk(
+            returns_by_symbol=returns, weights_by_symbol=weights
+        )
+        if len(decision.top_pairs) >= 2:
+            for i in range(len(decision.top_pairs) - 1):
+                assert abs(decision.top_pairs[i][2]) >= abs(decision.top_pairs[i + 1][2])
+
+    def test_compute_matrix_respects_min_points_filter(self):
+        """Symbols with fewer than min_points valid returns are excluded from the matrix."""
+        returns = {
+            "A": [0.01, -0.02, 0.03, -0.01, 0.02, -0.02, 0.01, 0.00, 0.01, -0.01],  # 10 pts
+            "B": [0.01, -0.02],  # only 2 pts — below min_points=5
+        }
+        matrix = compute_correlation_matrix(returns, window=20, min_points=5)
+        assert "A" in matrix
+        assert "B" not in matrix  # excluded due to insufficient data
+
+    def test_apply_limits_scaling_on_breach(self):
+        """Breached decision must scale down max_gross_exposure and max_symbol_weight."""
+        limits = {"max_gross_exposure": 1.5, "max_symbol_weight": 0.30, "other_param": 42}
+        d = CorrelationGuardDecision(
+            ok=False,
+            reason_code="CORR_MAX_PAIR_EXCEEDED",
+            n_symbols=2,
+            max_pair_abs_corr=0.92,
+            weighted_avg_abs_corr=0.65,
+            top_pairs=[("A", "B", 0.92)],
+            suggestions=["Reduce A"],
+            matrix={"A": {"A": 1.0, "B": 0.92}, "B": {"A": 0.92, "B": 1.0}},
+        )
+        pol = CorrelationGuardPolicy(exposure_scale_on_breach=0.75)
+        out = apply_correlation_guard_to_limits(limits, d, policy=pol)
+        assert out["max_gross_exposure"] == pytest.approx(1.5 * 0.75)
+        assert out["max_symbol_weight"] == pytest.approx(0.30 * 0.75)
+        # Unrelated keys must be preserved unchanged
+        assert out["other_param"] == 42
+        assert out["correlation_guard_ok"] is False
+        assert out["correlation_guard_scale"] == 0.75
+
+    def test_apply_limits_no_scaling_when_ok(self):
+        """When decision is ok, limits must be unchanged."""
+        limits = {"max_gross_exposure": 1.2, "max_symbol_weight": 0.20}
+        d = CorrelationGuardDecision(
+            ok=True,
+            reason_code="CORR_OK",
+            n_symbols=2,
+            max_pair_abs_corr=0.30,
+            weighted_avg_abs_corr=0.20,
+            top_pairs=[],
+            suggestions=[],
+            matrix={},
+        )
+        out = apply_correlation_guard_to_limits(limits, d)
+        assert out["max_gross_exposure"] == 1.2
+        assert out["max_symbol_weight"] == 0.20
+        assert out["correlation_guard_ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: render_correlation_report
+# ---------------------------------------------------------------------------
+
+class TestRenderReport:
+    def test_render_includes_key_fields(self):
+        d = CorrelationGuardDecision(
+            ok=False,
+            reason_code="CORR_MAX_PAIR_EXCEEDED",
+            n_symbols=2,
+            max_pair_abs_corr=0.95,
+            weighted_avg_abs_corr=0.60,
+            top_pairs=[("A", "B", 0.95)],
+            suggestions=["Reduce A"],
+            matrix={},
+        )
+        report_text = render_correlation_report(d)
+        assert "CORR_MAX_PAIR_EXCEEDED" in report_text
+        assert "A" in report_text and "B" in report_text
+        assert "Reduce A" in report_text
+
+    def test_render_ok_decision(self):
+        d = CorrelationGuardDecision(
+            ok=True,
+            reason_code="CORR_OK",
+            n_symbols=1,
+            max_pair_abs_corr=0.0,
+            weighted_avg_abs_corr=0.0,
+            top_pairs=[],
+            suggestions=[],
+            matrix={},
+        )
+        report_text = render_correlation_report(d)
+        assert "CORR_OK" in report_text
+
+
+# ---------------------------------------------------------------------------
+# Tests: log_correlation_incident
+# ---------------------------------------------------------------------------
+
+class TestLogCorrelationIncident:
+    def _make_incidents_db(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(":memory:")
+        conn.execute(
+            """
+            CREATE TABLE incidents (
+                incident_id TEXT PRIMARY KEY,
+                ts TEXT,
+                severity TEXT,
+                source TEXT,
+                code TEXT,
+                detail_json TEXT,
+                resolved INTEGER DEFAULT 0
+            )
+            """
+        )
+        conn.commit()
+        return conn
+
+    def test_ok_decision_does_not_log_incident(self):
+        conn = self._make_incidents_db()
+        d = CorrelationGuardDecision(
+            ok=True,
+            reason_code="CORR_OK",
+            n_symbols=2,
+            max_pair_abs_corr=0.3,
+            weighted_avg_abs_corr=0.2,
+            top_pairs=[],
+            suggestions=[],
+            matrix={},
+        )
+        log_correlation_incident(conn, d)
+        rows = conn.execute("SELECT * FROM incidents").fetchall()
+        assert len(rows) == 0
+
+    def test_breached_decision_logs_incident(self):
+        conn = self._make_incidents_db()
+        d = CorrelationGuardDecision(
+            ok=False,
+            reason_code="CORR_MAX_PAIR_EXCEEDED",
+            n_symbols=2,
+            max_pair_abs_corr=0.92,
+            weighted_avg_abs_corr=0.60,
+            top_pairs=[("A", "B", 0.92)],
+            suggestions=["Reduce A"],
+            matrix={},
+        )
+        log_correlation_incident(conn, d)
+        rows = conn.execute("SELECT source, code FROM incidents").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "correlation_guard"
+        assert rows[0][1] == "CORR_MAX_PAIR_EXCEEDED"
+
+    def test_critical_severity_when_high_corr_and_many_symbols(self):
+        conn = self._make_incidents_db()
+        d = CorrelationGuardDecision(
+            ok=False,
+            reason_code="CORR_MAX_PAIR_EXCEEDED",
+            n_symbols=4,  # >= 3
+            max_pair_abs_corr=0.97,  # >= 0.95
+            weighted_avg_abs_corr=0.70,
+            top_pairs=[("A", "B", 0.97)],
+            suggestions=["Reduce A"],
+            matrix={},
+        )
+        log_correlation_incident(conn, d)
+        row = conn.execute("SELECT severity FROM incidents").fetchone()
+        assert row[0] == "critical"
+
+    def test_warn_severity_when_below_critical_threshold(self):
+        conn = self._make_incidents_db()
+        d = CorrelationGuardDecision(
+            ok=False,
+            reason_code="CORR_WEIGHTED_AVG_EXCEEDED",
+            n_symbols=2,  # < 3
+            max_pair_abs_corr=0.60,  # < 0.95
+            weighted_avg_abs_corr=0.58,
+            top_pairs=[],
+            suggestions=["Diversify"],
+            matrix={},
+        )
+        log_correlation_incident(conn, d)
+        row = conn.execute("SELECT severity FROM incidents").fetchone()
+        assert row[0] == "warn"
+
+    def test_no_incidents_table_does_not_crash(self):
+        """If incidents table doesn't exist, log_correlation_incident must not raise."""
+        conn = sqlite3.connect(":memory:")
+        d = CorrelationGuardDecision(
+            ok=False,
+            reason_code="CORR_MAX_PAIR_EXCEEDED",
+            n_symbols=2,
+            max_pair_abs_corr=0.92,
+            weighted_avg_abs_corr=0.60,
+            top_pairs=[("A", "B", 0.92)],
+            suggestions=["Reduce A"],
+            matrix={},
+        )
+        # Must not raise even without incidents table
+        log_correlation_incident(conn, d)

--- a/tests/test_v4_30_proposal_executor.py
+++ b/tests/test_v4_30_proposal_executor.py
@@ -1,0 +1,435 @@
+"""Tests for proposal_executor module.
+
+Covers:
+- Duplicate SellIntent is handled idempotently
+- Intent marked as executed after successful execution
+- Intent marked as failed after broker error
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from openclaw.proposal_executor import (
+    SellIntent,
+    _build_execution_key,
+    ensure_execution_journal_schema,
+    execute_pending_proposals,
+    mark_intent_executed,
+    mark_intent_executing,
+    mark_intent_failed,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build in-memory DB with required tables
+# ---------------------------------------------------------------------------
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE strategy_proposals (
+            proposal_id TEXT PRIMARY KEY,
+            generated_by TEXT,
+            target_rule TEXT,
+            rule_category TEXT,
+            proposed_value TEXT,
+            supporting_evidence TEXT,
+            confidence REAL,
+            requires_human_approval INTEGER DEFAULT 1,
+            status TEXT NOT NULL DEFAULT 'pending',
+            proposal_json TEXT,
+            created_at INTEGER,
+            decided_at INTEGER,
+            expires_at INTEGER
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE positions (
+            symbol TEXT PRIMARY KEY,
+            quantity REAL,
+            current_price REAL,
+            state TEXT,
+            avg_price REAL,
+            unrealized_pnl REAL,
+            high_water_mark REAL,
+            entry_trading_day TEXT
+        )
+        """
+    )
+    conn.commit()
+    ensure_execution_journal_schema(conn)
+    return conn
+
+
+def _insert_proposal(
+    conn: sqlite3.Connection,
+    *,
+    proposal_id: str,
+    target_rule: str = "POSITION_REBALANCE",
+    status: str = "approved",
+    proposal_json: dict | None = None,
+    expires_at: int | None = None,
+) -> None:
+    if proposal_json is None:
+        proposal_json = {"symbol": "2330", "reduce_pct": 0.5}
+    conn.execute(
+        """
+        INSERT INTO strategy_proposals
+            (proposal_id, generated_by, target_rule, rule_category,
+             status, proposal_json, created_at, expires_at)
+        VALUES (?, 'test', ?, 'entry_parameters', ?, ?, ?, ?)
+        """,
+        (
+            proposal_id,
+            target_rule,
+            status,
+            json.dumps(proposal_json),
+            int(time.time() * 1000),
+            expires_at,
+        ),
+    )
+    conn.commit()
+
+
+def _insert_position(
+    conn: sqlite3.Connection, symbol: str, quantity: float, price: float
+) -> None:
+    conn.execute(
+        "INSERT OR REPLACE INTO positions (symbol, quantity, current_price) VALUES (?,?,?)",
+        (symbol, quantity, price),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests: ensure_execution_journal_schema
+# ---------------------------------------------------------------------------
+
+class TestJournalSchema:
+    def test_schema_creation_is_idempotent(self):
+        """Calling ensure_execution_journal_schema twice must not raise."""
+        conn = sqlite3.connect(":memory:")
+        ensure_execution_journal_schema(conn)
+        ensure_execution_journal_schema(conn)  # second call — must not crash
+
+    def test_journal_table_exists_after_schema_call(self):
+        conn = sqlite3.connect(":memory:")
+        ensure_execution_journal_schema(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='proposal_execution_journal'"
+        ).fetchone()
+        assert row is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: execute_pending_proposals — basic flows
+# ---------------------------------------------------------------------------
+
+class TestExecutePendingProposals:
+    def test_no_proposals_returns_empty(self):
+        conn = _make_db()
+        intents, n_noted = execute_pending_proposals(conn)
+        assert intents == []
+        assert n_noted == 0
+
+    def test_approved_proposal_with_position_returns_intent(self):
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(
+            conn, proposal_id="p-001",
+            proposal_json={"symbol": "2330", "reduce_pct": 0.5}
+        )
+        intents, _ = execute_pending_proposals(conn)
+        assert len(intents) == 1
+        intent = intents[0]
+        assert intent.proposal_id == "p-001"
+        assert intent.symbol == "2330"
+        assert intent.qty == 500  # 1000 * 0.5
+        assert intent.price == 500.0
+
+    def test_approved_proposal_status_becomes_queued(self):
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-002", proposal_json={"symbol": "2330", "reduce_pct": 0.3})
+        execute_pending_proposals(conn)
+        row = conn.execute(
+            "SELECT status FROM strategy_proposals WHERE proposal_id='p-002'"
+        ).fetchone()
+        assert row[0] == "queued"
+
+    def test_proposal_with_no_position_is_skipped(self):
+        """If symbol has no position in DB, proposal should be marked skipped."""
+        conn = _make_db()
+        # No position inserted
+        _insert_proposal(
+            conn, proposal_id="p-003",
+            proposal_json={"symbol": "9999", "reduce_pct": 0.5}
+        )
+        intents, _ = execute_pending_proposals(conn)
+        assert intents == []
+        row = conn.execute(
+            "SELECT status FROM strategy_proposals WHERE proposal_id='p-003'"
+        ).fetchone()
+        assert row[0] == "skipped"
+
+    def test_strategy_direction_proposal_is_noted(self):
+        conn = _make_db()
+        _insert_proposal(
+            conn, proposal_id="p-dir-001",
+            target_rule="STRATEGY_DIRECTION",
+            proposal_json={"direction": "bullish"}
+        )
+        intents, n_noted = execute_pending_proposals(conn)
+        assert intents == []
+        assert n_noted == 1
+        row = conn.execute(
+            "SELECT status FROM strategy_proposals WHERE proposal_id='p-dir-001'"
+        ).fetchone()
+        assert row[0] == "noted"
+
+    def test_expired_proposal_is_not_returned(self):
+        """Proposals with expires_at in the past should be ignored."""
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        past_ts = int(time.time()) - 3600  # 1 hour ago
+        _insert_proposal(
+            conn, proposal_id="p-expired",
+            proposal_json={"symbol": "2330", "reduce_pct": 0.5},
+            expires_at=past_ts,
+        )
+        intents, _ = execute_pending_proposals(conn)
+        assert not any(i.proposal_id == "p-expired" for i in intents)
+
+    def test_zero_price_proposal_is_skipped(self):
+        """If current_price is 0, proposal should be skipped (no valid price)."""
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 0.0)  # price = 0
+        _insert_proposal(conn, proposal_id="p-noprice", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+        intents, _ = execute_pending_proposals(conn)
+        assert not any(i.proposal_id == "p-noprice" for i in intents)
+
+
+# ---------------------------------------------------------------------------
+# Tests: duplicate SellIntent is handled idempotently
+# ---------------------------------------------------------------------------
+
+class TestDuplicateSellIntent:
+    def test_duplicate_call_returns_same_execution_key(self):
+        """Two calls with identical proposal/symbol/qty/price must yield the same execution_key."""
+        key1 = _build_execution_key("p-001", "2330", 500, 500.0)
+        key2 = _build_execution_key("p-001", "2330", 500, 500.0)
+        assert key1 == key2
+
+    def test_different_params_yield_different_key(self):
+        key1 = _build_execution_key("p-001", "2330", 500, 500.0)
+        key2 = _build_execution_key("p-001", "2330", 600, 500.0)  # different qty
+        assert key1 != key2
+
+    def test_execute_pending_proposals_twice_deduplicates(self):
+        """Calling execute_pending_proposals twice for the same queued proposal should not double-add intents."""
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-dedup", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+
+        intents1, _ = execute_pending_proposals(conn)
+        assert len(intents1) == 1
+
+        # Second call — proposal now has status='queued', journal state='prepared'
+        intents2, _ = execute_pending_proposals(conn)
+        # Should still return the intent (queued, not completed)
+        # but the execution_key must be identical across both calls
+        if intents2:
+            assert intents1[0].execution_key == intents2[0].execution_key
+
+    def test_completed_journal_entry_not_returned_again(self):
+        """Once marked executed, the proposal must not appear in subsequent execute calls."""
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-once", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+
+        intents, _ = execute_pending_proposals(conn)
+        assert len(intents) == 1
+        intent = intents[0]
+
+        # Mark as executing then executed
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+        mark_intent_executed(conn, intent.proposal_id, execution_key=intent.execution_key, order_id="ord-123")
+
+        # Second scan — should not return this proposal again
+        intents2, _ = execute_pending_proposals(conn)
+        assert not any(i.proposal_id == "p-once" for i in intents2)
+
+
+# ---------------------------------------------------------------------------
+# Tests: mark_intent_executed
+# ---------------------------------------------------------------------------
+
+class TestMarkIntentExecuted:
+    def test_intent_marked_executed_updates_proposal_status(self):
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-exec-01", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+
+        intents, _ = execute_pending_proposals(conn)
+        intent = intents[0]
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+        mark_intent_executed(conn, intent.proposal_id, execution_key=intent.execution_key, order_id="ord-555")
+
+        # Proposal status must be 'executed'
+        row = conn.execute(
+            "SELECT status FROM strategy_proposals WHERE proposal_id=?", (intent.proposal_id,)
+        ).fetchone()
+        assert row[0] == "executed"
+
+    def test_intent_marked_executed_updates_journal_state(self):
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-exec-02", proposal_json={"symbol": "2330", "reduce_pct": 0.3})
+
+        intents, _ = execute_pending_proposals(conn)
+        intent = intents[0]
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+        mark_intent_executed(conn, intent.proposal_id, execution_key=intent.execution_key, order_id="ord-777")
+
+        journal = conn.execute(
+            "SELECT state, last_order_id FROM proposal_execution_journal WHERE execution_key=?",
+            (intent.execution_key,),
+        ).fetchone()
+        assert journal[0] == "completed"
+        assert journal[1] == "ord-777"
+
+    def test_mark_executed_without_execution_key_updates_by_proposal_id(self):
+        """mark_intent_executed supports lookup by proposal_id alone (no execution_key)."""
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-exec-03", proposal_json={"symbol": "2330", "reduce_pct": 0.4})
+
+        intents, _ = execute_pending_proposals(conn)
+        intent = intents[0]
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+        # No execution_key passed
+        mark_intent_executed(conn, intent.proposal_id, order_id="ord-888")
+
+        row = conn.execute(
+            "SELECT status FROM strategy_proposals WHERE proposal_id=?", (intent.proposal_id,)
+        ).fetchone()
+        assert row[0] == "executed"
+
+    def test_mark_executing_increments_attempt_count(self):
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-exec-04", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+
+        intents, _ = execute_pending_proposals(conn)
+        intent = intents[0]
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+
+        row = conn.execute(
+            "SELECT attempt_count, state FROM proposal_execution_journal WHERE execution_key=?",
+            (intent.execution_key,),
+        ).fetchone()
+        assert row[0] >= 1
+        assert row[1] == "executing"
+
+
+# ---------------------------------------------------------------------------
+# Tests: mark_intent_failed after broker error
+# ---------------------------------------------------------------------------
+
+class TestMarkIntentFailed:
+    def test_intent_marked_failed_updates_proposal_status(self):
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-fail-01", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+
+        intents, _ = execute_pending_proposals(conn)
+        intent = intents[0]
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+        mark_intent_failed(
+            conn, intent.proposal_id, "broker_rejected: insufficient margin",
+            execution_key=intent.execution_key
+        )
+
+        row = conn.execute(
+            "SELECT status FROM strategy_proposals WHERE proposal_id=?", (intent.proposal_id,)
+        ).fetchone()
+        assert row[0] == "failed"
+
+    def test_intent_marked_failed_updates_journal_state(self):
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-fail-02", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+
+        intents, _ = execute_pending_proposals(conn)
+        intent = intents[0]
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+        mark_intent_failed(
+            conn, intent.proposal_id, "network_error",
+            execution_key=intent.execution_key
+        )
+
+        journal = conn.execute(
+            "SELECT state, last_error FROM proposal_execution_journal WHERE execution_key=?",
+            (intent.execution_key,),
+        ).fetchone()
+        assert journal[0] == "failed"
+        assert "network_error" in (journal[1] or "")
+
+    def test_failed_proposal_appends_to_supporting_evidence(self):
+        """mark_intent_failed should append broker_reject reason to supporting_evidence."""
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-fail-03", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+
+        intents, _ = execute_pending_proposals(conn)
+        intent = intents[0]
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+        mark_intent_failed(conn, intent.proposal_id, "order_limit_exceeded", execution_key=intent.execution_key)
+
+        row = conn.execute(
+            "SELECT supporting_evidence FROM strategy_proposals WHERE proposal_id=?",
+            (intent.proposal_id,),
+        ).fetchone()
+        evidence = row[0] or ""
+        assert "order_limit_exceeded" in evidence
+
+    def test_mark_failed_without_execution_key(self):
+        """mark_intent_failed with no execution_key should still update by proposal_id."""
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-fail-04", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+
+        intents, _ = execute_pending_proposals(conn)
+        intent = intents[0]
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+        # No execution_key
+        mark_intent_failed(conn, intent.proposal_id, "timeout")
+
+        row = conn.execute(
+            "SELECT status FROM strategy_proposals WHERE proposal_id=?", (intent.proposal_id,)
+        ).fetchone()
+        assert row[0] == "failed"
+
+    def test_failed_intent_journal_preserved_for_audit(self):
+        """After failure, the journal row should still exist (not deleted)."""
+        conn = _make_db()
+        _insert_position(conn, "2330", 1000, 500.0)
+        _insert_proposal(conn, proposal_id="p-fail-05", proposal_json={"symbol": "2330", "reduce_pct": 0.5})
+
+        intents, _ = execute_pending_proposals(conn)
+        intent = intents[0]
+        mark_intent_executing(conn, intent.proposal_id, intent.execution_key)
+        mark_intent_failed(conn, intent.proposal_id, "broker_down", execution_key=intent.execution_key)
+
+        journal_row = conn.execute(
+            "SELECT execution_key FROM proposal_execution_journal WHERE execution_key=?",
+            (intent.execution_key,),
+        ).fetchone()
+        assert journal_row is not None, "Journal row must be preserved after failure for audit trail"


### PR DESCRIPTION
## Summary

- Add 62 new pytest tests across three new test files covering `broker_reconciliation`, `correlation_guard`, and `proposal_executor`
- All 1947 tests (new + existing) pass with no regressions

## Test coverage added

### `tests/test_v4_30_broker_reconciliation.py` (16 tests)
- Clean reconciliation (no mismatch, single and multi-symbol)
- Partial fill / quantity mismatch detection
- Missing local position and missing broker position detection
- Multi-symbol reconciliation with multiple mismatch categories
- Simulation mode: broker-empty suppresses incident (`resolved_simulation=True`)
- Non-simulation mode: mismatch creates incident in DB
- Open order reconciliation (missing broker order ID flagged)

### `tests/test_v4_30_correlation_guard.py` (24 tests)
- Zero-variance inputs (constant price series) — no crash, returns 0.0
- Single symbol — skips correlation check, returns `ok=True`
- Known Pearson correlation values (perfectly correlated, negated, orthogonal)
- `min_points` filter excludes symbols with insufficient data
- `top_pairs` sorted by |correlation| descending
- `apply_correlation_guard_to_limits` scales down on breach, preserves on ok
- `render_correlation_report` includes key fields
- `log_correlation_incident`: ok skips, breach logs, critical vs warn severity, missing table no-crash

### `tests/test_v4_30_proposal_executor.py` (22 tests)
- `ensure_execution_journal_schema` is idempotent
- `execute_pending_proposals` basic flows: empty, approved with position, no-position skip, STRATEGY_DIRECTION noted, expired skipped, zero-price skipped
- Duplicate `SellIntent`: same params yield same execution key; completed journal entry not returned again
- `mark_intent_executed`: updates proposal status, journal state, supports lookup by proposal_id only
- `mark_intent_executing`: increments attempt_count
- `mark_intent_failed`: updates proposal status, journal state, appends to supporting_evidence, journal row preserved for audit trail

## Test plan

- [x] `pytest tests/test_v4_30_broker_reconciliation.py tests/test_v4_30_correlation_guard.py tests/test_v4_30_proposal_executor.py -v` → 62 passed
- [x] `pytest -q` (full suite) → 1947 passed, 4 warnings

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)