### PR TITLE
refactor(frontend): split PositionDetailDrawer into sub-components

### DIFF
--- a/frontend/web/src/components/PositionDetailDrawer.jsx
+++ b/frontend/web/src/components/PositionDetailDrawer.jsx
@@ -1,142 +1,34 @@
 import React, { useEffect, useState } from 'react'
-import { X, TrendingUp, TrendingDown, Shield, BarChart3, FileText, AlertTriangle, Lock, Unlock, GitBranch, CheckCircle2, XCircle } from 'lucide-react'
-import { authFetch, getApiBase, getToken } from '../lib/auth'
+import { X, TrendingUp, TrendingDown, Shield, BarChart3, AlertTriangle, Lock } from 'lucide-react'
+import { authFetch, getApiBase } from '../lib/auth'
 import { lockSymbol, unlockSymbol } from '../lib/portfolio'
 import { formatCurrency, formatNumber } from '../lib/format'
-import KlineChart from './KlineChart'
+import QuotePanel from './position-detail/QuotePanel'
+import KlinePanel from './position-detail/KlinePanel'
+import DecisionChainPanel from './position-detail/DecisionChainPanel'
+import PositionLocks from './position-detail/PositionLocks'
+import DetailSection from './position-detail/DetailSection'
 
-/** 五檔即時報價面板 */
-function QuotePanel({ symbol }) {
-    const [snap, setSnap] = useState(null)
-    const [source, setSource] = useState(null)
-    const [bidask, setBidask] = useState(null)
-    const [live, setLive] = useState(false)
+/** Label-value pair */
+function DetailField({ label, value, valueClass = 'text-slate-200' }) {
+    return (
+        <div>
+            <div className="text-xs text-slate-500">{label}</div>
+            <div className={`mt-0.5 text-sm font-medium ${valueClass}`}>{value}</div>
+        </div>
+    )
+}
 
-    // 初始 snapshot（含 EOD fallback）
-    useEffect(() => {
-        if (!symbol) return
-        const base = getApiBase()
-        authFetch(`${base}/api/portfolio/quote/${encodeURIComponent(symbol)}`)
-            .then(r => r.json())
-            .then(d => { if (d?.data) { setSnap(d.data); setSource(d.source) } })
-            .catch(() => { })
-    }, [symbol])
-
-    // BidAsk SSE 即時訂閱
-    // Throttled via rAF: we store the latest value in a ref and commit to state
-    // once per animation frame to prevent rapid quote pushes from causing jank.
-    useEffect(() => {
-        if (!symbol) return
-        const base = getApiBase()
-        const token = getToken()
-        const url = `${base}/api/portfolio/quote-stream/${encodeURIComponent(symbol)}${token ? `?token=${token}` : ''}`
-        const es = new EventSource(url)
-
-        const latestRef = { current: null }
-        let rafId = null
-
-        function flushBidask() {
-            rafId = null
-            if (latestRef.current) {
-                setBidask(latestRef.current)
-                latestRef.current = null
-            }
-        }
-
-        es.onopen = () => setLive(true)
-        es.onmessage = e => {
-            try {
-                const d = JSON.parse(e.data)
-                if (d.type === 'bidask') {
-                    latestRef.current = d
-                    if (rafId == null) rafId = requestAnimationFrame(flushBidask)
-                }
-            } catch { }
-        }
-        es.onerror = () => setLive(false)
-        return () => {
-            if (rafId != null) cancelAnimationFrame(rafId)
-            es.close()
-            setLive(false)
-        }
-    }, [symbol])
-
-    const bids = (bidask?.bid_price || []).map((p, i) => ({ price: p, vol: bidask.bid_volume?.[i] ?? 0 }))
-    const asks = (bidask?.ask_price || []).map((p, i) => ({ price: p, vol: bidask.ask_volume?.[i] ?? 0 }))
-    const hasFive = bids.length > 0 || asks.length > 0
+/** Chip score progress bar — 0-3 red, 4-6 yellow, 7-10 green */
+function ChipScoreBar({ score }) {
+    const pct = Math.min(100, Math.max(0, (score / 10) * 100))
+    let color = 'bg-rose-500'
+    if (score >= 7) color = 'bg-emerald-500'
+    else if (score >= 4) color = 'bg-amber-500'
 
     return (
-        <div className="rounded-xl border border-slate-700 bg-slate-950/60 p-4">
-            {/* 標題列 */}
-            <div className="flex items-center justify-between mb-3">
-                <span className="text-xs font-semibold text-slate-200">即時報價</span>
-                {source === 'eod'
-                    ? <span className="flex items-center gap-1 text-[11px] text-slate-400">
-                        <span className="inline-block h-1.5 w-1.5 rounded-full bg-slate-500" />
-                        最後收盤資料（{snap?.trade_date || ''}）
-                    </span>
-                    : <span className={`flex items-center gap-1 text-[11px] ${live ? 'text-emerald-400' : 'text-slate-500'}`}>
-                        <span className={`inline-block h-1.5 w-1.5 rounded-full ${live ? 'bg-emerald-400 animate-pulse' : 'bg-slate-600'}`} />
-                        {live ? '即時連線' : '等待開盤'}
-                    </span>
-                }
-            </div>
-
-            {/* KPI 四格 */}
-            <div className="grid grid-cols-2 gap-x-4 gap-y-2 mb-3 text-xs">
-                <div>
-                    <div className="text-slate-500 mb-0.5">最新成交</div>
-                    <div className="text-xl font-bold text-slate-100">
-                        {snap?.close ? `$${snap.close}` : '—'}
-                    </div>
-                </div>
-                <div>
-                    <div className="text-slate-500 mb-0.5">漲跌幅</div>
-                    <div className={`text-base font-semibold ${snap?.change_rate == null ? 'text-slate-400'
-                            : snap.change_rate >= 0 ? 'text-emerald-400' : 'text-rose-400'
-                        }`}>
-                        {snap?.change_rate != null
-                            ? `${snap.change_rate >= 0 ? '+' : ''}${snap.change_rate.toFixed(2)}%`
-                            : '—'}
-                    </div>
-                </div>
-                <div>
-                    <div className="text-slate-500 mb-0.5">總成交量</div>
-                    <div className="text-slate-200 font-medium">
-                        {snap?.volume != null ? `${snap.volume.toLocaleString()} 張` : '—'}
-                    </div>
-                </div>
-                <div>
-                    <div className="text-slate-500 mb-0.5">成交金額</div>
-                    <div className="text-slate-200 font-medium">
-                        {snap?.total_amount ? `$${(snap.total_amount / 1000).toFixed(0)}K` : '—'}
-                    </div>
-                </div>
-            </div>
-
-            {/* 五檔 bid/ask */}
-            {hasFive ? (
-                <div>
-                    <div className="grid grid-cols-4 text-[11px] text-slate-500 px-1 mb-1">
-                        <div className="text-right">買量(張)</div>
-                        <div className="text-right pr-3">買價</div>
-                        <div className="pl-3">賣價</div>
-                        <div>賣量(張)</div>
-                    </div>
-                    {Array.from({ length: 5 }, (_, i) => (
-                        <div key={i} className="grid grid-cols-4 text-xs py-0.5 rounded odd:bg-slate-900/30">
-                            <div className="text-right text-emerald-400/70 pr-1">{bids[i]?.vol ?? '—'}</div>
-                            <div className="text-right text-emerald-300 font-mono font-medium pr-3">{bids[i]?.price ?? '—'}</div>
-                            <div className="text-rose-300 font-mono font-medium pl-3">{asks[i]?.price ?? '—'}</div>
-                            <div className="text-rose-400/70 pl-1">{asks[i]?.vol ?? '—'}</div>
-                        </div>
-                    ))}
-                </div>
-            ) : (
-                <div className="text-center text-[11px] text-slate-600 py-1">
-                    {live ? '等待五檔推送…' : '開盤後顯示五檔行情'}
-                </div>
-            )}
+        <div className="h-1.5 w-12 rounded-full bg-slate-800 overflow-hidden">
+            <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
         </div>
     )
 }
@@ -220,18 +112,11 @@ export default function PositionDetailDrawer({ symbol, position, isLocked, onLoc
                         <p className="text-xs text-slate-400">持倉詳情 · 決策鏈</p>
                     </div>
                     <div className="flex items-center gap-2">
-                        <button
-                            onClick={handleToggleLock}
-                            disabled={lockLoading}
-                            title={isLocked ? '解除鎖定（允許賣出）' : '鎖定（禁止 AI 賣出）'}
-                            className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 ${isLocked
-                                    ? 'bg-amber-500/15 text-amber-400 hover:bg-amber-500/25 ring-1 ring-amber-500/30'
-                                    : 'bg-slate-800 text-slate-400 hover:bg-slate-700 hover:text-slate-200'
-                                }`}
-                        >
-                            {isLocked ? <Unlock className="h-3.5 w-3.5" /> : <Lock className="h-3.5 w-3.5" />}
-                            {lockLoading ? '處理中…' : isLocked ? '解除鎖定' : '鎖定持股'}
-                        </button>
+                        <PositionLocks
+                            isLocked={isLocked}
+                            lockLoading={lockLoading}
+                            onToggle={handleToggleLock}
+                        />
                         <button
                             onClick={onClose}
                             className="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-800 hover:text-slate-200"
@@ -252,7 +137,7 @@ export default function PositionDetailDrawer({ symbol, position, isLocked, onLoc
                     {/* 即時報價（五檔）— 始終顯示 */}
                     <QuotePanel symbol={symbol} />
                     {/* K 線圖 */}
-                    <KlineChart symbol={symbol} />
+                    <KlinePanel symbol={symbol} />
 
                     {loading && (
                         <div className="flex items-center justify-center py-20">
@@ -302,7 +187,7 @@ export default function PositionDetailDrawer({ symbol, position, isLocked, onLoc
                             )}
 
                             {/* ── 決策鏈 ── */}
-                            <DecisionChainSection decision={detail.decision} riskCheck={detail.risk_check} fills={detail.fills} />
+                            <DecisionChainPanel decision={detail.decision} riskCheck={detail.risk_check} fills={detail.fills} />
 
                             {/* ── 止損 / 止盈 ── */}
                             <DetailSection icon={Shield} title="止損 / 止盈設定">
@@ -355,159 +240,5 @@ export default function PositionDetailDrawer({ symbol, position, isLocked, onLoc
                 </div>
             </div>
         </>
-    )
-}
-
-/** 決策鏈 section：strategy → risk_check → fills */
-function DecisionChainSection({ decision, riskCheck, fills }) {
-    return (
-        <DetailSection icon={GitBranch} title="決策鏈">
-            <div className="space-y-3">
-                {/* Strategy decision */}
-                <ChainStep
-                    step="1"
-                    label="策略決策"
-                    color="indigo"
-                    content={
-                        decision ? (
-                            <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-                                <span className="text-slate-500">策略</span>
-                                <span className="text-indigo-300 font-mono">{decision.strategy_id || '-'}</span>
-                                <span className="text-slate-500">版本</span>
-                                <span className="text-slate-300">{decision.strategy_version || '-'}</span>
-                                <span className="text-slate-500">方向</span>
-                                <span className={`font-semibold ${decision.signal_side === 'buy' ? 'text-emerald-300' : 'text-rose-300'}`}>
-                                    {decision.signal_side?.toUpperCase() || '-'}
-                                </span>
-                                <span className="text-slate-500">信心分</span>
-                                <span className="text-amber-300">{decision.signal_score ?? '-'}</span>
-                                <span className="text-slate-500">時間</span>
-                                <span className="text-slate-400">{decision.ts ? new Date(decision.ts).toLocaleString('zh-TW', { hour12: false }) : '-'}</span>
-                            </div>
-                        ) : (
-                            <span className="text-slate-500 text-xs">暫無決策記錄</span>
-                        )
-                    }
-                />
-
-                {/* Risk check */}
-                <ChainStep
-                    step="2"
-                    label="風控核驗"
-                    color={riskCheck?.passed ? 'emerald' : 'rose'}
-                    content={
-                        riskCheck ? (
-                            <div className="flex items-center gap-3 text-xs">
-                                {riskCheck.passed
-                                    ? <CheckCircle2 className="h-4 w-4 text-emerald-400 flex-shrink-0" />
-                                    : <XCircle className="h-4 w-4 text-rose-400 flex-shrink-0" />
-                                }
-                                <span className={riskCheck.passed ? 'text-emerald-300' : 'text-rose-300'}>
-                                    {riskCheck.passed ? '通過' : `拒絕：${riskCheck.reject_code || '未知'}`}
-                                </span>
-                                {riskCheck.metrics?.orders_last_60s != null && (
-                                    <span className="text-slate-500">60s 訂單數：{riskCheck.metrics.orders_last_60s}</span>
-                                )}
-                            </div>
-                        ) : (
-                            <span className="text-slate-500 text-xs">暫無風控記錄</span>
-                        )
-                    }
-                />
-
-                {/* Fills */}
-                <ChainStep
-                    step="3"
-                    label="成交明細"
-                    color="slate"
-                    content={
-                        fills && fills.length > 0 ? (
-                            <div className="space-y-1">
-                                <div className="grid grid-cols-4 gap-2 text-[11px] text-slate-500 font-medium">
-                                    <span>時間</span>
-                                    <span>數量</span>
-                                    <span>價格</span>
-                                    <span>手續費</span>
-                                </div>
-                                {fills.map((f, i) => (
-                                    <div key={f.fill_id || i} className="grid grid-cols-4 gap-2 text-xs">
-                                        <span className="text-slate-400">
-                                            {f.ts ? new Date(f.ts).toLocaleTimeString('zh-TW', { hour12: false }) : '-'}
-                                        </span>
-                                        <span className="text-slate-200">{f.qty}</span>
-                                        <span className="text-slate-200">{formatCurrency(f.price)}</span>
-                                        <span className="text-slate-400">{f.fee ? formatCurrency(f.fee) : '0'}</span>
-                                    </div>
-                                ))}
-                            </div>
-                        ) : (
-                            <span className="text-slate-500 text-xs">暫無成交記錄</span>
-                        )
-                    }
-                />
-            </div>
-        </DetailSection>
-    )
-}
-
-/** 單一鏈節點 */
-function ChainStep({ step, label, color, content }) {
-    const dotColor = {
-        indigo: 'bg-indigo-500',
-        emerald: 'bg-emerald-500',
-        rose: 'bg-rose-500',
-        slate: 'bg-slate-500',
-    }[color] || 'bg-slate-500'
-
-    return (
-        <div className="flex gap-3">
-            <div className="flex flex-col items-center">
-                <div className={`flex h-6 w-6 items-center justify-center rounded-full ${dotColor} text-[10px] font-bold text-white flex-shrink-0`}>
-                    {step}
-                </div>
-                <div className="mt-1 w-px flex-1 bg-slate-800" />
-            </div>
-            <div className="pb-3 flex-1 min-w-0">
-                <div className="text-xs font-semibold text-slate-300 mb-1.5">{label}</div>
-                {content}
-            </div>
-        </div>
-    )
-}
-
-/** Section wrapper */
-function DetailSection({ icon: Icon, title, children }) {
-    return (
-        <div className="rounded-xl border border-slate-800/80 bg-slate-900/40 p-4">
-            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-200">
-                <Icon className="h-4 w-4 text-emerald-400" />
-                {title}
-            </div>
-            {children}
-        </div>
-    )
-}
-
-/** Label-value pair */
-function DetailField({ label, value, valueClass = 'text-slate-200' }) {
-    return (
-        <div>
-            <div className="text-xs text-slate-500">{label}</div>
-            <div className={`mt-0.5 text-sm font-medium ${valueClass}`}>{value}</div>
-        </div>
-    )
-}
-
-/** Chip score progress bar — 0-3 red, 4-6 yellow, 7-10 green */
-function ChipScoreBar({ score }) {
-    const pct = Math.min(100, Math.max(0, (score / 10) * 100))
-    let color = 'bg-rose-500'
-    if (score >= 7) color = 'bg-emerald-500'
-    else if (score >= 4) color = 'bg-amber-500'
-
-    return (
-        <div className="h-1.5 w-12 rounded-full bg-slate-800 overflow-hidden">
-            <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
-        </div>
     )
 }

--- a/frontend/web/src/components/position-detail/DecisionChainPanel.jsx
+++ b/frontend/web/src/components/position-detail/DecisionChainPanel.jsx
@@ -1,0 +1,121 @@
+import React from 'react'
+import { GitBranch, CheckCircle2, XCircle } from 'lucide-react'
+import { formatCurrency } from '../../lib/format'
+import DetailSection from './DetailSection'
+
+/** 單一鏈節點 */
+function ChainStep({ step, label, color, content }) {
+    const dotColor = {
+        indigo: 'bg-indigo-500',
+        emerald: 'bg-emerald-500',
+        rose: 'bg-rose-500',
+        slate: 'bg-slate-500',
+    }[color] || 'bg-slate-500'
+
+    return (
+        <div className="flex gap-3">
+            <div className="flex flex-col items-center">
+                <div className={`flex h-6 w-6 items-center justify-center rounded-full ${dotColor} text-[10px] font-bold text-white flex-shrink-0`}>
+                    {step}
+                </div>
+                <div className="mt-1 w-px flex-1 bg-slate-800" />
+            </div>
+            <div className="pb-3 flex-1 min-w-0">
+                <div className="text-xs font-semibold text-slate-300 mb-1.5">{label}</div>
+                {content}
+            </div>
+        </div>
+    )
+}
+
+/** 決策鏈 section：strategy → risk_check → fills */
+export default function DecisionChainPanel({ decision, riskCheck, fills }) {
+    return (
+        <DetailSection icon={GitBranch} title="決策鏈">
+            <div className="space-y-3">
+                {/* Strategy decision */}
+                <ChainStep
+                    step="1"
+                    label="策略決策"
+                    color="indigo"
+                    content={
+                        decision ? (
+                            <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                                <span className="text-slate-500">策略</span>
+                                <span className="text-indigo-300 font-mono">{decision.strategy_id || '-'}</span>
+                                <span className="text-slate-500">版本</span>
+                                <span className="text-slate-300">{decision.strategy_version || '-'}</span>
+                                <span className="text-slate-500">方向</span>
+                                <span className={`font-semibold ${decision.signal_side === 'buy' ? 'text-emerald-300' : 'text-rose-300'}`}>
+                                    {decision.signal_side?.toUpperCase() || '-'}
+                                </span>
+                                <span className="text-slate-500">信心分</span>
+                                <span className="text-amber-300">{decision.signal_score ?? '-'}</span>
+                                <span className="text-slate-500">時間</span>
+                                <span className="text-slate-400">{decision.ts ? new Date(decision.ts).toLocaleString('zh-TW', { hour12: false }) : '-'}</span>
+                            </div>
+                        ) : (
+                            <span className="text-slate-500 text-xs">暫無決策記錄</span>
+                        )
+                    }
+                />
+
+                {/* Risk check */}
+                <ChainStep
+                    step="2"
+                    label="風控核驗"
+                    color={riskCheck?.passed ? 'emerald' : 'rose'}
+                    content={
+                        riskCheck ? (
+                            <div className="flex items-center gap-3 text-xs">
+                                {riskCheck.passed
+                                    ? <CheckCircle2 className="h-4 w-4 text-emerald-400 flex-shrink-0" />
+                                    : <XCircle className="h-4 w-4 text-rose-400 flex-shrink-0" />
+                                }
+                                <span className={riskCheck.passed ? 'text-emerald-300' : 'text-rose-300'}>
+                                    {riskCheck.passed ? '通過' : `拒絕：${riskCheck.reject_code || '未知'}`}
+                                </span>
+                                {riskCheck.metrics?.orders_last_60s != null && (
+                                    <span className="text-slate-500">60s 訂單數：{riskCheck.metrics.orders_last_60s}</span>
+                                )}
+                            </div>
+                        ) : (
+                            <span className="text-slate-500 text-xs">暫無風控記錄</span>
+                        )
+                    }
+                />
+
+                {/* Fills */}
+                <ChainStep
+                    step="3"
+                    label="成交明細"
+                    color="slate"
+                    content={
+                        fills && fills.length > 0 ? (
+                            <div className="space-y-1">
+                                <div className="grid grid-cols-4 gap-2 text-[11px] text-slate-500 font-medium">
+                                    <span>時間</span>
+                                    <span>數量</span>
+                                    <span>價格</span>
+                                    <span>手續費</span>
+                                </div>
+                                {fills.map((f, i) => (
+                                    <div key={f.fill_id || i} className="grid grid-cols-4 gap-2 text-xs">
+                                        <span className="text-slate-400">
+                                            {f.ts ? new Date(f.ts).toLocaleTimeString('zh-TW', { hour12: false }) : '-'}
+                                        </span>
+                                        <span className="text-slate-200">{f.qty}</span>
+                                        <span className="text-slate-200">{formatCurrency(f.price)}</span>
+                                        <span className="text-slate-400">{f.fee ? formatCurrency(f.fee) : '0'}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <span className="text-slate-500 text-xs">暫無成交記錄</span>
+                        )
+                    }
+                />
+            </div>
+        </DetailSection>
+    )
+}

--- a/frontend/web/src/components/position-detail/DetailSection.jsx
+++ b/frontend/web/src/components/position-detail/DetailSection.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+/** Section wrapper */
+export default function DetailSection({ icon: Icon, title, children }) {
+    return (
+        <div className="rounded-xl border border-slate-800/80 bg-slate-900/40 p-4">
+            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-200">
+                <Icon className="h-4 w-4 text-emerald-400" />
+                {title}
+            </div>
+            {children}
+        </div>
+    )
+}

--- a/frontend/web/src/components/position-detail/KlinePanel.jsx
+++ b/frontend/web/src/components/position-detail/KlinePanel.jsx
@@ -1,0 +1,3 @@
+// Re-export KlineChart as KlinePanel for use within position-detail sub-components.
+// KlineChart lives at the shared components level and is already a standalone SVG chart.
+export { default } from '../KlineChart'

--- a/frontend/web/src/components/position-detail/PositionLocks.jsx
+++ b/frontend/web/src/components/position-detail/PositionLocks.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Lock, Unlock } from 'lucide-react'
+
+/**
+ * Lock/unlock button rendered inside the drawer header.
+ * Props:
+ *   isLocked     — boolean
+ *   lockLoading  — boolean
+ *   onToggle     — () => void
+ */
+export default function PositionLocks({ isLocked, lockLoading, onToggle }) {
+    return (
+        <button
+            onClick={onToggle}
+            disabled={lockLoading}
+            title={isLocked ? '解除鎖定（允許賣出）' : '鎖定（禁止 AI 賣出）'}
+            className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 ${isLocked
+                    ? 'bg-amber-500/15 text-amber-400 hover:bg-amber-500/25 ring-1 ring-amber-500/30'
+                    : 'bg-slate-800 text-slate-400 hover:bg-slate-700 hover:text-slate-200'
+                }`}
+        >
+            {isLocked ? <Unlock className="h-3.5 w-3.5" /> : <Lock className="h-3.5 w-3.5" />}
+            {lockLoading ? '處理中…' : isLocked ? '解除鎖定' : '鎖定持股'}
+        </button>
+    )
+}

--- a/frontend/web/src/components/position-detail/QuotePanel.jsx
+++ b/frontend/web/src/components/position-detail/QuotePanel.jsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from 'react'
+import { authFetch, getApiBase, getToken } from '../../lib/auth'
+
+/** 五檔即時報價面板 */
+export default function QuotePanel({ symbol }) {
+    const [snap, setSnap] = useState(null)
+    const [source, setSource] = useState(null)
+    const [bidask, setBidask] = useState(null)
+    const [live, setLive] = useState(false)
+
+    // 初始 snapshot（含 EOD fallback）
+    useEffect(() => {
+        if (!symbol) return
+        const base = getApiBase()
+        authFetch(`${base}/api/portfolio/quote/${encodeURIComponent(symbol)}`)
+            .then(r => r.json())
+            .then(d => { if (d?.data) { setSnap(d.data); setSource(d.source) } })
+            .catch(() => { })
+    }, [symbol])
+
+    // BidAsk SSE 即時訂閱
+    // Throttled via rAF: we store the latest value in a ref and commit to state
+    // once per animation frame to prevent rapid quote pushes from causing jank.
+    useEffect(() => {
+        if (!symbol) return
+        const base = getApiBase()
+        const token = getToken()
+        const url = `${base}/api/portfolio/quote-stream/${encodeURIComponent(symbol)}${token ? `?token=${token}` : ''}`
+        const es = new EventSource(url)
+
+        const latestRef = { current: null }
+        let rafId = null
+
+        function flushBidask() {
+            rafId = null
+            if (latestRef.current) {
+                setBidask(latestRef.current)
+                latestRef.current = null
+            }
+        }
+
+        es.onopen = () => setLive(true)
+        es.onmessage = e => {
+            try {
+                const d = JSON.parse(e.data)
+                if (d.type === 'bidask') {
+                    latestRef.current = d
+                    if (rafId == null) rafId = requestAnimationFrame(flushBidask)
+                }
+            } catch { }
+        }
+        es.onerror = () => setLive(false)
+        return () => {
+            if (rafId != null) cancelAnimationFrame(rafId)
+            es.close()
+            setLive(false)
+        }
+    }, [symbol])
+
+    const bids = (bidask?.bid_price || []).map((p, i) => ({ price: p, vol: bidask.bid_volume?.[i] ?? 0 }))
+    const asks = (bidask?.ask_price || []).map((p, i) => ({ price: p, vol: bidask.ask_volume?.[i] ?? 0 }))
+    const hasFive = bids.length > 0 || asks.length > 0
+
+    return (
+        <div className="rounded-xl border border-slate-700 bg-slate-950/60 p-4">
+            {/* 標題列 */}
+            <div className="flex items-center justify-between mb-3">
+                <span className="text-xs font-semibold text-slate-200">即時報價</span>
+                {source === 'eod'
+                    ? <span className="flex items-center gap-1 text-[11px] text-slate-400">
+                        <span className="inline-block h-1.5 w-1.5 rounded-full bg-slate-500" />
+                        最後收盤資料（{snap?.trade_date || ''}）
+                    </span>
+                    : <span className={`flex items-center gap-1 text-[11px] ${live ? 'text-emerald-400' : 'text-slate-500'}`}>
+                        <span className={`inline-block h-1.5 w-1.5 rounded-full ${live ? 'bg-emerald-400 animate-pulse' : 'bg-slate-600'}`} />
+                        {live ? '即時連線' : '等待開盤'}
+                    </span>
+                }
+            </div>
+
+            {/* KPI 四格 */}
+            <div className="grid grid-cols-2 gap-x-4 gap-y-2 mb-3 text-xs">
+                <div>
+                    <div className="text-slate-500 mb-0.5">最新成交</div>
+                    <div className="text-xl font-bold text-slate-100">
+                        {snap?.close ? `$${snap.close}` : '—'}
+                    </div>
+                </div>
+                <div>
+                    <div className="text-slate-500 mb-0.5">漲跌幅</div>
+                    <div className={`text-base font-semibold ${snap?.change_rate == null ? 'text-slate-400'
+                            : snap.change_rate >= 0 ? 'text-emerald-400' : 'text-rose-400'
+                        }`}>
+                        {snap?.change_rate != null
+                            ? `${snap.change_rate >= 0 ? '+' : ''}${snap.change_rate.toFixed(2)}%`
+                            : '—'}
+                    </div>
+                </div>
+                <div>
+                    <div className="text-slate-500 mb-0.5">總成交量</div>
+                    <div className="text-slate-200 font-medium">
+                        {snap?.volume != null ? `${snap.volume.toLocaleString()} 張` : '—'}
+                    </div>
+                </div>
+                <div>
+                    <div className="text-slate-500 mb-0.5">成交金額</div>
+                    <div className="text-slate-200 font-medium">
+                        {snap?.total_amount ? `$${(snap.total_amount / 1000).toFixed(0)}K` : '—'}
+                    </div>
+                </div>
+            </div>
+
+            {/* 五檔 bid/ask */}
+            {hasFive ? (
+                <div>
+                    <div className="grid grid-cols-4 text-[11px] text-slate-500 px-1 mb-1">
+                        <div className="text-right">買量(張)</div>
+                        <div className="text-right pr-3">買價</div>
+                        <div className="pl-3">賣價</div>
+                        <div>賣量(張)</div>
+                    </div>
+                    {Array.from({ length: 5 }, (_, i) => (
+                        <div key={i} className="grid grid-cols-4 text-xs py-0.5 rounded odd:bg-slate-900/30">
+                            <div className="text-right text-emerald-400/70 pr-1">{bids[i]?.vol ?? '—'}</div>
+                            <div className="text-right text-emerald-300 font-mono font-medium pr-3">{bids[i]?.price ?? '—'}</div>
+                            <div className="text-rose-300 font-mono font-medium pl-3">{asks[i]?.price ?? '—'}</div>
+                            <div className="text-rose-400/70 pl-1">{asks[i]?.vol ?? '—'}</div>
+                        </div>
+                    ))}
+                </div>
+            ) : (
+                <div className="text-center text-[11px] text-slate-600 py-1">
+                    {live ? '等待五檔推送…' : '開盤後顯示五檔行情'}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/web/src/components/position-detail/index.jsx
+++ b/frontend/web/src/components/position-detail/index.jsx
@@ -1,0 +1,1 @@
+export { default } from '../PositionDetailDrawer'


### PR DESCRIPTION
## Summary

- Extracts `QuotePanel`, `KlinePanel`, `DecisionChainPanel`, `PositionLocks`, and `DetailSection` from `PositionDetailDrawer.jsx` (513 lines) into separate files under `frontend/web/src/components/position-detail/`
- `PositionDetailDrawer.jsx` is now a focused container that manages drawer open/close state, position-detail data fetching, and layout composition
- `position-detail/index.jsx` re-exports `PositionDetailDrawer` for consumers that prefer the directory import path
- Zero functionality changes: all SSE connections, rAF throttling, event cleanup on unmount, props, and CSS classes are identical to the original

Closes #217

## Test plan

- [x] `cd frontend/web && npm test -- --run` — 11 test files, 129 tests, all passed
- [ ] Manual smoke test: open PositionDetailDrawer in browser, verify QuotePanel SSE live indicator, KlineChart rendering, lock/unlock button, decision chain display

🤖 Generated with [Claude Code](https://claude.com/claude-code)