### PR TITLE
refactor: unify DB connection patterns in core engine

### DIFF
--- a/src/openclaw/agent_orchestrator.py
+++ b/src/openclaw/agent_orchestrator.py
@@ -91,18 +91,14 @@ def _run_reflection_agent() -> None:
     """同步包裝：在 executor 執行 ReflectionAgent.reflect_weekly()。
     自行開連線，避免與主迴圈共用 conn 導致 ProgrammingError（closed database）。
     """
-    conn = None
     try:
-        conn = sqlite3.connect(DB_PATH, timeout=10)
-        conn.row_factory = sqlite3.Row
+        from openclaw.db_utils import get_readwrite_conn
         from openclaw.strategy_optimizer import ReflectionAgent
-        proposals = ReflectionAgent(conn).reflect_weekly()
+        with get_readwrite_conn(DB_PATH) as conn:
+            proposals = ReflectionAgent(conn).reflect_weekly()
         log.info("[orchestrator] ReflectionAgent 建議 %d 項", len(proposals))
     except Exception as e:
         log.warning("[orchestrator] ReflectionAgent 失敗：%s", e)
-    finally:
-        if conn:
-            conn.close()
 
 
 # ── 主排程迴圈 ────────────────────────────────────────────────────────────────
@@ -122,67 +118,66 @@ async def run_orchestrator() -> None:
     last_health_off_utc: Optional[datetime] = None
     last_opt_trigger_date: Optional[str] = None
 
+    from openclaw.db_utils import get_readwrite_conn
+
     while True:
         now_twn = datetime.now(tz=_TZ_TWN)
         now_utc = datetime.now(tz=timezone.utc)
-        conn = sqlite3.connect(DB_PATH, timeout=10)
-        conn.row_factory = sqlite3.Row
         try:
-            # ── 定時任務 ──────────────────────────────────────────────────
-            if _is_weekday_twn(now_twn):
-                if _should_run_now("08:20", now_twn):
-                    asyncio.create_task(_run_agent("MarketResearchAgent", run_market_research))
+            with get_readwrite_conn(DB_PATH) as conn:
+                # ── 定時任務 ──────────────────────────────────────────────────
+                if _is_weekday_twn(now_twn):
+                    if _should_run_now("08:20", now_twn):
+                        asyncio.create_task(_run_agent("MarketResearchAgent", run_market_research))
 
-                if _should_run_now("14:30", now_twn):
-                    asyncio.create_task(_run_agent("PortfolioReviewAgent", run_portfolio_review))
+                    if _should_run_now("14:30", now_twn):
+                        asyncio.create_task(_run_agent("PortfolioReviewAgent", run_portfolio_review))
 
-                # 每交易日 22:00 TWN → 盤後分析（資料最晚 21:14 入庫，22:00 安全）
-                if _should_run_now("22:00", now_twn):
-                    asyncio.create_task(_run_agent("EODAnalysisAgent", run_eod_analysis))
+                    # 每交易日 22:00 TWN → 盤後分析（資料最晚 21:14 入庫，22:00 安全）
+                    if _should_run_now("22:00", now_twn):
+                        asyncio.create_task(_run_agent("EODAnalysisAgent", run_eod_analysis))
 
-                # 每 30 分鐘系統健康（市場時段）
-                if 9 <= now_twn.hour < 14:
-                    if (last_health_run_utc is None or
-                            (now_utc - last_health_run_utc).seconds >= 1800):
+                    # 每 30 分鐘系統健康（市場時段）
+                    if 9 <= now_twn.hour < 14:
+                        if (last_health_run_utc is None or
+                                (now_utc - last_health_run_utc).seconds >= 1800):
+                            asyncio.create_task(_run_agent("SystemHealthAgent", run_system_health))
+                            last_health_run_utc = now_utc
+
+                # 每 2 小時系統健康（非市場時段）
+                if not (9 <= now_twn.hour < 14):
+                    if (last_health_off_utc is None or
+                            (now_utc - last_health_off_utc).seconds >= 7200):
                         asyncio.create_task(_run_agent("SystemHealthAgent", run_system_health))
-                        last_health_run_utc = now_utc
+                        last_health_off_utc = now_utc
 
-            # 每 2 小時系統健康（非市場時段）
-            if not (9 <= now_twn.hour < 14):
-                if (last_health_off_utc is None or
-                        (now_utc - last_health_off_utc).seconds >= 7200):
-                    asyncio.create_task(_run_agent("SystemHealthAgent", run_system_health))
-                    last_health_off_utc = now_utc
+                if _is_monday_twn(now_twn):
+                    if _should_run_now("07:00", now_twn):
+                        asyncio.create_task(
+                            _run_agent("SystemOptimizationAgent", run_system_optimization))
+                        # 週一 07:00 深度反思（非阻塞）
+                        asyncio.create_task(asyncio.to_thread(_run_reflection_agent))
+                    if _should_run_now("07:30", now_twn):
+                        asyncio.create_task(
+                            _run_agent("StrategyCommitteeAgent", run_strategy_committee))
 
-            if _is_monday_twn(now_twn):
-                if _should_run_now("07:00", now_twn):
-                    asyncio.create_task(
-                        _run_agent("SystemOptimizationAgent", run_system_optimization))
-                    # 週一 07:00 深度反思（非阻塞）
-                    asyncio.create_task(asyncio.to_thread(_run_reflection_agent))
-                if _should_run_now("07:30", now_twn):
+                # ── 事件任務 ──────────────────────────────────────────────────
+                new_reviewed_at = _pm_review_just_completed(last_seen=last_pm_reviewed_at)
+                if new_reviewed_at:
+                    log.info("[EVENT] PM review completed → StrategyCommitteeAgent")
+                    last_pm_reviewed_at = new_reviewed_at
                     asyncio.create_task(
                         _run_agent("StrategyCommitteeAgent", run_strategy_committee))
 
-            # ── 事件任務 ──────────────────────────────────────────────────
-            new_reviewed_at = _pm_review_just_completed(last_seen=last_pm_reviewed_at)
-            if new_reviewed_at:
-                log.info("[EVENT] PM review completed → StrategyCommitteeAgent")
-                last_pm_reviewed_at = new_reviewed_at
-                asyncio.create_task(
-                    _run_agent("StrategyCommitteeAgent", run_strategy_committee))
-
-            today_str = now_twn.strftime("%Y-%m-%d")
-            if last_opt_trigger_date != today_str and _watcher_no_fills_3days(conn):
-                log.info("[EVENT] 3-day no fills → SystemOptimizationAgent")
-                last_opt_trigger_date = today_str
-                asyncio.create_task(
-                    _run_agent("SystemOptimizationAgent", run_system_optimization))
+                today_str = now_twn.strftime("%Y-%m-%d")
+                if last_opt_trigger_date != today_str and _watcher_no_fills_3days(conn):
+                    log.info("[EVENT] 3-day no fills → SystemOptimizationAgent")
+                    last_opt_trigger_date = today_str
+                    asyncio.create_task(
+                        _run_agent("SystemOptimizationAgent", run_system_optimization))
 
         except Exception as e:
             log.error("[ORCHESTRATOR] Main loop error: %s", e, exc_info=True)
-        finally:
-            conn.close()
 
         await asyncio.sleep(60)
 

--- a/src/openclaw/db_utils.py
+++ b/src/openclaw/db_utils.py
@@ -1,0 +1,109 @@
+"""Unified database connection utilities for the AI Trader core engine.
+
+Provides two context-manager helpers for SQLite access:
+- ``get_readonly_conn`` — read-only mode (URI mode=ro); suitable for queries.
+- ``get_readwrite_conn`` — read-write mode with automatic commit/rollback.
+
+For long-lived connections that need explicit transaction control (e.g.
+``ticker_watcher``'s inner scan loop), use ``open_watcher_conn`` which
+returns a plain ``sqlite3.Connection`` with WAL mode and autocommit enabled.
+
+Do NOT import or modify ``frontend/backend/app/db.py`` — that module owns
+its own connection-pool pattern for the FastAPI process.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _get_db_path() -> str:
+    """Resolve path to trades.db relative to this file's repo root.
+
+    Layout: src/openclaw/db_utils.py → parents[2] = repo root
+    """
+    root = Path(__file__).resolve().parents[2]
+    return str(root / "data" / "sqlite" / "trades.db")
+
+
+@contextmanager
+def get_readonly_conn(db_path: Optional[str] = None) -> Iterator[sqlite3.Connection]:
+    """Yield a read-only SQLite connection.
+
+    Uses ``file:...?mode=ro`` URI to guarantee no writes are possible.
+    The connection is closed automatically when the context exits.
+
+    Example::
+
+        with get_readonly_conn() as conn:
+            rows = conn.execute("SELECT * FROM orders").fetchall()
+    """
+    path = db_path or _get_db_path()
+    uri = f"file:{path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@contextmanager
+def get_readwrite_conn(db_path: Optional[str] = None) -> Iterator[sqlite3.Connection]:
+    """Yield a read-write SQLite connection with automatic commit/rollback.
+
+    Commits on clean exit; rolls back and re-raises on any exception.
+    The connection is closed automatically when the context exits.
+
+    Example::
+
+        with get_readwrite_conn() as conn:
+            conn.execute("INSERT INTO orders ...", (...,))
+    """
+    path = db_path or _get_db_path()
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def open_watcher_conn(db_path: Optional[str] = None) -> sqlite3.Connection:
+    """Open a long-lived read-write connection optimised for the watcher loop.
+
+    Sets WAL journal mode, NORMAL synchronous, a 30-second busy timeout, and
+    foreign-key enforcement.  ``isolation_level=None`` enables autocommit so
+    the caller can issue explicit ``BEGIN IMMEDIATE`` / ``COMMIT`` / ``ROLLBACK``
+    statements — matching the existing ticker_watcher transaction pattern.
+
+    The caller is responsible for calling ``conn.close()`` when done.
+
+    Example::
+
+        conn = open_watcher_conn()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            ...
+            conn.commit()
+        finally:
+            conn.close()
+    """
+    path = db_path or _get_db_path()
+    conn = sqlite3.connect(path, timeout=30, check_same_thread=False, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute("PRAGMA synchronous=NORMAL;")
+    conn.execute("PRAGMA busy_timeout=30000;")
+    conn.execute("PRAGMA foreign_keys=ON;")
+    logger.debug("Opened watcher connection to %s", path)
+    return conn

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -134,12 +134,8 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
 
 
 def _open_conn() -> sqlite3.Connection:
-    conn = sqlite3.connect(DB_PATH, timeout=30, check_same_thread=False, isolation_level=None)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL;")
-    conn.execute("PRAGMA synchronous=NORMAL;")
-    conn.execute("PRAGMA busy_timeout=30000;")
-    conn.execute("PRAGMA foreign_keys=ON;")
+    from openclaw.db_utils import open_watcher_conn
+    conn = open_watcher_conn(DB_PATH)
     _ensure_schema(conn)
     return conn
 

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,0 +1,182 @@
+"""Tests for src/openclaw/db_utils.py — unified DB connection utilities."""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from openclaw.db_utils import (
+    _get_db_path,
+    get_readonly_conn,
+    get_readwrite_conn,
+    open_watcher_conn,
+)
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def tmp_db(tmp_path: Path) -> str:
+    """Create a minimal SQLite DB with a 'items' table and return its path."""
+    db_path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO items (value) VALUES ('hello')")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# ── _get_db_path ──────────────────────────────────────────────────────────────
+
+def test_get_db_path_resolves_to_trades_db():
+    """_get_db_path returns a path ending with data/sqlite/trades.db."""
+    path = _get_db_path()
+    assert path.endswith("data/sqlite/trades.db")
+    # Must be absolute
+    assert Path(path).is_absolute()
+
+
+# ── get_readonly_conn ─────────────────────────────────────────────────────────
+
+def test_readonly_conn_can_read(tmp_db: str):
+    """get_readonly_conn allows SELECT queries."""
+    with get_readonly_conn(tmp_db) as conn:
+        rows = conn.execute("SELECT value FROM items").fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "hello"
+
+
+def test_readonly_conn_refuses_writes(tmp_db: str):
+    """get_readonly_conn raises an error on INSERT/UPDATE/DELETE."""
+    with pytest.raises(Exception):
+        with get_readonly_conn(tmp_db) as conn:
+            conn.execute("INSERT INTO items (value) VALUES ('new')")
+
+
+def test_readonly_conn_closed_after_exit(tmp_db: str):
+    """Connection is closed after the context manager exits."""
+    with get_readonly_conn(tmp_db) as conn:
+        pass  # just enter and exit
+    # Attempting to use the connection after close raises ProgrammingError
+    with pytest.raises(Exception):
+        conn.execute("SELECT 1")
+
+
+def test_readonly_conn_row_factory(tmp_db: str):
+    """Rows are returned as sqlite3.Row (accessible by name)."""
+    with get_readonly_conn(tmp_db) as conn:
+        row = conn.execute("SELECT value FROM items").fetchone()
+    assert row["value"] == "hello"
+
+
+# ── get_readwrite_conn ────────────────────────────────────────────────────────
+
+def test_readwrite_conn_allows_writes(tmp_db: str):
+    """get_readwrite_conn allows INSERT and auto-commits on clean exit."""
+    with get_readwrite_conn(tmp_db) as conn:
+        conn.execute("INSERT INTO items (value) VALUES ('world')")
+
+    # Verify the row persisted after the context closed
+    verify = sqlite3.connect(tmp_db)
+    rows = verify.execute("SELECT value FROM items ORDER BY id").fetchall()
+    verify.close()
+    assert len(rows) == 2
+    assert rows[1][0] == "world"
+
+
+def test_readwrite_conn_rollback_on_error(tmp_db: str):
+    """get_readwrite_conn rolls back when an exception is raised inside."""
+    with pytest.raises(RuntimeError):
+        with get_readwrite_conn(tmp_db) as conn:
+            conn.execute("INSERT INTO items (value) VALUES ('rollback_me')")
+            raise RuntimeError("forced error")
+
+    # The inserted row must NOT be present
+    verify = sqlite3.connect(tmp_db)
+    rows = verify.execute("SELECT value FROM items WHERE value='rollback_me'").fetchall()
+    verify.close()
+    assert rows == []
+
+
+def test_readwrite_conn_reraises_exception(tmp_db: str):
+    """The original exception propagates out of get_readwrite_conn."""
+    class _Sentinel(Exception):
+        pass
+
+    with pytest.raises(_Sentinel):
+        with get_readwrite_conn(tmp_db) as conn:
+            raise _Sentinel("sentinel")
+
+
+def test_readwrite_conn_closed_after_exit(tmp_db: str):
+    """Connection is closed after the context manager exits (success path)."""
+    with get_readwrite_conn(tmp_db) as conn:
+        pass
+    with pytest.raises(Exception):
+        conn.execute("SELECT 1")
+
+
+def test_readwrite_conn_row_factory(tmp_db: str):
+    """Rows returned by get_readwrite_conn are sqlite3.Row instances."""
+    with get_readwrite_conn(tmp_db) as conn:
+        row = conn.execute("SELECT value FROM items").fetchone()
+    assert row["value"] == "hello"
+
+
+# ── open_watcher_conn ─────────────────────────────────────────────────────────
+
+def test_watcher_conn_allows_writes(tmp_db: str):
+    """open_watcher_conn returns a writable connection."""
+    conn = open_watcher_conn(tmp_db)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("INSERT INTO items (value) VALUES ('watcher')")
+        conn.commit()
+    finally:
+        conn.close()
+
+    verify = sqlite3.connect(tmp_db)
+    rows = verify.execute("SELECT value FROM items WHERE value='watcher'").fetchall()
+    verify.close()
+    assert len(rows) == 1
+
+
+def test_watcher_conn_explicit_rollback(tmp_db: str):
+    """open_watcher_conn supports explicit ROLLBACK (isolation_level=None)."""
+    conn = open_watcher_conn(tmp_db)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("INSERT INTO items (value) VALUES ('should_rollback')")
+        conn.execute("ROLLBACK")
+    finally:
+        conn.close()
+
+    verify = sqlite3.connect(tmp_db)
+    rows = verify.execute(
+        "SELECT value FROM items WHERE value='should_rollback'"
+    ).fetchall()
+    verify.close()
+    assert rows == []
+
+
+def test_watcher_conn_wal_mode(tmp_db: str):
+    """open_watcher_conn sets WAL journal mode."""
+    conn = open_watcher_conn(tmp_db)
+    try:
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        assert row[0] == "wal"
+    finally:
+        conn.close()
+
+
+def test_watcher_conn_row_factory(tmp_db: str):
+    """open_watcher_conn rows are accessible by column name."""
+    conn = open_watcher_conn(tmp_db)
+    try:
+        row = conn.execute("SELECT value FROM items").fetchone()
+        assert row["value"] == "hello"
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

- Add `src/openclaw/db_utils.py` with three unified connection helpers:
  - `get_readonly_conn()` — context manager, URI `mode=ro`, prevents writes
  - `get_readwrite_conn()` — context manager, auto-commit on exit, auto-rollback on exception
  - `open_watcher_conn()` — long-lived connection with WAL mode + autocommit for ticker_watcher's explicit transaction loop
- Migrate `ticker_watcher._open_conn()` to delegate to `open_watcher_conn`, preserving all PRAGMA settings and explicit `BEGIN IMMEDIATE` / `ROLLBACK` patterns
- Migrate `agent_orchestrator._run_reflection_agent()` and `run_orchestrator()` main loop from bare `sqlite3.connect()` to `get_readwrite_conn()`
- `frontend/backend/app/db.py` is NOT touched — it keeps its own pooling pattern for FastAPI

## Test plan

- [ ] 14 new tests in `tests/test_db_utils.py` all pass
  - readonly connection refuses writes
  - readwrite connection commits on success, rolls back on exception, re-raises original exception
  - watcher connection sets WAL journal mode, supports explicit ROLLBACK
  - `row_factory` set on all three helpers
- [ ] Full core engine suite: `PYTHONPATH=src pytest --tb=no --ignore=tests/test_property_based.py` → 1837 passed, 0 new failures (pre-existing `pydantic_settings` env issues unrelated to this PR)

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)