### PR TITLE
refactor(exceptions): narrow except Exception to specific types

### DIFF
--- a/frontend/backend/app/api/portfolio.py
+++ b/frontend/backend/app/api/portfolio.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import time
 import uuid
 from typing import Any, Dict, List, Literal, Optional
@@ -22,7 +23,7 @@ def _read_locked() -> list:
     try:
         with open(_LOCKED_PATH, "r") as f:
             return json.load(f).get("locked", [])
-    except Exception:
+    except (OSError, ValueError):
         return []
 
 
@@ -120,7 +121,7 @@ def portfolio_positions(simulation: Optional[bool] = None):
                 for r in rows
             ]
             return {"status": "ok", "source": "db_positions", "simulation": simulation, "positions": positions}
-    except Exception:
+    except sqlite3.Error:
         pass
 
     # ── Fallback: compute net positions from orders+fills ────────────────────
@@ -155,7 +156,7 @@ def portfolio_positions(simulation: Optional[bool] = None):
                 for r in rows
             ]
             return {"status": "ok", "source": "db_fills", "simulation": simulation, "positions": positions}
-    except Exception:
+    except sqlite3.Error:
         pass
 
     return {"status": "ok", "source": "no_data", "simulation": simulation, "positions": []}
@@ -281,7 +282,7 @@ def get_position_detail(symbol: str):
             cap = _json.load(f)
             def_sl = float(cap.get("default_stop_loss_pct", 0.05))
             def_tp = float(cap.get("default_take_profit_pct", 0.10))
-    except Exception:  # pragma: no cover
+    except (OSError, ValueError):  # pragma: no cover
         pass  # pragma: no cover
 
     with get_conn() as conn:
@@ -317,7 +318,7 @@ def get_position_detail(symbol: str):
                 if dec:
                     try:
                         reason = _json.loads(dec["reason_json"] or "{}")
-                    except Exception:
+                    except (json.JSONDecodeError, ValueError):
                         reason = {}
                     decision_info = {
                         "decision_id": decision_id,
@@ -338,7 +339,7 @@ def get_position_detail(symbol: str):
                 if rc:
                     try:
                         metrics = _json.loads(rc["metrics_json"] or "{}")
-                    except Exception:
+                    except (json.JSONDecodeError, ValueError):
                         metrics = {}
                     risk_info = {
                         "passed": bool(rc["passed"]),
@@ -375,7 +376,7 @@ def get_position_detail(symbol: str):
             if pp:
                 stop_loss = pp["stop_loss"]
                 take_profit = pp["take_profit"]
-        except Exception:
+        except sqlite3.Error:
             pass
 
         if avg_price:
@@ -403,7 +404,7 @@ def get_position_detail(symbol: str):
                 }
                 for r in rows
             ]
-        except Exception:
+        except sqlite3.Error:
             pass
 
     return {
@@ -442,7 +443,7 @@ def get_portfolio_kpis():
             available_cash = float(cap_data.get("total_capital_twd", 500000.0))
             def_sl = float(cap_data.get("default_stop_loss_pct", 0.05))
             def_tp = float(cap_data.get("default_take_profit_pct", 0.10))
-    except Exception:  # pragma: no cover
+    except (OSError, ValueError):  # pragma: no cover
         available_cash = 500000.0  # pragma: no cover
         def_sl = 0.05  # pragma: no cover
         def_tp = 0.10  # pragma: no cover
@@ -466,7 +467,7 @@ def get_portfolio_kpis():
             try:
                 from openclaw.pnl_engine import get_overall_win_rate as _win_rate
                 overall_win_rate = _win_rate(conn)
-            except Exception:
+            except Exception:  # noqa: BLE001 — dynamic import; can't predict exceptions
                 pass
 
             # Try to get latest cash from position snapshots if available
@@ -476,9 +477,9 @@ def get_portfolio_kpis():
                 ).fetchone()
                 if snapshot_row and snapshot_row["available_cash"] is not None:
                     available_cash = snapshot_row["available_cash"]
-            except Exception:
+            except sqlite3.Error:
                 pass
-    except Exception as e:  # pragma: no cover
+    except sqlite3.Error as e:  # pragma: no cover
         pass  # pragma: no cover  # fallback to defaults
 
     return {
@@ -572,11 +573,11 @@ def get_monthly_summary(month: str = "2026-02"):
                             sell_dt = _dt.datetime.fromisoformat(str(s["timestamp"]).replace("Z", "+00:00"))
                             days = abs((sell_dt - buy_dt).total_seconds()) / 86400
                             holding_days_list.append(days)
-                        except Exception:
+                        except (ValueError, TypeError):
                             pass
                 if holding_days_list:
                     avg_holding_days = sum(holding_days_list) / len(holding_days_list)
-            except Exception:  # pragma: no cover
+            except (sqlite3.Error, ValueError):  # pragma: no cover
                 avg_holding_days = 0.0  # pragma: no cover
 
             return {
@@ -621,7 +622,7 @@ def get_equity_curve(days: int = 60, start_equity: float = 100000.0):
             series = _eq_curve(conn, days=days, start_equity=start_equity)
         if series:
             return {"status": "ok", "data": series, "source": "db"}
-    except Exception:
+    except Exception:  # noqa: BLE001 — dynamic import; can't predict exceptions
         pass
     return {"status": "ok", "data": [], "source": "no_data"}
 
@@ -678,7 +679,7 @@ def get_trade_causal_chain(trade_id: str):
                     }
                     for row in llm_results
                 ]
-            except Exception:
+            except sqlite3.Error:
                 llm_traces = []
 
         decision_id = trade_dict.get('decision_id', f"dec_{trade_id}")
@@ -779,7 +780,7 @@ def close_position(symbol: str):
             ).fetchone()
             if price_row and price_row["current_price"]:
                 sell_price = float(price_row["current_price"])
-        except Exception:
+        except sqlite3.Error:
             pass
 
         if sell_price <= 0:
@@ -919,7 +920,7 @@ def close_position(symbol: str):
                 on_sell_filled(conn, symbol=symbol, qty=f["qty"],
                                sell_price=f["price"], fee=f["fee"], tax=f["tax"])
             sync_positions_table(conn)
-        except Exception:
+        except Exception:  # noqa: BLE001 — dynamic import; can't predict exceptions
             pass  # non-critical
 
     return {
@@ -989,7 +990,7 @@ def get_quote_snapshot(symbol: str):
                     "bid_price": bid1, "ask_price": ask1,
                 },
             }
-    except Exception:
+    except Exception:  # noqa: BLE001 — broker API; can't predict exceptions
         pass
     # Fallback: last EOD close from eod_prices
     try:
@@ -1010,7 +1011,7 @@ def get_quote_snapshot(symbol: str):
                         "trade_date": row["trade_date"],
                     },
                 }
-    except Exception:
+    except sqlite3.Error:
         pass
     return {"status": "ok", "symbol": symbol, "source": "closed", "data": None}
 
@@ -1032,7 +1033,7 @@ async def get_quote_stream(symbol: str, request: Request):
         try:
             api = _get_api(simulation=True)
             quote_service.subscribe(symbol, queue, loop, api)
-        except Exception:
+        except Exception:  # noqa: BLE001 — broker API; can't predict exceptions
             pass  # Market closed or Shioaji unavailable
 
         try:

--- a/frontend/backend/app/api/reports.py
+++ b/frontend/backend/app/api/reports.py
@@ -36,7 +36,7 @@ def conn_dep():
             yield conn
     except HTTPException:
         raise
-    except Exception as e:
+    except (sqlite3.Error, OSError) as e:
         raise HTTPException(status_code=500, detail=f"DB error: {e}")
 
 
@@ -46,7 +46,7 @@ def _read_portfolio_json() -> List[Dict[str, Any]]:
         with open(_PORTFOLIO_JSON, "r") as f:
             data = json.load(f)
         return data.get("holdings", [])
-    except Exception:
+    except (OSError, ValueError):
         return []
 
 
@@ -98,7 +98,7 @@ def _get_sim_positions(conn: sqlite3.Connection) -> List[Dict[str, Any]]:
             }
             for r in rows
         ]
-    except Exception:
+    except sqlite3.Error:
         return []
 
 
@@ -119,7 +119,7 @@ def _get_recent_trades(conn: sqlite3.Connection, days: int = 7) -> List[Dict[str
             (cutoff,),
         ).fetchall()
         return [dict(r) for r in rows]
-    except Exception:
+    except sqlite3.Error:
         return []
 
 
@@ -169,7 +169,7 @@ def _get_technical_indicators(
                 "macd_signal": _last_valid(signal_line),
                 "macd_histogram": _last_valid(histogram),
             }
-        except Exception:
+        except (sqlite3.Error, ValueError, IndexError, TypeError):
             continue
     return result
 
@@ -209,7 +209,7 @@ def _get_institution_summary(
                 "short_balance": r["short_balance"],
             }
         result["_trade_date"] = latest_date
-    except Exception:
+    except sqlite3.Error:
         pass
     return result
 
@@ -231,7 +231,7 @@ def _get_latest_eod_analysis(conn: sqlite3.Connection) -> Optional[Dict[str, Any
                 except (json.JSONDecodeError, TypeError):
                     pass
         return d
-    except Exception:
+    except sqlite3.Error:
         return None
 
 
@@ -279,7 +279,7 @@ def get_report_context(
         )
         with open(state_path) as f:
             system_state = json.load(f)
-    except Exception:
+    except (OSError, ValueError):
         pass
 
     return {

--- a/frontend/backend/tests/test_reports_api.py
+++ b/frontend/backend/tests/test_reports_api.py
@@ -323,7 +323,7 @@ def test_reports_context_db_error_returns_500(tmp_path, monkeypatch):
 
     @contextmanager
     def broken_conn():
-        raise RuntimeError("simulated DB failure")
+        raise sqlite3.OperationalError("simulated DB failure")
         yield  # noqa: unreachable
 
     monkeypatch.setattr(db_mod, "get_conn", broken_conn)

--- a/src/openclaw/broker_reconciliation.py
+++ b/src/openclaw/broker_reconciliation.py
@@ -199,7 +199,7 @@ def _insert_reconciliation_incident_best_effort(
     for row in rows:
         try:
             payload = json.loads(row[0] or "{}")
-        except Exception:
+        except json.JSONDecodeError:
             continue
         if payload.get("stable_detail") == stable_detail:
             return

--- a/src/openclaw/concentration_guard.py
+++ b/src/openclaw/concentration_guard.py
@@ -56,7 +56,7 @@ def check_concentration(
                 "SELECT DISTINCT symbol FROM orders WHERE side='sell' AND status='submitted'"
             ).fetchall()
         }
-    except Exception as e:
+    except sqlite3.Error as e:
         log.error("Dedup query failed, proceeding WITHOUT dedup — "
                   "duplicate proposals may be generated: %s", e)
         pending_symbols = set()

--- a/src/openclaw/proposal_executor.py
+++ b/src/openclaw/proposal_executor.py
@@ -220,7 +220,7 @@ def execute_pending_proposals(conn: sqlite3.Connection) -> tuple[list[SellIntent
                 conn.commit()
                 n_noted += 1
 
-        except Exception as e:
+        except (json.JSONDecodeError, sqlite3.Error, ValueError, TypeError) as e:
             log.error("Error processing proposal %s: %s", proposal_id, e, exc_info=True)
 
     return intents, n_noted

--- a/src/openclaw/risk_engine.py
+++ b/src/openclaw/risk_engine.py
@@ -25,10 +25,7 @@ def _is_symbol_locked(symbol: str) -> bool:
     except json.JSONDecodeError as e:
         logger.warning("Corrupted config file: %s — %s", _LOCKED_SYMBOLS_PATH, e)
         return False
-    except PermissionError:
-        logger.error("Permission denied reading: %s", _LOCKED_SYMBOLS_PATH)
-        return False
-    except Exception as e:
+    except OSError as e:
         logger.warning("Unexpected error reading %s: %s", _LOCKED_SYMBOLS_PATH, e)
         return False
 
@@ -49,10 +46,7 @@ def _get_daily_pm_approval() -> bool:
     except json.JSONDecodeError as e:
         logger.warning("Corrupted config file: %s — %s", _DAILY_PM_PATH, e)
         return False
-    except PermissionError:
-        logger.error("Permission denied reading: %s", _DAILY_PM_PATH)
-        return False
-    except Exception as e:
+    except OSError as e:
         logger.warning("Unexpected error reading %s: %s", _DAILY_PM_PATH, e)
         return False
 
@@ -182,7 +176,7 @@ def _build_candidate(decision: Decision, market: MarketState, portfolio: Portfol
         authority_level = limits.get("authority_level")
         try:
             authority_level = int(authority_level) if authority_level is not None else None
-        except Exception:
+        except (TypeError, ValueError):
             authority_level = None
 
         qty = calculate_position_qty(
@@ -260,7 +254,8 @@ def evaluate_and_build_order(
                 "correlation_guard_reason": limits.get("correlation_guard_reason"),
                 "correlation_guard_scale": limits.get("correlation_guard_scale"),
             })
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — optional plugin; must not crash main pipeline
+            logger.warning("[risk_engine] correlation_guard raised: %s", e)
             base_metrics["correlation_guard_error"] = str(e)
 
 

--- a/src/openclaw/risk_engine.py
+++ b/src/openclaw/risk_engine.py
@@ -26,7 +26,7 @@ def _is_symbol_locked(symbol: str) -> bool:
         logger.warning("Corrupted config file: %s — %s", _LOCKED_SYMBOLS_PATH, e)
         return False
     except OSError as e:
-        logger.warning("Unexpected error reading %s: %s", _LOCKED_SYMBOLS_PATH, e)
+        logger.error("OS error reading %s: %s", _LOCKED_SYMBOLS_PATH, e)
         return False
 
 

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -407,7 +407,7 @@ def _log_trace(conn: sqlite3.Connection, *, symbol: str, signal: str, snap: dict
     )
     try:
         insert_llm_trace(conn, trace, auto_commit=True)
-    except sqlite3.Error as e:
+    except Exception as e:  # noqa: BLE001 — log utility; must never crash caller
         log.warning("insert_llm_trace failed: %s", e)
 
 
@@ -426,7 +426,7 @@ def _log_screen_trace(conn: sqlite3.Connection, *, universe: List[str], active: 
     )
     try:
         insert_llm_trace(conn, trace, auto_commit=True)
-    except sqlite3.Error as e:
+    except Exception as e:  # noqa: BLE001 — log utility; must never crash caller
         log.warning("_log_screen_trace failed: %s", e)
 
 

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -219,7 +219,7 @@ def _load_manual_watchlist() -> List[str]:
         if not result:
             raise ValueError("manual_watchlist is empty")
         return result
-    except Exception as e:
+    except (OSError, ValueError) as e:
         log.warning("watchlist.json read failed (%s) — using fallback %s", e, _FALLBACK_UNIVERSE)
         return list(_FALLBACK_UNIVERSE)
 
@@ -244,7 +244,7 @@ def _get_snapshot(api, symbol: str) -> dict:
                 vol   = int(getattr(s, "volume", 1000) or 1000)
                 if close > 0:
                     return {"close": close, "bid": bid, "ask": ask, "reference": ref, "volume": vol}
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — broker API; can't predict exceptions
             log.warning("Shioaji snapshot [%s]: %s — using mock", symbol, e)
 
     # Mock: small random walk around base price
@@ -407,7 +407,7 @@ def _log_trace(conn: sqlite3.Connection, *, symbol: str, signal: str, snap: dict
     )
     try:
         insert_llm_trace(conn, trace, auto_commit=True)
-    except Exception as e:
+    except sqlite3.Error as e:
         log.warning("insert_llm_trace failed: %s", e)
 
 
@@ -426,7 +426,7 @@ def _log_screen_trace(conn: sqlite3.Connection, *, universe: List[str], active: 
     )
     try:
         insert_llm_trace(conn, trace, auto_commit=True)
-    except Exception as e:
+    except sqlite3.Error as e:
         log.warning("_log_screen_trace failed: %s", e)
 
 
@@ -594,10 +594,10 @@ def run_watcher() -> None:
             try:
                 api.fetch_contracts()
                 log.info("Shioaji contracts fetched (simulation=True)")
-            except Exception as fe:
+            except Exception as fe:  # noqa: BLE001 — broker API; can't predict exceptions
                 log.warning("fetch_contracts failed (%s) — snapshots may use fallback", fe)
             log.info("Shioaji connected (simulation=%s) — using real market data", simulation)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — broker API; can't predict exceptions
             log.warning("Shioaji not available — mock data mode: %s", e)
 
     # 內存持倉追蹤：symbol → (qty, avg_price)（watcher 重啟後清空，從 DB sync）
@@ -619,7 +619,7 @@ def run_watcher() -> None:
         _conn_init.close()
         if positions:
             log.info("Restored %d positions from DB: %s", len(positions), list(positions.keys()))
-    except Exception as _e:
+    except sqlite3.Error as _e:
         log.warning("Could not restore positions from DB: %s", _e)
 
     # 每日重新篩選 watchlist
@@ -643,7 +643,7 @@ def run_watcher() -> None:
                 if n_cb > 0:
                     log.info("[tg_approver] Off-hours: processed %d callbacks", n_cb)
                 _conn.close()
-            except Exception as _tge:
+            except Exception as _tge:  # noqa: BLE001 — dynamic import + Telegram API
                 log.debug("[tg_approver] off-hours error: %s", _tge)
             time.sleep(60)
             continue
@@ -661,7 +661,7 @@ def run_watcher() -> None:
                     sys_candidates = load_system_candidates(_conn_sc)
                 finally:
                     _conn_sc.close()
-            except Exception as _sc_e:
+            except Exception as _sc_e:  # noqa: BLE001 — dynamic import; can't predict exceptions
                 log.warning("[SCREEN] load_system_candidates failed: %s", _sc_e)
             active_watchlist = list(dict.fromkeys(manual_watchlist + sys_candidates))
             log.info("[SCREEN] New day %s — manual=%d + system=%d → active=%d: %s",
@@ -687,7 +687,7 @@ def run_watcher() -> None:
                 limits = load_limits(conn, LimitQuery(strategy_id=STRATEGY_ID))
                 if not limits:
                     limits = default_limits()
-            except Exception as e:
+            except sqlite3.Error as e:
                 log.warning("load_limits failed (%s) — using defaults", e)
                 limits = default_limits()
 
@@ -709,7 +709,7 @@ def run_watcher() -> None:
                     n_tg = notify_pending_proposals(conn)
                     if n_tg > 0:
                         log.info("[tg_approver] Sent %d proposal notifications (PM not approved)", n_tg)
-                except Exception as _tge:
+                except Exception as _tge:  # noqa: BLE001 — dynamic import + Telegram API
                     log.debug("[tg_approver] error: %s", _tge)
                 conn.close()
                 time.sleep(POLL_INTERVAL_SEC)
@@ -756,7 +756,7 @@ def run_watcher() -> None:
             try:
                 from openclaw.risk_engine import _is_symbol_locked
                 _locked_syms = {s for s in positions if _is_symbol_locked(s)}
-            except Exception:
+            except (ImportError, OSError, ValueError):
                 pass
 
             for _exit_sym, (_exit_qty, _exit_avg) in list(positions.items()):
@@ -842,16 +842,16 @@ def run_watcher() -> None:
                                 sell_tax=float(_fill_row[1]),
                                 trade_date=_trade_date,
                             )
-                        except Exception as _pnl_err:
+                        except (sqlite3.Error, ValueError, ArithmeticError) as _pnl_err:
                             log.warning("[%s] pnl_engine error: %s", _exit_sym, _pnl_err)
                         positions.pop(_exit_sym, None)
                         high_water_marks.pop(_exit_sym, None)
                         log.info("[%s] SELL executed: reason=%s", _exit_sym, _exit_sig.reason)
-                except Exception as _sell_err:
+                except Exception as _sell_err:  # noqa: BLE001 — Shioaji broker API; can't predict exceptions
                     log.error("[%s] sell execution error: %s", _exit_sym, _sell_err, exc_info=True)
                     try:
                         conn.execute("ROLLBACK")
-                    except Exception:
+                    except Exception:  # noqa: BLE001 — rollback guard; must not raise
                         pass
 
             for symbol in active_watchlist:
@@ -874,7 +874,7 @@ def run_watcher() -> None:
                 try:
                     from openclaw.trading_engine import tick as _te_tick
                     _te_tick(conn, symbol)
-                except Exception as _te_err:
+                except Exception as _te_err:  # noqa: BLE001 — dynamic import; can't predict exceptions
                     log.warning("[%s] trading_engine.tick 失敗：%s", symbol, _te_err)
 
                 _agg_meta: dict = {}
@@ -893,7 +893,7 @@ def run_watcher() -> None:
                         "weights": _agg_signal.weights_used,
                         "reasons": _agg_signal.reasons,
                     }
-                except Exception as _agg_err:
+                except Exception as _agg_err:  # noqa: BLE001 — dynamic import; can't predict exceptions
                     log.warning("[%s] signal_aggregator 失敗 (%s), fallback to signal_generator",
                                 symbol, _agg_err)
                     from openclaw.signal_generator import compute_signal as _sg_compute
@@ -960,11 +960,11 @@ def run_watcher() -> None:
                         _persist_risk_check(conn, decision_id=decision_id, passed=False,
                                             reject_code=result.reject_code, metrics=result.metrics)
                         conn.commit()
-                    except Exception as e:
+                    except sqlite3.Error as e:
                         log.debug("persist rejected decision failed: %s", e)
                         try:
                             conn.execute("ROLLBACK")
-                        except Exception:
+                        except Exception:  # noqa: BLE001 — rollback guard; must not raise
                             pass
                     continue
 
@@ -1020,7 +1020,7 @@ def run_watcher() -> None:
                                     trade_date=trade_date,
                                 )
                                 log.info("[%s] realized_pnl=%.2f written to daily_pnl_summary", symbol, pnl)
-                            except Exception as pnl_err:
+                            except (sqlite3.Error, ValueError, ArithmeticError) as pnl_err:
                                 log.warning("[%s] pnl_engine error: %s", symbol, pnl_err)
                             positions.pop(symbol, None)
                             log.info("[%s] position closed — removed from in-memory map", symbol)
@@ -1028,13 +1028,13 @@ def run_watcher() -> None:
                         # Sync positions table after every fill
                         try:
                             sync_positions_table(conn)
-                        except Exception as sync_err:
+                        except sqlite3.Error as sync_err:
                             log.warning("sync_positions_table error: %s", sync_err)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 — Shioaji broker API; can't predict exceptions
                     log.error("[%s] order execution error: %s", symbol, e, exc_info=True)
                     try:
                         conn.execute("ROLLBACK")
-                    except Exception:
+                    except Exception:  # noqa: BLE001 — rollback guard; must not raise
                         pass
 
             # ── 每輪掃盤後：執行 approved proposals + 集中度守衛 ─────────────
@@ -1075,7 +1075,7 @@ def run_watcher() -> None:
                                     execution_key=intent.execution_key,
                                     order_id=_oid,
                                 )
-                            except Exception as mark_err:
+                            except sqlite3.Error as mark_err:
                                 log.critical("[proposals] BROKER EXECUTED sell %s %d shares but "
                                              "failed to mark proposal %s as executed — "
                                              "RISK OF DUPLICATE EXECUTION: %s",
@@ -1092,7 +1092,7 @@ def run_watcher() -> None:
                                 order_id=_oid,
                             )
                             log.warning("[proposals] Broker rejected rebalance sell %s → marked failed", intent.symbol)
-                    except Exception as intent_err:
+                    except Exception as intent_err:  # noqa: BLE001 — per-intent guard; Shioaji may raise anything
                         mark_intent_failed(
                             conn,
                             intent.proposal_id,
@@ -1103,11 +1103,11 @@ def run_watcher() -> None:
                                   intent.symbol, intent_err, exc_info=True)
                         try:
                             conn.execute("ROLLBACK")
-                        except Exception as rb_err:
+                        except Exception as rb_err:  # noqa: BLE001 — rollback guard; must not raise
                             log.error("[proposals] ROLLBACK failed — DB state may be inconsistent: %s", rb_err)
                 if sell_intents or n_noted:
                     log.info("[proposals] Processed %d sell intents, %d noted", len(sell_intents), n_noted)
-            except Exception as pe:
+            except Exception as pe:  # noqa: BLE001 — dynamic import + multi-step pipeline
                 log.error("[proposals] executor error: %s", pe, exc_info=True)
 
             try:
@@ -1115,7 +1115,7 @@ def run_watcher() -> None:
                 c_proposals = check_concentration(conn)
                 if c_proposals:
                     log.info("[concentration] Generated %d concentration proposals", len(c_proposals))
-            except Exception as ce:
+            except Exception as ce:  # noqa: BLE001 — dynamic import; can't predict exceptions
                 log.error("[concentration] guard error: %s", ce, exc_info=True)
 
             # ── Gemini 自動審查 pending proposals → 核准/拒絕 + Telegram 通知 ──
@@ -1124,7 +1124,7 @@ def run_watcher() -> None:
                 n_reviewed = auto_review_pending_proposals(conn)
                 if n_reviewed > 0:
                     log.info("[reviewer] Auto-reviewed %d pending proposals", n_reviewed)
-            except Exception as rv:
+            except Exception as rv:  # noqa: BLE001 — dynamic import + Gemini API
                 log.error("[reviewer] proposal reviewer error: %s", rv, exc_info=True)
 
             # ── Telegram 提案通知 + 老闆 inline 核准 ──────────────────────────
@@ -1136,15 +1136,15 @@ def run_watcher() -> None:
                 n_cb = poll_approval_callbacks(conn)
                 if n_cb > 0:
                     log.info("[tg_approver] Processed %d approval callbacks", n_cb)
-            except Exception as _ta:
+            except Exception as _ta:  # noqa: BLE001 — dynamic import + Telegram API
                 log.warning("[tg_approver] error: %s", _ta)
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — outer scan cycle guard; must catch all
             log.error("Scan cycle error: %s", e, exc_info=True)
         finally:
             try:
                 conn.close()
-            except Exception:
+            except sqlite3.Error:
                 pass
 
         log.info("=== Scan done. Sleeping %ds ===", POLL_INTERVAL_SEC)

--- a/src/openclaw/trading_engine.py
+++ b/src/openclaw/trading_engine.py
@@ -170,6 +170,7 @@ def tick(conn: sqlite3.Connection, symbol: str) -> None:
                 (symbol,),
             )
             conn.execute("COMMIT")
-        except Exception:
+        except Exception:  # noqa: BLE001 — rollback guard; must catch all to ensure atomicity
+            log.exception("[trading_engine] transaction failed for %s; rolling back", symbol)
             conn.execute("ROLLBACK")
             raise


### PR DESCRIPTION
## Summary

- Replace `except Exception` with specific types across 8 highest-impact files in the trading pipeline, so programming errors (AttributeError, NameError, etc.) propagate instead of being silently swallowed
- Categorized each broad catch: narrowed where exception type is known; added `# noqa: BLE001` with justification for legitimate broad catches (broker APIs, dynamic imports, rollback guards)
- Fixed `test_reports_api` to raise `sqlite3.OperationalError` instead of `RuntimeError` when simulating DB failure — now matches what production actually raises

## Files changed

| File | Before | After | Notes |
|------|--------|-------|-------|
| `concentration_guard.py` | 1 | 0 | `sqlite3.Error` |
| `broker_reconciliation.py` | 1 | 0 | `json.JSONDecodeError` |
| `risk_engine.py` | 4 | 1 | `OSError`, `(TypeError, ValueError)`; 1 noqa (correlation plugin) |
| `trading_engine.py` | 1 | 1 | rollback guard kept broad + `log.exception()` added |
| `proposal_executor.py` | 1 | 0 | `(json.JSONDecodeError, sqlite3.Error, ValueError, TypeError)` |
| `reports.py` | 8 | 0 | `sqlite3.Error` for DB; `(OSError, ValueError)` for files |
| `portfolio.py` | 21 | 5 | 16 narrowed; 5 noqa (Shioaji/dynamic import) |
| `ticker_watcher.py` | 32 | 20 | 12 narrowed; 20 noqa (Shioaji/Gemini/Telegram/rollbacks) |

## Test plan

- [x] All 420 core engine tests pass (`pytest tests/ --ignore=tests/test_property_based.py --ignore=tests/test_ticker_watcher_live.py --ignore=tests/test_regressions.py`)
- [x] All 578 FastAPI backend tests pass (`cd frontend/backend && python -m pytest tests/ -q`)
- [x] Fixed `test_reports_context_db_error_returns_500` to use realistic exception type

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)