### PR TITLE
fix(eod-analysis): 加入盤後報告股價驗證審查關卡 #231

### DIFF
--- a/src/openclaw/agents/eod_analysis.py
+++ b/src/openclaw/agents/eod_analysis.py
@@ -85,6 +85,65 @@ def _ensure_table(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+_ANOMALY_THRESHOLD = 0.15  # 15% 單日漲跌幅視為異常
+
+
+def _validate_position_prices(
+    conn: sqlite3.Connection,
+    symbols: list,
+    trade_date: str,
+) -> dict:
+    """驗證持倉股票是否有當日 EOD 價格，並偵測異常漲跌幅。
+
+    Returns:
+        {
+            "missing_symbols": [...],     # 當日無收盤價的持倉
+            "anomaly_symbols": [...],     # 漲跌幅超過閾值的持倉
+            "is_valid": bool,             # 所有持倉均有當日價格
+            "details": {symbol: {...}},   # 每檔詳細資訊
+        }
+    """
+    if not symbols:
+        return {"missing_symbols": [], "anomaly_symbols": [], "is_valid": True, "details": {}}
+
+    placeholders = ",".join("?" for _ in symbols)
+    rows = conn.execute(
+        f"SELECT symbol, close, change FROM eod_prices "
+        f"WHERE trade_date=? AND symbol IN ({placeholders})",
+        [trade_date] + list(symbols),
+    ).fetchall()
+
+    found = {r[0]: {"close": r[1], "change": r[2]} for r in rows}
+    missing = [s for s in symbols if s not in found]
+    anomalies = []
+    details = {}
+
+    for sym, data in found.items():
+        close = data["close"]
+        change = data["change"]
+        is_anomaly = False
+        if close and change is not None:
+            pct = abs(change / (close - change)) if (close - change) != 0 else 0.0
+            is_anomaly = pct >= _ANOMALY_THRESHOLD
+            if is_anomaly:
+                anomalies.append(sym)
+        details[sym] = {
+            "close": close,
+            "change": change,
+            "is_anomaly": is_anomaly,
+        }
+
+    for sym in missing:
+        details[sym] = {"close": None, "change": None, "is_anomaly": False}
+
+    return {
+        "missing_symbols": missing,
+        "anomaly_symbols": anomalies,
+        "is_valid": len(missing) == 0,
+        "details": details,
+    }
+
+
 def _calc_symbol_indicators(
     conn: sqlite3.Connection,
     symbol: str,
@@ -246,13 +305,41 @@ def run_eod_analysis(
             if indicators:
                 technical[sym] = indicators
 
+        # 3.5 審查關卡：驗證持倉股票是否有當日 EOD 價格
+        price_validation = _validate_position_prices(_conn, pos_symbols, _date)
+        if price_validation["missing_symbols"]:
+            log.warning(
+                "[eod_analysis] 持倉缺少當日收盤價 (trade_date=%s): %s",
+                _date,
+                price_validation["missing_symbols"],
+            )
+        if price_validation["anomaly_symbols"]:
+            log.warning(
+                "[eod_analysis] 持倉異常漲跌幅 >=%.0f%% (trade_date=%s): %s",
+                _ANOMALY_THRESHOLD * 100,
+                _date,
+                price_validation["anomaly_symbols"],
+            )
+
         # 4. 組 Prompt
+        validation_note = ""
+        if price_validation["missing_symbols"]:
+            validation_note += (
+                f"\n⚠️ 注意：以下持倉在 {_date} 無 EOD 收盤價，技術指標可能使用前日數據：{price_validation['missing_symbols']}\n"
+            )
+        if price_validation["anomaly_symbols"]:
+            validation_note += (
+                f"\n⚠️ 注意：以下持倉漲跌幅超過 {int(_ANOMALY_THRESHOLD * 100)}%，請確認資料正確性：{price_validation['anomaly_symbols']}\n"
+            )
+
         prompt = _PROMPT_TEMPLATE.format(
             trade_date=_date,
             market_overview=json.dumps(top_movers, ensure_ascii=False, indent=2),
             institution_data=json.dumps(institution_data, ensure_ascii=False, indent=2) or "（無三大法人資料）",
             technical_summary=json.dumps(technical, ensure_ascii=False, indent=2),
         )
+        if validation_note:
+            prompt = validation_note + prompt
 
         # 5. 呼叫 Gemini
         result_dict = call_agent_llm(prompt, model=DEFAULT_MODEL)
@@ -301,7 +388,7 @@ def run_eod_analysis(
             confidence=float(result_dict.get("confidence", 0.7)),
             action_type=str(result_dict.get("action_type", "suggest")),
             proposals=result_dict.get("proposals", []),
-            raw=result_dict,
+            raw={**result_dict, "price_validation": price_validation},
         )
     finally:
         if conn is None:

--- a/src/tests/agents/test_eod_analysis.py
+++ b/src/tests/agents/test_eod_analysis.py
@@ -2,7 +2,7 @@ import json
 import sqlite3
 from datetime import date, timedelta
 import pytest
-from openclaw.agents.eod_analysis import run_eod_analysis
+from openclaw.agents.eod_analysis import run_eod_analysis, _validate_position_prices
 
 
 @pytest.fixture
@@ -166,6 +166,85 @@ def test_last_helper_returns_none_when_all_indicators_are_none(mem_db, monkeypat
     assert technical["8888"]["ma5"] is None
     assert technical["8888"]["ma20"] is None
     assert technical["8888"]["ma60"] is None
+
+
+# ── _validate_position_prices 單元測試 ─────────────────────────────────────
+
+def test_validate_all_prices_present(mem_db):
+    """所有持倉有當日收盤價、無異常漲跌 → is_valid=True, 無缺失/異常。"""
+    result = _validate_position_prices(mem_db, ["2330"], "2026-01-28")
+    assert result["is_valid"] is True
+    assert result["missing_symbols"] == []
+    assert result["anomaly_symbols"] == []
+    assert "2330" in result["details"]
+    assert result["details"]["2330"]["close"] == pytest.approx(559.0)
+
+
+def test_validate_missing_symbols(mem_db):
+    """持倉股票無當日 EOD 記錄 → is_valid=False, missing_symbols 包含缺失標的。"""
+    result = _validate_position_prices(mem_db, ["2330", "9999"], "2026-01-28")
+    assert result["is_valid"] is False
+    assert "9999" in result["missing_symbols"]
+    assert "2330" not in result["missing_symbols"]
+
+
+def test_validate_anomaly_detection(mem_db):
+    """單日漲跌幅 >= 15% 應被標記為異常。"""
+    # 插入一筆：收盤 100，漲跌 +20 → prev_close=80 → pct=25% > 15%
+    mem_db.execute(
+        "INSERT INTO eod_prices VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        ("2026-01-28", "TWSE", "7777", "測試異常股",
+         100.0, 20.0, 98.0, 102.0, 97.0,
+         500000.0, 50000000.0, 1000.0, "http://test", "2026-01-28"),
+    )
+    mem_db.commit()
+
+    result = _validate_position_prices(mem_db, ["7777"], "2026-01-28")
+    assert "7777" in result["anomaly_symbols"]
+    assert result["details"]["7777"]["is_anomaly"] is True
+
+
+def test_validate_no_anomaly_for_normal_change(mem_db):
+    """單日漲跌幅 < 15% 不應標記為異常。"""
+    # 插入一筆：收盤 100，漲跌 +5 → prev_close=95 → pct≈5.3%
+    mem_db.execute(
+        "INSERT INTO eod_prices VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        ("2026-01-28", "TWSE", "6666", "正常漲幅股",
+         100.0, 5.0, 99.0, 101.0, 98.0,
+         500000.0, 50000000.0, 1000.0, "http://test", "2026-01-28"),
+    )
+    mem_db.commit()
+
+    result = _validate_position_prices(mem_db, ["6666"], "2026-01-28")
+    assert "6666" not in result["anomaly_symbols"]
+    assert result["details"]["6666"]["is_anomaly"] is False
+
+
+def test_validate_empty_symbols(mem_db):
+    """傳入空清單應直接回傳 is_valid=True。"""
+    result = _validate_position_prices(mem_db, [], "2026-01-28")
+    assert result["is_valid"] is True
+    assert result["missing_symbols"] == []
+
+
+def test_run_eod_analysis_price_validation_in_result(mem_db, monkeypatch):
+    """run_eod_analysis 成功時，raw 應包含 price_validation 欄位。"""
+    monkeypatch.setattr(
+        "openclaw.agents.eod_analysis.call_agent_llm",
+        lambda p, model=None: {
+            "summary": "ok", "confidence": 0.8, "action_type": "suggest",
+            "proposals": [], "market_outlook": {},
+        },
+    )
+    monkeypatch.setattr("openclaw.agents.eod_analysis.write_trace", lambda *a, **k: None)
+
+    result = run_eod_analysis(trade_date="2026-01-28", conn=mem_db)
+    assert result.success is True
+    assert "price_validation" in result.raw
+    pv = result.raw["price_validation"]
+    assert "is_valid" in pv
+    assert "missing_symbols" in pv
+    assert "anomaly_symbols" in pv
 
 
 def test_run_eod_analysis_closes_own_connection_when_no_conn_passed(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- 新增 `_validate_position_prices()` 函式：在 EOD 報告生成前驗證持倉股票是否有當日收盤價
- 偵測異常漲跌幅（>= 15%，防止資料錯誤影響 LLM 分析）
- 驗證警告注入 LLM Prompt，提醒模型數據可能不完整
- 驗證結果附加至 `AgentResult.raw["price_validation"]` 供下游使用

## 問題根因 (Issue #231)
盤後分析 Agent 在調用 Gemini LLM 前沒有任何股價驗證關卡。若某持倉當日沒有 EOD 價格（停牌、資料抓取失敗），技術指標會靜默使用舊數據，LLM 以為是最新數據分析，導致時間錯位（與 Issue #205 同一病因）。

## Test Plan
- [x] `test_validate_all_prices_present` — 正常情況全通過
- [x] `test_validate_missing_symbols` — 缺失標的正確識別
- [x] `test_validate_anomaly_detection` — 25% 漲幅正確標記為異常
- [x] `test_validate_no_anomaly_for_normal_change` — 5% 漲幅不誤報
- [x] `test_validate_empty_symbols` — 空清單不崩潰
- [x] `test_run_eod_analysis_price_validation_in_result` — 整合驗證結果欄位
- [x] 全部 1990 個核心測試通過

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)