### PR TITLE
fix(tests): correct BACKEND_ROOT to frontend/backend/ — fixes CI ModuleNotFoundError

### DIFF
--- a/frontend/backend/tests/conftest.py
+++ b/frontend/backend/tests/conftest.py
@@ -7,10 +7,12 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
-from openclaw.path_utils import get_repo_root
 
 # Ensure `import app.*` works no matter where pytest rootdir is.
-BACKEND_ROOT = get_repo_root()
+# Use __file__ to locate frontend/backend/ directly — get_repo_root() returns
+# the repo root, not frontend/backend/, so `import app` would fail in CI where
+# pytest does not automatically add cwd to sys.path.
+BACKEND_ROOT = Path(__file__).resolve().parent.parent  # .../frontend/backend/
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 


### PR DESCRIPTION
## Summary

- `frontend/backend/tests/conftest.py` was using `get_repo_root()` to set `BACKEND_ROOT`, but `get_repo_root()` returns the **repo root**, not `frontend/backend/`
- In CI, `pytest -q tests/` runs without `python -m`, so cwd is NOT automatically added to `sys.path`
- `import app` failed because `frontend/backend/` was never in `sys.path`
- Fix: use `Path(__file__).resolve().parent.parent` to reliably compute `frontend/backend/`

## Root Cause Chain

```
CI: pytest -q tests/ (working-directory: frontend/backend)
  → repo root pytest.ini: pythonpath = src  (adds <repo>/src, NOT frontend/backend/)
  → conftest.py: sys.path.insert(0, get_repo_root())  (adds repo root, NOT frontend/backend/)
  → import app  ← ModuleNotFoundError: No module named 'app'
```

## Test plan

- [x] `578 passed` locally with `.venv/bin/pytest tests/` from `frontend/backend/`
- [x] Unblocks PR #238 and PR #239 (same pre-existing CI failure)

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)