### PR TITLE
fix(tests): use sqlite3.OperationalError in shutdown test mock — fixes #243

### DIFF
--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,5 +1,6 @@
 """Tests for ticker_watcher graceful shutdown (Issue #237)."""
 import signal
+import sqlite3
 import time
 import types
 import unittest.mock as mock
@@ -84,7 +85,7 @@ def test_loop_exits_when_shutdown_requested(monkeypatch):
         "openclaw.risk_store": mock.MagicMock(),
         "openclaw.daily_pm_review": mock.MagicMock(),
     }):
-        with mock.patch("openclaw.ticker_watcher._open_conn", side_effect=Exception("no db")):
+        with mock.patch("openclaw.ticker_watcher._open_conn", side_effect=sqlite3.OperationalError("no db")):
             with mock.patch("openclaw.ticker_watcher._load_manual_watchlist", return_value=[]):
                 tw.run_watcher()
 


### PR DESCRIPTION
## Summary

- `test_loop_exits_when_shutdown_requested` was using `side_effect=Exception("no db")` in its `_open_conn` mock
- PR #239 (#216 narrow-except) changed the handler from `except Exception` to `except sqlite3.Error`
- Plain `Exception` is not a `sqlite3.Error` subclass → exception propagated → test failed
- Fix: use `sqlite3.OperationalError("no db")` which IS a `sqlite3.Error` subclass

## Test plan

- [x] `tests/test_graceful_shutdown.py` — 7 passed
- [x] Unblocks PR #240 CI

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)