### PR TITLE
feat(reports): add committee_outlook to report context API [#198]

### DIFF
--- a/frontend/backend/app/api/reports.py
+++ b/frontend/backend/app/api/reports.py
@@ -214,6 +214,55 @@ def _get_institution_summary(
     return result
 
 
+def _get_committee_outlook(conn: sqlite3.Connection) -> Optional[Dict[str, Any]]:
+    """Latest strategy_committee proposal within the last 24 hours.
+
+    Extracts bull_thesis / bear_thesis / arbiter_stance from committee_context
+    stored in proposal_json. Returns None gracefully if no data or any error.
+    """
+    try:
+        cutoff_ms = int(
+            (datetime.now(timezone.utc) - timedelta(hours=24)).timestamp() * 1000
+        )
+        row = conn.execute(
+            """SELECT proposal_id, proposal_json, confidence, created_at
+               FROM strategy_proposals
+               WHERE generated_by = 'strategy_committee'
+                 AND created_at >= ?
+               ORDER BY created_at DESC
+               LIMIT 1""",
+            (cutoff_ms,),
+        ).fetchone()
+        if not row:
+            return None
+
+        proposal_json_raw = row["proposal_json"]
+        if not proposal_json_raw:
+            return None
+
+        try:
+            pj = json.loads(proposal_json_raw) if isinstance(proposal_json_raw, str) else proposal_json_raw
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+        ctx = pj.get("committee_context", {}) if isinstance(pj, dict) else {}
+        bull = ctx.get("bull", {}) if isinstance(ctx, dict) else {}
+        bear = ctx.get("bear", {}) if isinstance(ctx, dict) else {}
+        arbiter = ctx.get("arbiter", {}) if isinstance(ctx, dict) else {}
+
+        return {
+            "proposal_id": row["proposal_id"],
+            "created_at": row["created_at"],
+            "bull_thesis": bull.get("thesis") if isinstance(bull, dict) else None,
+            "bear_thesis": bear.get("thesis") if isinstance(bear, dict) else None,
+            "arbiter_stance": arbiter.get("stance") if isinstance(arbiter, dict) else None,
+            "arbiter_summary": arbiter.get("summary") if isinstance(arbiter, dict) else None,
+            "confidence": float(row["confidence"]) if row["confidence"] is not None else None,
+        }
+    except sqlite3.Error:
+        return None
+
+
 def _get_latest_eod_analysis(conn: sqlite3.Connection) -> Optional[Dict[str, Any]]:
     """Latest EOD analysis report."""
     try:
@@ -271,7 +320,10 @@ def get_report_context(
     # 7. Latest EOD analysis
     eod_analysis = _get_latest_eod_analysis(conn)
 
-    # 8. System state
+    # 8. Committee outlook (last 24h, morning/evening only)
+    committee_outlook = _get_committee_outlook(conn) if type in ("morning", "evening") else None
+
+    # 10. System state
     system_state = None
     try:
         state_path = os.path.join(
@@ -300,6 +352,7 @@ def get_report_context(
         "institution_chips": chips,
         "recent_trades": recent_trades,
         "eod_analysis": eod_analysis,
+        "committee_outlook": committee_outlook,
         "system_state": {
             "simulation_mode": system_state.get("simulation_mode", True) if system_state else True,
             "trading_enabled": system_state.get("trading_enabled", False) if system_state else False,

--- a/frontend/backend/tests/test_reports_api.py
+++ b/frontend/backend/tests/test_reports_api.py
@@ -93,6 +93,23 @@ def _init_reports_db(path: Path) -> None:
                 technical TEXT,
                 strategy TEXT
             );
+
+            CREATE TABLE strategy_proposals (
+                proposal_id TEXT PRIMARY KEY,
+                generated_by TEXT,
+                target_rule TEXT,
+                rule_category TEXT,
+                current_value TEXT,
+                proposed_value TEXT,
+                supporting_evidence TEXT,
+                confidence REAL,
+                requires_human_approval INTEGER,
+                status TEXT,
+                expires_at INTEGER,
+                proposal_json TEXT,
+                created_at INTEGER,
+                decided_at INTEGER
+            );
             """
         )
         conn.execute(
@@ -297,6 +314,98 @@ def test_reports_context_no_chips_tables(tmp_path, monkeypatch):
     assert payload["institution_chips"] == {}
     assert payload["eod_analysis"] is None
     assert payload["simulated_positions"]["positions"][0]["symbol"] == "2330"
+
+
+def test_reports_context_includes_committee_outlook(tmp_path, monkeypatch):
+    """committee_outlook is populated when a strategy_committee proposal exists within 24h."""
+    import time
+
+    with _make_client(tmp_path, monkeypatch) as client:
+        import app.db as db
+
+        now_ms = int(time.time() * 1000)
+        proposal_json = json.dumps({
+            "generated_by": "strategy_committee",
+            "committee_context": {
+                "bull": {"thesis": "技術面強勢，TSMC 突破前高", "confidence": 0.75},
+                "bear": {"thesis": "外資持續賣超，需謹慎", "confidence": 0.60},
+                "arbiter": {
+                    "summary": "整體偏多，建議持倉觀望",
+                    "stance": "constructive",
+                },
+            },
+        })
+        with db.get_conn_rw() as conn:
+            conn.execute(
+                """INSERT INTO strategy_proposals
+                   (proposal_id, generated_by, target_rule, rule_category,
+                    proposed_value, supporting_evidence, confidence,
+                    requires_human_approval, status, proposal_json, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    "p-test-001", "strategy_committee", "STRATEGY_DIRECTION", "strategy",
+                    "constructive", "bull evidence", 0.72,
+                    1, "pending", proposal_json, now_ms,
+                ),
+            )
+
+        r = client.get("/api/reports/context?type=morning", headers=_AUTH)
+
+    assert r.status_code == 200
+    payload = r.json()
+    outlook = payload.get("committee_outlook")
+    assert outlook is not None
+    assert outlook["proposal_id"] == "p-test-001"
+    assert outlook["bull_thesis"] == "技術面強勢，TSMC 突破前高"
+    assert outlook["bear_thesis"] == "外資持續賣超，需謹慎"
+    assert outlook["arbiter_stance"] == "constructive"
+    assert outlook["arbiter_summary"] == "整體偏多，建議持倉觀望"
+    assert outlook["confidence"] == 0.72
+
+
+def test_reports_context_committee_outlook_null_when_no_data(tmp_path, monkeypatch):
+    """committee_outlook is null when no strategy_committee proposal exists within 24h."""
+    with _make_client(tmp_path, monkeypatch) as client:
+        r = client.get("/api/reports/context?type=morning", headers=_AUTH)
+
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload.get("committee_outlook") is None
+
+
+def test_reports_context_committee_outlook_null_for_weekly(tmp_path, monkeypatch):
+    """committee_outlook is not included (null) for weekly report type."""
+    import time
+
+    with _make_client(tmp_path, monkeypatch) as client:
+        import app.db as db
+
+        now_ms = int(time.time() * 1000)
+        proposal_json = json.dumps({
+            "committee_context": {
+                "bull": {"thesis": "bull", "confidence": 0.7},
+                "bear": {"thesis": "bear", "confidence": 0.6},
+                "arbiter": {"summary": "neutral", "stance": "neutral"},
+            }
+        })
+        with db.get_conn_rw() as conn:
+            conn.execute(
+                """INSERT INTO strategy_proposals
+                   (proposal_id, generated_by, target_rule, rule_category,
+                    proposed_value, supporting_evidence, confidence,
+                    requires_human_approval, status, proposal_json, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    "p-weekly-001", "strategy_committee", "STRATEGY_DIRECTION", "strategy",
+                    "neutral", "evidence", 0.65, 1, "pending", proposal_json, now_ms,
+                ),
+            )
+
+        r = client.get("/api/reports/context?type=weekly", headers=_AUTH)
+
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload.get("committee_outlook") is None
 
 
 def test_reports_context_db_error_returns_500(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Morning/evening `/api/reports/context` 回傳新增 `committee_outlook` 欄位
- 從 `strategy_proposals` 取最近 24 小時內 `generated_by='strategy_committee'` 的最新提案
- 從 `proposal_json.committee_context` 提取 `bull_thesis` / `bear_thesis` / `arbiter_stance` / `arbiter_summary`
- Weekly 報告、查無資料、或 DB 錯誤時一律回傳 `null`（graceful degrade，不 500）

## Response shape

```json
{
  "committee_outlook": {
    "proposal_id": "...",
    "created_at": 1710000000000,
    "bull_thesis": "技術面強勢...",
    "bear_thesis": "外資賣超...",
    "arbiter_stance": "constructive",
    "arbiter_summary": "整體偏多...",
    "confidence": 0.72
  }
}
```

## Test plan

- [x] `test_reports_context_includes_committee_outlook` — 有資料時正確回傳
- [x] `test_reports_context_committee_outlook_null_when_no_data` — 無提案時為 null
- [x] `test_reports_context_committee_outlook_null_for_weekly` — weekly 報告為 null
- [x] 所有原有 7 個測試仍通過（共 10/10 green）

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)