### PR TITLE
fix(timezone): unify trade date to Taiwan timezone — fixes #246

### DIFF
--- a/src/openclaw/agents/eod_analysis.py
+++ b/src/openclaw/agents/eod_analysis.py
@@ -9,7 +9,7 @@ import json
 import logging
 import sqlite3
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -202,7 +202,8 @@ def run_eod_analysis(
 ) -> AgentResult:
     _db_path = db_path or str(_REPO_ROOT / "data" / "sqlite" / "trades.db")
     _conn = conn or open_conn(_db_path)
-    _date = trade_date or datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    _TZ_TWN = timezone(timedelta(hours=8))
+    _date = trade_date or datetime.now(tz=_TZ_TWN).strftime("%Y-%m-%d")
 
     try:
         _ensure_table(_conn)

--- a/src/openclaw/daily_pm_review.py
+++ b/src/openclaw/daily_pm_review.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 import time
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Any, Callable, Dict, Optional
 
 _log = logging.getLogger("daily_pm_review")
@@ -28,8 +28,12 @@ _BULLISH_KW = {"買", "加碼", "buy", "long", "積極", "正向", "樂觀", "�
 _BEARISH_KW = {"觀望", "減碼", "賣", "sell", "short", "保守", "停止", "暫停", "等待", "避險"}
 
 
+_TZ_TWN = timezone(timedelta(hours=8))
+
+
 def _today() -> str:
-    return date.today().isoformat()
+    """Return today's date in Taiwan timezone (UTC+8) as ISO string."""
+    return datetime.now(tz=_TZ_TWN).strftime("%Y-%m-%d")
 
 
 def get_daily_pm_approval() -> bool:

--- a/src/openclaw/risk_engine.py
+++ b/src/openclaw/risk_engine.py
@@ -36,10 +36,12 @@ _DAILY_PM_PATH = os.path.join(os.path.dirname(__file__), "../../config/daily_pm_
 def _get_daily_pm_approval() -> bool:
     """Check today's PM approval. Fails safe: returns False (blocked) on error."""
     try:
-        from datetime import date
+        from datetime import datetime, timezone, timedelta
+        _tz_twn = timezone(timedelta(hours=8))
+        today = datetime.now(tz=_tz_twn).strftime("%Y-%m-%d")
         with open(_DAILY_PM_PATH, "r") as f:
             state = json.load(f)
-        return state.get("date") == date.today().isoformat() and bool(state.get("approved", False))
+        return state.get("date") == today and bool(state.get("approved", False))
     except FileNotFoundError:
         logger.debug("Config file not found: %s, using defaults", _DAILY_PM_PATH)
         return False

--- a/src/tests/test_daily_pm_review.py
+++ b/src/tests/test_daily_pm_review.py
@@ -6,7 +6,7 @@ import json
 import os
 import sqlite3
 import tempfile
-from datetime import date
+from datetime import datetime, timezone, timedelta
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -33,9 +33,11 @@ def _patch_state_path(monkeypatch, path: str):
 # _today()
 # ---------------------------------------------------------------------------
 
-def test_today_returns_iso_string():
-    result = dpr._today()
-    assert result == date.today().isoformat()
+def test_today_returns_twn_date():
+    """_today() must return the Taiwan (UTC+8) date, not the server's local/UTC date."""
+    _TZ_TWN = timezone(timedelta(hours=8))
+    expected = datetime.now(tz=_TZ_TWN).strftime("%Y-%m-%d")
+    assert dpr._today() == expected
 
 
 # ---------------------------------------------------------------------------
@@ -43,7 +45,7 @@ def test_today_returns_iso_string():
 # ---------------------------------------------------------------------------
 
 def test_get_daily_pm_approval_true_when_today_and_approved(tmp_path, monkeypatch):
-    state = {"date": date.today().isoformat(), "approved": True}
+    state = {"date": dpr._today(), "approved": True}
     _patch_state_path(monkeypatch, _make_state_file(tmp_path, state))
     assert dpr.get_daily_pm_approval() is True
 
@@ -55,7 +57,7 @@ def test_get_daily_pm_approval_false_when_old_date(tmp_path, monkeypatch):
 
 
 def test_get_daily_pm_approval_false_when_not_approved(tmp_path, monkeypatch):
-    state = {"date": date.today().isoformat(), "approved": False}
+    state = {"date": dpr._today(), "approved": False}
     _patch_state_path(monkeypatch, _make_state_file(tmp_path, state))
     assert dpr.get_daily_pm_approval() is False
 
@@ -77,7 +79,7 @@ def test_get_daily_pm_approval_false_on_invalid_json(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_get_daily_pm_state_returns_full_dict_with_is_today(tmp_path, monkeypatch):
-    today = date.today().isoformat()
+    today = dpr._today()
     state = {"date": today, "approved": True, "confidence": 0.8}
     _patch_state_path(monkeypatch, _make_state_file(tmp_path, state))
     result = dpr.get_daily_pm_state()
@@ -233,7 +235,7 @@ def test_run_daily_pm_review_bearish_action(tmp_path, monkeypatch):
     def mock_llm(model, prompt):
         return llm_response
 
-    context = {"date": date.today().isoformat(), "recent_trades": [], "recent_pnl": []}
+    context = {"date": dpr._today(), "recent_trades": [], "recent_pnl": []}
     state = dpr.run_daily_pm_review(context=context, llm_call=mock_llm)
     assert state["approved"] is False
     assert state["source"] == "llm"
@@ -258,7 +260,7 @@ def test_run_daily_pm_review_bullish_action(tmp_path, monkeypatch):
     def mock_llm(model, prompt):
         return llm_response
 
-    context = {"date": date.today().isoformat(), "recent_trades": [], "recent_pnl": []}
+    context = {"date": dpr._today(), "recent_trades": [], "recent_pnl": []}
     state = dpr.run_daily_pm_review(context=context, llm_call=mock_llm)
     assert state["approved"] is True
     assert state["source"] == "llm"
@@ -283,7 +285,7 @@ def test_run_daily_pm_review_neutral_high_confidence_approved(tmp_path, monkeypa
     def mock_llm(model, prompt):
         return llm_response
 
-    context = {"date": date.today().isoformat(), "recent_trades": [], "recent_pnl": []}
+    context = {"date": dpr._today(), "recent_trades": [], "recent_pnl": []}
     state = dpr.run_daily_pm_review(context=context, llm_call=mock_llm)
     assert state["approved"] is True
     assert state["source"] == "llm"
@@ -308,7 +310,7 @@ def test_run_daily_pm_review_neutral_low_confidence_rejected(tmp_path, monkeypat
     def mock_llm(model, prompt):
         return llm_response
 
-    context = {"date": date.today().isoformat(), "recent_trades": [], "recent_pnl": []}
+    context = {"date": dpr._today(), "recent_trades": [], "recent_pnl": []}
     state = dpr.run_daily_pm_review(context=context, llm_call=mock_llm)
     assert state["approved"] is False
     assert state["source"] == "llm"
@@ -336,7 +338,7 @@ def test_run_daily_pm_review_includes_trace_fields(tmp_path, monkeypatch):
     def mock_llm(model, prompt):
         return llm_response
 
-    context = {"date": date.today().isoformat()}
+    context = {"date": dpr._today()}
     state = dpr.run_daily_pm_review(context=context, llm_call=mock_llm)
     assert state.get("_prompt") == "test-prompt"
     assert state.get("_raw_response") == "raw"
@@ -367,7 +369,7 @@ def test_run_daily_pm_review_adjudication_used_as_reason(tmp_path, monkeypatch):
     def mock_llm(model, prompt):
         return llm_response
 
-    context = {"date": date.today().isoformat()}
+    context = {"date": dpr._today()}
     state = dpr.run_daily_pm_review(context=context, llm_call=mock_llm)
     assert state["reason"] == "PM 最終裁決"
 


### PR DESCRIPTION
## Summary

- `daily_pm_review._today()`: `date.today()` → `datetime.now(UTC+8).strftime(...)`
- `risk_engine._get_daily_pm_approval()`: `date.today()` → TWN datetime
- `eod_analysis.run_eod_analysis()`: `datetime.now(UTC)` → `datetime.now(UTC+8)`

On a UTC server, the old code returned the wrong trading date during **UTC 16:00–23:59** (Taiwan midnight to 08:00). This caused PM approval checks to return False (blocking all trades) and eod_analysis to query the wrong `trade_date`.

## Test plan

- [x] `src/tests/test_daily_pm_review.py` — 25 passed (updated test assertions to use `dpr._today()`)
- [x] `tests/test_v4_31_risk_engine_coverage.py` — all passed
- [x] `src/tests/agents/test_eod_analysis.py` — all passed

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)