### PR TITLE
fix(signal): add max_date to _fetch_candles — exclude intraday partial EOD data [#247]

### DIFF
--- a/src/openclaw/signal_generator.py
+++ b/src/openclaw/signal_generator.py
@@ -5,9 +5,14 @@
 """
 import os
 import sqlite3
+from datetime import datetime, timezone, timedelta
 from typing import Optional
 
 from openclaw.signal_logic import SignalParams, evaluate_entry, evaluate_exit
+
+_TZ_TWN = timezone(timedelta(hours=8))
+# 盤後收盤基準：14:30 TWN（台股 13:30 收盤，ingest 約 14:00–14:30 完成）
+_EOD_COMPLETE_HOUR = 14
 
 _TAKE_PROFIT_PCT:          float = float(os.environ.get("TAKE_PROFIT_PCT",   "0.02"))
 _STOP_LOSS_PCT:            float = float(os.environ.get("STOP_LOSS_PCT",     "0.03"))
@@ -16,12 +21,30 @@ _TRAILING_PCT_TIGHT:       float = float(os.environ.get("TRAILING_PCT_TIGHT","0.
 _TRAILING_PROFIT_THRESHOLD: float = 0.50
 
 
-def _fetch_candles(conn: sqlite3.Connection, symbol: str, days: int = 60) -> list[dict]:
-    """從 eod_prices 取最近 N 日 OHLCV（由舊到新）"""
+def _fetch_candles(
+    conn: sqlite3.Connection,
+    symbol: str,
+    days: int = 60,
+    max_date: Optional[str] = None,
+) -> list[dict]:
+    """從 eod_prices 取最近 N 日 OHLCV（由舊到新）。
+
+    Args:
+        max_date: 只取 trade_date <= max_date 的資料。
+                  None = 自動決定：盤後（TWN >= 14:30）取當日；盤中取前一日，
+                  避免混入當日尚未完成的 EOD ingest 資料。
+    """
+    if max_date is None:
+        twn = datetime.now(tz=_TZ_TWN)
+        if twn.hour >= _EOD_COMPLETE_HOUR:
+            max_date = twn.strftime("%Y-%m-%d")
+        else:
+            max_date = (twn - timedelta(days=1)).strftime("%Y-%m-%d")
+
     rows = conn.execute(
         "SELECT trade_date, open, high, low, close, volume "
-        "FROM eod_prices WHERE symbol=? ORDER BY trade_date DESC LIMIT ?",
-        (symbol, days)
+        "FROM eod_prices WHERE symbol=? AND trade_date<=? ORDER BY trade_date DESC LIMIT ?",
+        (symbol, max_date, days)
     ).fetchall()
     return [
         {"date": r[0], "open": r[1], "high": r[2], "low": r[3],
@@ -46,12 +69,15 @@ def compute_signal(
     position_avg_price: Optional[float],
     high_water_mark: Optional[float],
     trailing_pct: float = _TRAILING_PCT_BASE,
+    max_date: Optional[str] = None,
 ) -> str:
     """計算交易信號。公開 API 不變。
 
+    Args:
+        max_date: 傳給 _fetch_candles；None = 依 TWN 時間自動決定（推薦）。
     Returns: "buy" | "sell" | "flat"
     """
-    candles = _fetch_candles(conn, symbol)
+    candles = _fetch_candles(conn, symbol, max_date=max_date)
     if len(candles) < 5:
         return "flat"
 

--- a/src/tests/test_signal_generator.py
+++ b/src/tests/test_signal_generator.py
@@ -1,8 +1,11 @@
 """test_signal_generator.py — EOD 日線驅動信號生成器測試"""
 import sqlite3
 import pytest
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch
 import random
+
+_TZ_TWN = timezone(timedelta(hours=8))
 
 
 @pytest.fixture
@@ -80,3 +83,85 @@ def test_signal_generator_stop_loss_triggers(db_with_eod):
                             position_avg_price=latest * 1.5,
                             high_water_mark=latest * 1.5)
     assert result == "sell"
+
+
+# ---------------------------------------------------------------------------
+# max_date / intraday filtering tests (Issue #247)
+# ---------------------------------------------------------------------------
+
+def _make_db_with_today(tmp_path, today_str: str):
+    """建立含今日（不完整）資料的 DB，今日 close 設為異常高值以便偵測。"""
+    conn = sqlite3.connect(str(tmp_path / "t.db"))
+    conn.execute("""CREATE TABLE eod_prices (
+        trade_date TEXT, symbol TEXT, open REAL, high REAL, low REAL,
+        close REAL, volume REAL, PRIMARY KEY (trade_date, symbol)
+    )""")
+    # 20 天歷史（正常價格）
+    price = 500.0
+    random.seed(42)
+    for i in range(20):
+        d = (date(2026, 2, 1) + timedelta(days=i)).isoformat()
+        price = price * (1 + random.uniform(-0.01, 0.01))
+        conn.execute("INSERT INTO eod_prices VALUES (?,?,?,?,?,?,?)",
+            (d, "2330", price, price * 1.01, price * 0.99, price, 1e6))
+    # 當日不完整資料（close = 99999 — 異常高，若混入必然失真）
+    conn.execute("INSERT INTO eod_prices VALUES (?,?,?,?,?,?,?)",
+        (today_str, "2330", 99999, 99999, 99999, 99999, 0))
+    conn.commit()
+    return conn
+
+
+def test_fetch_candles_excludes_today_during_market_hours(tmp_path):
+    """盤中（TWN hour < 14）_fetch_candles 應排除當日資料。"""
+    from openclaw.signal_generator import _fetch_candles
+    today_str = "2026-03-17"
+    conn = _make_db_with_today(tmp_path, today_str)
+
+    # 模擬 TWN 時間 10:30（盤中）
+    mock_now = datetime(2026, 3, 17, 10, 30, tzinfo=_TZ_TWN)
+    with patch("openclaw.signal_generator.datetime") as mock_dt:
+        mock_dt.now.return_value = mock_now
+        candles = _fetch_candles(conn, "2330")
+
+    assert all(c["date"] < today_str for c in candles), \
+        "盤中不應包含當日 EOD 資料"
+    assert all(c["close"] < 9000 for c in candles), \
+        "close 不應包含異常的 99999"
+
+
+def test_fetch_candles_includes_today_after_market_close(tmp_path):
+    """盤後（TWN hour >= 14）_fetch_candles 應包含當日資料。"""
+    from openclaw.signal_generator import _fetch_candles
+    today_str = "2026-03-17"
+    conn = _make_db_with_today(tmp_path, today_str)
+
+    mock_now = datetime(2026, 3, 17, 14, 35, tzinfo=_TZ_TWN)
+    with patch("openclaw.signal_generator.datetime") as mock_dt:
+        mock_dt.now.return_value = mock_now
+        candles = _fetch_candles(conn, "2330")
+
+    dates = [c["date"] for c in candles]
+    assert today_str in dates, "盤後應包含當日資料"
+
+
+def test_fetch_candles_explicit_max_date_respected(tmp_path):
+    """明確傳入 max_date 時，應以該日期為上限。"""
+    from openclaw.signal_generator import _fetch_candles
+    today_str = "2026-03-17"
+    conn = _make_db_with_today(tmp_path, today_str)
+
+    candles = _fetch_candles(conn, "2330", max_date="2026-02-15")
+    assert all(c["date"] <= "2026-02-15" for c in candles)
+
+
+def test_compute_signal_passes_max_date(tmp_path):
+    """compute_signal 支援明確傳入 max_date。"""
+    from openclaw.signal_generator import compute_signal
+    today_str = "2026-03-17"
+    conn = _make_db_with_today(tmp_path, today_str)
+
+    # 明確排除今日
+    result = compute_signal(conn, "2330",
+                            position_avg_price=None, high_water_mark=None,
+                            max_date="2026-02-20")
+    assert result in ("buy", "sell", "flat")


### PR DESCRIPTION
## Summary
- `_fetch_candles` 加入 `max_date` 參數，盤中（TWN < 14:30）自動排除當日未完成的 EOD ingest 資料
- `compute_signal` 透傳 `max_date`（向後相容，預設 None = 自動決定）
- 新增 4 個測試：盤中排除、盤後包含、明確 max_date、compute_signal 透傳

## Root Cause
`eod_ingest` 可能在盤中部分寫入當日 OHLCV；`_fetch_candles` 無上界過濾，MA/RSI/MACD 混入不完整資料導致信號失真。

## Test Plan
- [x] `test_fetch_candles_excludes_today_during_market_hours` — mock TWN 10:30，確認排除
- [x] `test_fetch_candles_includes_today_after_market_close` — mock TWN 14:35，確認包含
- [x] `test_fetch_candles_explicit_max_date_respected` — 明確傳入 max_date
- [x] `test_compute_signal_passes_max_date` — API 透傳驗證
- [x] 全部現有測試仍通過

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)