### PR TITLE
fix(cache): dynamic TTL to market close for lm_signal_cache [#248]

### DIFF
--- a/src/openclaw/lm_signal_cache.py
+++ b/src/openclaw/lm_signal_cache.py
@@ -12,7 +12,31 @@ Cache miss 時 caller 應使用 neutral score（0.5）。
 import sqlite3
 import time
 import uuid
+from datetime import datetime, timezone, timedelta
 from typing import Optional
+
+_TZ_TWN = timezone(timedelta(hours=8))
+# 台股收盤 13:30，ingest 完成後 cache 自然過期
+_MARKET_CLOSE_HOUR = 13
+_MARKET_CLOSE_MINUTE = 30
+# 最低 TTL：確保跨隔夜異常時至少持續 1 小時
+_MIN_TTL_SECONDS = 3600
+
+
+def _ttl_to_market_close() -> int:
+    """計算現在到當日台股收盤（13:30 TWN）的秒數。
+
+    若已過收盤時間，回傳 _MIN_TTL_SECONDS（避免 TTL=0 導致立即過期）。
+    """
+    now = datetime.now(tz=_TZ_TWN)
+    close = now.replace(
+        hour=_MARKET_CLOSE_HOUR,
+        minute=_MARKET_CLOSE_MINUTE,
+        second=0,
+        microsecond=0,
+    )
+    remaining = int((close - now).total_seconds())
+    return max(remaining, _MIN_TTL_SECONDS)
 
 
 def write_cache(
@@ -22,17 +46,18 @@ def write_cache(
     source: str,                 # 'strategy_committee' | 'pm_review'
     direction: str,              # 'bull' | 'bear' | 'neutral'
     raw_json: str,
-    ttl_seconds: int = 3600,
+    ttl_seconds: Optional[int] = None,  # None = 動態到當日收盤；明確傳入則使用固定值
     autocommit: bool = True,     # False = 呼叫方自行管理 transaction
 ) -> str:
     """寫入 LLM 快取，回傳 cache_id。"""
+    effective_ttl = ttl_seconds if ttl_seconds is not None else _ttl_to_market_close()
     cache_id = str(uuid.uuid4())
     now = int(time.time())
     conn.execute(
         """INSERT INTO lm_signal_cache
            (cache_id, symbol, score, source, direction, raw_json, created_at, expires_at)
            VALUES (?,?,?,?,?,?,?,?)""",
-        (cache_id, symbol, score, source, direction, raw_json, now, now + ttl_seconds),
+        (cache_id, symbol, score, source, direction, raw_json, now, now + effective_ttl),
     )
     if autocommit:
         conn.commit()

--- a/tests/test_lm_signal_cache.py
+++ b/tests/test_lm_signal_cache.py
@@ -1,4 +1,8 @@
 import sqlite3, time, pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+_TZ_TWN = timezone(timedelta(hours=8))
 
 @pytest.fixture
 def cache_db(tmp_path):
@@ -70,3 +74,61 @@ def test_write_returns_cache_id(cache_db):
     cid = write_cache(cache_db, symbol=None, score=0.5, source="test",
                       direction="neutral", raw_json="{}")
     assert isinstance(cid, str) and len(cid) > 0
+
+
+# ---------------------------------------------------------------------------
+# TTL 動態計算測試 (Issue #248)
+# ---------------------------------------------------------------------------
+
+def test_ttl_to_market_close_before_close(cache_db):
+    """盤中（TWN < 13:30）TTL 應大於 0 且不超過 5 小時。"""
+    from openclaw.lm_signal_cache import _ttl_to_market_close
+    mock_now = datetime(2026, 3, 17, 9, 0, tzinfo=_TZ_TWN)   # 09:00 TWN
+    with patch("openclaw.lm_signal_cache.datetime") as m:
+        m.now.return_value = mock_now
+        ttl = _ttl_to_market_close()
+    # 09:00 → 13:30 = 4.5h = 16200s
+    assert 16000 < ttl < 17000
+
+
+def test_ttl_to_market_close_after_close_returns_min(cache_db):
+    """盤後（TWN > 13:30）TTL 應回傳 _MIN_TTL_SECONDS。"""
+    from openclaw.lm_signal_cache import _ttl_to_market_close, _MIN_TTL_SECONDS
+    mock_now = datetime(2026, 3, 17, 14, 0, tzinfo=_TZ_TWN)   # 14:00 TWN（盤後）
+    with patch("openclaw.lm_signal_cache.datetime") as m:
+        m.now.return_value = mock_now
+        ttl = _ttl_to_market_close()
+    assert ttl == _MIN_TTL_SECONDS
+
+
+def test_write_cache_default_ttl_lasts_to_market_close(cache_db):
+    """預設 TTL write_cache 後，09:00 寫入應在 13:29 仍有效。"""
+    from openclaw.lm_signal_cache import write_cache, read_cache
+
+    # Simulate write at 09:00 TWN
+    write_time = datetime(2026, 3, 17, 9, 0, tzinfo=_TZ_TWN)
+    with patch("openclaw.lm_signal_cache.datetime") as m:
+        m.now.return_value = write_time
+        write_cache(cache_db, symbol=None, score=0.75, source="committee",
+                    direction="bull", raw_json="{}")
+
+    # At 13:29 TWN the entry should still be readable (expires_at > now)
+    close_minus_1m = int(datetime(2026, 3, 17, 13, 29, tzinfo=_TZ_TWN).timestamp())
+    row = cache_db.execute(
+        "SELECT expires_at FROM lm_signal_cache ORDER BY created_at DESC LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert row[0] > close_minus_1m, "cache 應在 13:29 仍有效"
+
+
+def test_write_cache_explicit_ttl_not_overridden(cache_db):
+    """明確傳入 ttl_seconds 時，不使用動態計算。"""
+    from openclaw.lm_signal_cache import write_cache
+    import time as _time
+    before = int(_time.time())
+    write_cache(cache_db, symbol=None, score=0.5, source="test",
+                direction="neutral", raw_json="{}", ttl_seconds=60)
+    row = cache_db.execute(
+        "SELECT expires_at, created_at FROM lm_signal_cache ORDER BY created_at DESC LIMIT 1"
+    ).fetchone()
+    assert abs(row[0] - row[1] - 60) <= 2  # expires_at ≈ created_at + 60


### PR DESCRIPTION
## Summary
- `_ttl_to_market_close()` 計算現在到 13:30 TWN（台股收盤）的秒數，盤後回傳 MIN_TTL（3600s）
- `write_cache` 的 `ttl_seconds` 改為 `Optional[int]`，`None`（預設）= 動態計算；明確傳入固定值向後相容
- strategy_committee 08:30 寫入的 cache 整個交易日有效，不再 09:30 後退化為 neutral 0.5

## Test Plan
- [x] `test_ttl_to_market_close_before_close` — 09:00 TWN → TTL ≈ 16200s
- [x] `test_ttl_to_market_close_after_close_returns_min` — 14:00 TWN → TTL = MIN
- [x] `test_write_cache_default_ttl_lasts_to_market_close` — 13:29 仍可讀到
- [x] `test_write_cache_explicit_ttl_not_overridden` — 明確傳 60s 有效
- [x] 所有現有 7 個測試繼續通過

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)