### PR TITLE
fix(watcher): use EOD history as fallback for exit signal after restart [#249]

### DIFF
--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -459,6 +459,29 @@ def _update_price_history(price_history: Dict[str, List[float]], symbol: str, cl
         del hist[0]
 
 
+def _build_exit_closes(
+    conn: sqlite3.Connection,
+    symbol: str,
+    price_history: Dict[str, List[float]],
+) -> List[float]:
+    """組合 EOD 歷史收盤 + 當日盤中 ticks，供 exit signal 評估使用。
+
+    watcher 重啟後 price_history 為空，仍可從 eod_prices 取得歷史資料，
+    確保 MA/RSI 計算不因重啟而短暫失效。
+    """
+    eod_rows = conn.execute(
+        "SELECT close FROM eod_prices WHERE symbol=? AND close IS NOT NULL "
+        "ORDER BY trade_date DESC LIMIT ?",
+        (symbol, _PRICE_HISTORY_MAX),
+    ).fetchall()
+    eod_closes: List[float] = [r[0] for r in reversed(eod_rows)]
+
+    # 盤中 ticks（最多取最後 20 筆，避免重複疊加過多）
+    intraday: List[float] = price_history.get(symbol, [])[-20:]
+
+    return eod_closes + intraday
+
+
 def _evaluate_cash_mode(
     price_history: Dict[str, List[float]], current_cash_mode: bool
 ) -> tuple[bool, str]:
@@ -784,8 +807,8 @@ def run_watcher() -> None:
                 pass
 
             for _exit_sym, (_exit_qty, _exit_avg) in list(positions.items()):
-                _exit_closes = price_history.get(_exit_sym, [])
-                if len(_exit_closes) < 1:
+                _exit_closes = _build_exit_closes(conn, _exit_sym, price_history)
+                if len(_exit_closes) < 5:
                     continue
                 if _exit_sym in _locked_syms:
                     log.debug("[%s] sell skipped — locked symbol", _exit_sym)

--- a/tests/test_ticker_watcher_sell.py
+++ b/tests/test_ticker_watcher_sell.py
@@ -277,3 +277,64 @@ class TestTrailingStop:
         result = evaluate_exit([100], avg_price=0.0, high_water_mark=100.0)
         assert result.signal == "flat"
         assert "insufficient_data" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# _build_exit_closes tests (Issue #249)
+# ---------------------------------------------------------------------------
+
+import sqlite3
+from datetime import date, timedelta
+
+
+def _make_eod_db(tmp_path, symbol: str = "2330", n_days: int = 20):
+    """建立含 eod_prices 的測試 DB。"""
+    conn = sqlite3.connect(str(tmp_path / "trades.db"))
+    conn.execute("""CREATE TABLE eod_prices (
+        trade_date TEXT, symbol TEXT, open REAL, high REAL, low REAL,
+        close REAL, volume REAL, PRIMARY KEY (trade_date, symbol)
+    )""")
+    base = 500.0
+    for i in range(n_days):
+        d = (date(2026, 2, 1) + timedelta(days=i)).isoformat()
+        conn.execute("INSERT INTO eod_prices VALUES (?,?,?,?,?,?,?)",
+            (d, symbol, base, base + 1, base - 1, base + i * 0.5, 1e6))
+    conn.commit()
+    return conn
+
+
+def test_build_exit_closes_returns_eod_when_history_empty(tmp_path):
+    """price_history 空時，應從 eod_prices 取歷史收盤。"""
+    from openclaw.ticker_watcher import _build_exit_closes
+    conn = _make_eod_db(tmp_path, n_days=20)
+    closes = _build_exit_closes(conn, "2330", {})
+    assert len(closes) == 20
+    assert all(isinstance(c, float) for c in closes)
+
+
+def test_build_exit_closes_appends_intraday_ticks(tmp_path):
+    """price_history 有值時，應 append 至 EOD 歷史後。"""
+    from openclaw.ticker_watcher import _build_exit_closes
+    conn = _make_eod_db(tmp_path, n_days=10)
+    ph = {"2330": [510.0, 511.0, 509.5]}
+    closes = _build_exit_closes(conn, "2330", ph)
+    assert len(closes) == 13       # 10 EOD + 3 intraday
+    assert closes[-1] == 509.5    # 最後一筆是盤中最新價
+
+
+def test_build_exit_closes_intraday_capped_at_20(tmp_path):
+    """盤中 ticks 最多取 20 筆，避免比 EOD 還長。"""
+    from openclaw.ticker_watcher import _build_exit_closes
+    conn = _make_eod_db(tmp_path, n_days=5)
+    ph = {"2330": [500.0 + i for i in range(50)]}  # 50 盤中 ticks
+    closes = _build_exit_closes(conn, "2330", ph)
+    # 5 EOD + 20 intraday（最後 20）
+    assert len(closes) == 25
+
+
+def test_build_exit_closes_unknown_symbol_returns_empty(tmp_path):
+    """未知股票無 EOD 資料且 price_history 無值時，回傳空串列。"""
+    from openclaw.ticker_watcher import _build_exit_closes
+    conn = _make_eod_db(tmp_path, n_days=5)
+    closes = _build_exit_closes(conn, "9999", {})
+    assert closes == []


### PR DESCRIPTION
## Summary
- 新增 `_build_exit_closes(conn, symbol, price_history)` — 先從 `eod_prices` 取最近 60 日收盤，再 append 當日盤中 ticks（最多 20 筆）
- exit signal 使用 `_build_exit_closes` 替代原本的 `price_history.get(sym, [])`
- 最小資料量閾值從 1 調高至 5（與 `compute_signal` 一致）

## Root Cause
watcher 重啟後 `price_history` 清空，`len(_exit_closes) < 1` 跳過所有止損評估，直到累積足夠盤中 ticks 前持倉無保護。

## Test Plan
- [x] `test_build_exit_closes_returns_eod_when_history_empty` — 空 price_history → 取 EOD
- [x] `test_build_exit_closes_appends_intraday_ticks` — EOD + intraday 正確合併
- [x] `test_build_exit_closes_intraday_capped_at_20` — 盤中 ticks 上限 20
- [x] `test_build_exit_closes_unknown_symbol_returns_empty` — 無資料回傳空串列
- [x] 所有現有 watcher sell tests 繼續通過

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)