### PR TITLE
feat(llm): 遷移策略評估 LLM 從 Gemini 至 MiniMax M2.5

### DIFF
--- a/src/openclaw/agents/base.py
+++ b/src/openclaw/agents/base.py
@@ -1,4 +1,4 @@
-"""agents/base.py — 共用 helper：DB 查詢、Gemini 呼叫、trace/proposal 寫入。"""
+"""agents/base.py — 共用 helper：DB 查詢、LLM 呼叫、trace/proposal 寫入。"""
 from __future__ import annotations
 
 import json
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from openclaw.llm_gemini import gemini_call
+from openclaw.llm_minimax import minimax_call
 from openclaw.llm_observability import LLMTrace, insert_llm_trace
 from openclaw.path_utils import get_repo_root
 
@@ -18,8 +18,8 @@ _REPO_ROOT = get_repo_root()
 _DEFAULT_DB = str(_REPO_ROOT / "data" / "sqlite" / "trades.db")
 
 # 預設模型：可透過環境變數覆寫
-DEFAULT_MODEL: str = os.environ.get("AGENT_LLM_MODEL", "gemini-2.5-flash")
-COMMITTEE_MODEL: str = os.environ.get("AGENT_COMMITTEE_MODEL", "gemini-3.1-pro-preview")
+DEFAULT_MODEL: str = os.environ.get("AGENT_LLM_MODEL", "MiniMax-M2.5")
+COMMITTEE_MODEL: str = os.environ.get("AGENT_COMMITTEE_MODEL", "MiniMax-M2.5")
 
 
 def open_conn(db_path: str = _DEFAULT_DB) -> sqlite3.Connection:
@@ -40,9 +40,9 @@ def call_agent_llm(
     prompt: str,
     model: str = DEFAULT_MODEL,
 ) -> Dict[str, Any]:
-    """呼叫 Gemini，回傳解析後的 dict。失敗時回傳 fallback dict。"""
+    """呼叫 MiniMax M2.5，回傳解析後的 dict。失敗時回傳 fallback dict。"""
     try:
-        return gemini_call(model, prompt)
+        return minimax_call(model, prompt)
     except Exception as e:
         return {
             "summary": f"LLM 呼叫失敗：{e}",

--- a/src/openclaw/llm_minimax.py
+++ b/src/openclaw/llm_minimax.py
@@ -1,0 +1,129 @@
+"""llm_minimax.py — MiniMax M2.5 LLM adapter（OpenAI-compatible API）。
+
+實作與 llm_gemini.gemini_call 相同的介面：
+    minimax_call(model, prompt) -> dict
+
+Env:
+    MINIMAX_API_KEY — 從 frontend/backend/.env 或環境變數載入。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from typing import Any, Dict
+
+import requests
+
+log = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.minimax.io/v1"
+_DEFAULT_MODEL = "MiniMax-M2.5"
+_TIMEOUT = 120  # seconds
+
+
+def _extract_json(text: str) -> Dict[str, Any]:
+    """從 LLM 回應文字中提取 JSON dict（與 llm_gemini 相同的容錯邏輯）。"""
+    text = text.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    m = re.search(r"```(?:json)?\s*([\s\S]*?)```", text)
+    if m:
+        try:
+            return json.loads(m.group(1).strip())
+        except json.JSONDecodeError:
+            pass
+    m = re.search(r"\{[\s\S]*\}", text)
+    if m:
+        try:
+            return json.loads(m.group(0))
+        except json.JSONDecodeError:
+            pass
+    raise ValueError(f"Cannot parse JSON from MiniMax response: {text[:300]}")
+
+
+def minimax_call(model: str, prompt: str) -> Dict[str, Any]:
+    """呼叫 MiniMax M2.5，回傳解析後的 JSON dict。
+
+    Args:
+        model: MiniMax 模型 ID，e.g. "MiniMax-M2.5"。
+        prompt: 完整 prompt 字串。
+
+    Returns:
+        解析後的 dict，包含 '_raw_response', '_prompt', '_latency_ms', '_model'。
+
+    Raises:
+        RuntimeError: MINIMAX_API_KEY 未設定。
+        ValueError: 回應無法解析為 JSON。
+        requests.HTTPError: API 回傳非 2xx 狀態碼。
+    """
+    api_key = os.environ.get("MINIMAX_API_KEY", "").strip()
+    if not api_key:
+        # 嘗試從 frontend/backend/.env 讀取
+        _load_minimax_key_from_dotenv()
+        api_key = os.environ.get("MINIMAX_API_KEY", "").strip()
+    if not api_key:
+        raise RuntimeError("MINIMAX_API_KEY 未設定（請在 frontend/backend/.env 設定）")
+
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "response_format": {"type": "json_object"},
+        "temperature": 0.7,
+    }
+
+    t0 = time.time()
+    resp = requests.post(
+        f"{_BASE_URL}/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+        timeout=_TIMEOUT,
+    )
+    resp.raise_for_status()
+    latency_ms = int((time.time() - t0) * 1000)
+
+    body = resp.json()
+    raw_text = body["choices"][0]["message"]["content"]
+    usage = body.get("usage", {})
+
+    parsed = _extract_json(raw_text)
+
+    if isinstance(parsed, list):
+        result: Dict[str, Any] = {"items": parsed}
+    else:
+        result = parsed
+
+    result["_prompt"] = prompt
+    result["_raw_response"] = raw_text
+    result["_latency_ms"] = latency_ms
+    result["_model"] = model
+    result["_input_tokens"] = usage.get("prompt_tokens", 0)
+    result["_output_tokens"] = usage.get("completion_tokens", 0)
+
+    return result
+
+
+def _load_minimax_key_from_dotenv() -> None:
+    """嘗試從 frontend/backend/.env 載入 MINIMAX_API_KEY 至環境變數。"""
+    from openclaw.path_utils import get_repo_root
+    dotenv_path = get_repo_root() / "frontend" / "backend" / ".env"
+    if not dotenv_path.exists():
+        return
+    try:
+        with open(dotenv_path) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("MINIMAX_API_KEY="):
+                    val = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    os.environ["MINIMAX_API_KEY"] = val
+                    break
+    except OSError:
+        pass

--- a/src/openclaw/model_registry.py
+++ b/src/openclaw/model_registry.py
@@ -11,7 +11,11 @@ from typing import Dict
 # Keys: user-facing / legacy ids that may appear in configs/tests.
 # Values: pinned provider model ids that are safe to call.
 ALLOWED_MODELS: Dict[str, str] = {
-    # Canonical pinned ids
+    # MiniMax (primary strategy LLM)
+    "minimax/MiniMax-M2.5": "MiniMax-M2.5",
+    "MiniMax-M2.5": "MiniMax-M2.5",
+
+    # Google Gemini (kept for backward compat / fallback)
     "google/gemini-1.5-pro-002": "google/gemini-1.5-pro-002",
     "google/gemini-1.5-flash-002": "google/gemini-1.5-flash-002",
     "google/gemini-3.1-pro-001": "google/gemini-3.1-pro-001",

--- a/src/openclaw/proposal_reviewer.py
+++ b/src/openclaw/proposal_reviewer.py
@@ -1,4 +1,4 @@
-"""proposal_reviewer.py — Gemini 自動審查 pending 策略提案
+"""proposal_reviewer.py — LLM 自動審查 pending 策略提案（MiniMax M2.5）
 
 掃描 strategy_proposals 中 status='pending' 的提案，
 呼叫 Gemini 做快速審查，輸出 approve / reject + 理由，
@@ -17,7 +17,7 @@ import time
 
 log = logging.getLogger(__name__)
 
-_MODEL = "gemini-2.0-flash"
+_MODEL = "MiniMax-M2.5"
 
 _REVIEW_PROMPT_TMPL = """你是一位台股 Portfolio Manager，請快速審查以下減倉提案。
 
@@ -66,33 +66,15 @@ def _build_position_summary(conn: sqlite3.Connection) -> str:
 
 def _gemini_review(symbol: str, weight: float, reduce_pct: float,
                    evidence: str, position_summary: str) -> dict:
-    """呼叫 Gemini 審查提案，回傳 {decision, confidence, reason}。"""
-    import re, os
-    from google import genai
+    """呼叫 MiniMax M2.5 審查提案，回傳 {decision, confidence, reason}。"""
+    from openclaw.llm_minimax import minimax_call
 
-    api_key = os.environ.get("GEMINI_API_KEY", "").strip()
-    if not api_key:
-        raise RuntimeError("GEMINI_API_KEY 未設定")
-
-    client = genai.Client(api_key=api_key)
     prompt = _REVIEW_PROMPT_TMPL.format(
         symbol=symbol, weight=weight, reduce_pct=reduce_pct,
         evidence=evidence, position_summary=position_summary,
     )
-    resp = client.models.generate_content(
-        model=_MODEL,
-        contents=prompt,
-        config=genai.types.GenerateContentConfig(
-            response_mime_type="application/json",
-        ),
-    )
-    text = resp.text.strip()
-
-    # 嘗試解析 JSON（容錯 markdown code fence）
-    m = re.search(r"\{[\s\S]*\}", text)
-    if m:
-        return json.loads(m.group(0))
-    return json.loads(text)
+    result = minimax_call(_MODEL, prompt)
+    return {k: v for k, v in result.items() if not k.startswith("_")}
 
 
 def auto_review_pending_proposals(conn: sqlite3.Connection) -> int:

--- a/src/tests/test_agents.py
+++ b/src/tests/test_agents.py
@@ -202,7 +202,7 @@ class TestWriteProposal:
 class TestCallAgentLlm:
     def test_returns_fallback_on_error(self):
         from openclaw.agents.base import call_agent_llm
-        with patch("openclaw.agents.base.gemini_call", side_effect=RuntimeError("no key")):
+        with patch("openclaw.agents.base.minimax_call", side_effect=RuntimeError("no key")):
             result = call_agent_llm("test prompt")
         assert result["action_type"] == "observe"
         assert result["confidence"] == 0.0


### PR DESCRIPTION
## Summary

- 新增 `llm_minimax.py`：OpenAI-compatible adapter，用 `requests` 呼叫 MiniMax M2.5，支援 JSON mode (`response_format: json_object`)
- `model_registry.py`：加入 `MiniMax-M2.5` / `minimax/MiniMax-M2.5` allowlist
- `agents/base.py`：換用 `minimax_call`，`DEFAULT_MODEL` / `COMMITTEE_MODEL` 改為 `MiniMax-M2.5`
- `proposal_reviewer.py`：`_gemini_review` 改用 `minimax_call`，移除 `google-genai` SDK 依賴

## Test plan

- [x] 基本 import + 驗證（model_registry allowlist、預設模型值、JSON 解析）通過
- [x] 472 tests passed, 2 skipped（排除 `hypothesis` / `pydantic_settings` 環境缺失的不相關 test）
- [ ] PM2 重啟後確認 PM review / 提案審查呼叫 MiniMax M2.5

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)