### PR TITLE
fix(optimizer): 修復自主優化三層架構（param_bounds + SQL欄位 + eod串接）

### DIFF
--- a/src/openclaw/eod_ingest.py
+++ b/src/openclaw/eod_ingest.py
@@ -322,6 +322,27 @@ def main() -> None:
                 file=__import__("sys").stderr,
             )
 
+        # 盤後自動優化（僅在價格資料成功寫入時執行）
+        optimizer_adjustments: list = []
+        if status == "success":
+            try:
+                from openclaw.strategy_optimizer import (
+                    StrategyMetricsEngine, OptimizationGateway,
+                )
+                conn.row_factory = __import__("sqlite3").Row
+                metrics = StrategyMetricsEngine(conn).compute()
+                optimizer_adjustments = OptimizationGateway(conn).on_eod(metrics)
+                if optimizer_adjustments:
+                    print(
+                        f"[eod_ingest] optimizer adjustments: {optimizer_adjustments}",
+                        file=__import__("sys").stderr,
+                    )
+            except Exception as opt_exc:
+                print(
+                    f"[eod_ingest] optimizer skipped: {opt_exc}",
+                    file=__import__("sys").stderr,
+                )
+
         try:
             print(
                 json.dumps(
@@ -333,6 +354,7 @@ def main() -> None:
                         "institution_flows": inst_rows,
                         "margin_data": margin_rows,
                         "institution_error": inst_error,
+                        "optimizer_adjustments": optimizer_adjustments,
                         "error": error_text,
                     },
                     ensure_ascii=True,

--- a/src/openclaw/strategy_optimizer.py
+++ b/src/openclaw/strategy_optimizer.py
@@ -111,9 +111,39 @@ class StrategyMetricsEngine:
         return trades
 
 
+def _ensure_optimizer_schema(conn: sqlite3.Connection) -> None:
+    """確保 param_bounds 存在並初始化預設護欄（冪等）。"""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS param_bounds (
+            param_key           TEXT PRIMARY KEY,
+            min_val             REAL NOT NULL,
+            max_val             REAL NOT NULL,
+            weekly_max_delta    REAL NOT NULL,
+            last_auto_change_ts INTEGER,
+            frozen_until_ts     INTEGER
+        )
+    """)
+    # 確保 trailing_pct 有護欄定義
+    conn.execute("""
+        INSERT OR IGNORE INTO param_bounds
+            (param_key, min_val, max_val, weekly_max_delta)
+        VALUES ('trailing_pct', 0.02, 0.15, 0.02)
+    """)
+    # 確保 trailing_pct 有初始值（若不存在）
+    import uuid
+    conn.execute("""
+        INSERT INTO risk_limits
+            (limit_id, scope, rule_name, rule_value, enabled, updated_at)
+        SELECT ?, 'global', 'trailing_pct', 0.05, 1, datetime('now')
+        WHERE NOT EXISTS (SELECT 1 FROM risk_limits WHERE rule_name='trailing_pct')
+    """, (uuid.uuid4().hex[:16],))
+    conn.commit()
+
+
 class OptimizationGateway:
     def __init__(self, conn: sqlite3.Connection):
         self.conn = conn
+        _ensure_optimizer_schema(conn)
 
     def on_eod(self, metrics: MetricsReport) -> list[dict]:
         """根據 EOD 統計結果執行安全調整。
@@ -163,11 +193,11 @@ class OptimizationGateway:
 
         # 讀取現值
         current = self.conn.execute(
-            "SELECT value FROM risk_limits WHERE name=?", (param_key,)
+            "SELECT rule_value FROM risk_limits WHERE rule_name=?", (param_key,)
         ).fetchone()
         if current is None:
             return None
-        old_val = current["value"]
+        old_val = current["rule_value"]
 
         # 本週累積 delta 檢查（確保 7 日內累積調整量不超過 weekly_max_delta）
         one_week_ago = now - 7 * 86400
@@ -197,7 +227,7 @@ class OptimizationGateway:
 
         # 執行調整
         self.conn.execute(
-            "UPDATE risk_limits SET value=?, updated_at=? WHERE name=?",
+            "UPDATE risk_limits SET rule_value=?, updated_at=? WHERE rule_name=?",
             (new_val, now, param_key)
         )
         # 寫入 optimization_log
@@ -244,10 +274,10 @@ class ReflectionAgent:
         """執行週期反思，回傳 proposals list（空 list = 無建議）。"""
         try:
             context = self._build_context()
-            response = self._call_gemini(context)
+            response = self._call_llm(context)
             return self._parse_proposals(response)
         except Exception as e:
-            log.warning("[ReflectionAgent] Gemini 反思失敗，跳過：%s", e)
+            log.warning("[ReflectionAgent] LLM 反思失敗，跳過：%s", e)
             return []
 
     def _build_context(self) -> str:
@@ -285,9 +315,10 @@ class ReflectionAgent:
 proposals 中每項格式：{{"param_key": "...", "action": "increase|decrease|review", "reason": "..."}}
 """
 
-    def _call_gemini(self, prompt: str) -> str:
-        from openclaw.llm_gemini import call_gemini  # type: ignore
-        return call_gemini(prompt)
+    def _call_llm(self, prompt: str) -> str:
+        from openclaw.llm_minimax import minimax_call
+        result = minimax_call("MiniMax-M2.5", prompt)
+        return result.get("_raw_response", "")
 
     def _parse_proposals(self, response: str) -> list[dict]:
         import json
@@ -295,5 +326,5 @@ proposals 中每項格式：{{"param_key": "...", "action": "increase|decrease|r
             data = json.loads(response)
             return data.get("proposals", [])
         except (json.JSONDecodeError, AttributeError):
-            log.warning("[ReflectionAgent] 無法解析 Gemini 回應")
+            log.warning("[ReflectionAgent] 無法解析 LLM 回應")
             return []

--- a/tests/test_strategy_optimizer.py
+++ b/tests/test_strategy_optimizer.py
@@ -1,5 +1,6 @@
 # tests/test_strategy_optimizer.py
-import sqlite3, time, pytest
+import sqlite3, time, uuid, pytest
+
 
 @pytest.fixture
 def opt_db(tmp_path):
@@ -28,8 +29,9 @@ def opt_db(tmp_path):
             last_auto_change_ts INTEGER, frozen_until_ts INTEGER
         );
         CREATE TABLE risk_limits (
-            name TEXT PRIMARY KEY, value REAL NOT NULL,
-            updated_at INTEGER
+            limit_id TEXT PRIMARY KEY, scope TEXT, symbol TEXT,
+            strategy_id TEXT, rule_name TEXT, rule_value REAL,
+            enabled INTEGER DEFAULT 1, updated_at TEXT
         );
     """)
     conn.commit()
@@ -38,7 +40,6 @@ def opt_db(tmp_path):
 
 def _insert_matched_trade(conn, symbol, buy_price, sell_price, qty=1000, days_ago=5):
     """插入一筆完整的買賣配對（模擬已平倉交易）"""
-    import uuid
     from datetime import datetime, timedelta
     ts_buy  = (datetime.now() - timedelta(days=days_ago+1)).isoformat()
     ts_sell = (datetime.now() - timedelta(days=days_ago)).isoformat()
@@ -61,6 +62,16 @@ def _insert_matched_trade(conn, symbol, buy_price, sell_price, qty=1000, days_ag
     tax  = sell_price * qty * 0.003
     conn.execute("INSERT INTO fills VALUES (?,?,?,?,?,?,?)",
         (fill_sell_id, sell_id, ts_sell, qty, sell_price, fee, tax))
+    conn.commit()
+
+
+def _insert_trailing_pct(conn, value=0.05):
+    """插入 trailing_pct risk_limit（使用正確的 production schema）"""
+    conn.execute(
+        "INSERT OR IGNORE INTO risk_limits (limit_id, scope, rule_name, rule_value, enabled, updated_at) "
+        "VALUES (?, 'global', 'trailing_pct', ?, 1, datetime('now'))",
+        (uuid.uuid4().hex[:16], value),
+    )
     conn.commit()
 
 
@@ -105,13 +116,11 @@ class TestOptimizationGateway:
 
     def test_param_bounds_respected(self, opt_db):
         """調整不超出 param_bounds 定義的 weekly_max_delta"""
-        # 插入 param_bounds
         opt_db.execute(
             "INSERT INTO param_bounds VALUES (?,?,?,?,?,?)",
             ("trailing_pct", 0.03, 0.10, 0.005, None, None)
         )
-        opt_db.execute("INSERT INTO risk_limits VALUES ('trailing_pct', 0.05, ?)", (int(time.time()),))
-        opt_db.commit()
+        _insert_trailing_pct(opt_db, 0.05)
 
         # 30 筆全是虧損 → 應嘗試調整 trailing_pct
         for i in range(30):
@@ -133,8 +142,7 @@ class TestOptimizationGateway:
             "INSERT INTO param_bounds VALUES (?,?,?,?,?,?)",
             ("trailing_pct", 0.03, 0.10, 0.005, None, None)
         )
-        opt_db.execute("INSERT INTO risk_limits VALUES ('trailing_pct', 0.05, ?)", (int(time.time()),))
-        opt_db.commit()
+        _insert_trailing_pct(opt_db, 0.05)
         for i in range(30):
             _insert_matched_trade(opt_db, "2330", 100, 95)
 
@@ -152,8 +160,7 @@ class TestOptimizationGateway:
             "INSERT INTO param_bounds VALUES (?,?,?,?,?,?)",
             ("trailing_pct", 0.03, 0.10, 0.005, None, future)  # frozen
         )
-        opt_db.execute("INSERT INTO risk_limits VALUES ('trailing_pct', 0.05, ?)", (int(time.time()),))
-        opt_db.commit()
+        _insert_trailing_pct(opt_db, 0.05)
         for i in range(30):
             _insert_matched_trade(opt_db, "2330", 100, 95)
 
@@ -171,7 +178,7 @@ class TestOptimizationGateway:
             "INSERT INTO param_bounds VALUES (?,?,?,?,?,?)",
             ("trailing_pct", 0.03, 0.10, 0.005, None, None)
         )
-        opt_db.execute("INSERT INTO risk_limits VALUES ('trailing_pct', 0.05, ?)", (now,))
+        _insert_trailing_pct(opt_db, 0.05)
         # 插入一筆本週已發生的自動調整，delta=0.005（達到 weekly_max_delta）
         opt_db.execute(
             """INSERT INTO optimization_log
@@ -197,8 +204,7 @@ class TestOptimizationGateway:
             "INSERT INTO param_bounds VALUES (?,?,?,?,?,?)",
             ("trailing_pct", 0.03, 0.10, 0.005, None, None)
         )
-        opt_db.execute("INSERT INTO risk_limits VALUES ('trailing_pct', 0.05, ?)", (now,))
-        opt_db.commit()
+        _insert_trailing_pct(opt_db, 0.05)
         for i in range(30):
             _insert_matched_trade(opt_db, "2330", 100, 95)
 
@@ -215,12 +221,13 @@ class TestOptimizationGateway:
 
 class TestReflectionAgent:
     def test_reflect_returns_list(self, opt_db, monkeypatch):
-        """reflect_weekly 回傳 list（即使 Gemini 未設定也不崩潰）"""
-        # mock llm_gemini
+        """reflect_weekly 回傳 list（即使 LLM 未設定也不崩潰）"""
         import sys, types
-        fake_gemini = types.ModuleType("openclaw.llm_gemini")
-        fake_gemini.call_gemini = lambda *a, **kw: '{"direction":"neutral","rationale":"test","proposals":[]}'
-        sys.modules["openclaw.llm_gemini"] = fake_gemini
+        fake_minimax = types.ModuleType("openclaw.llm_minimax")
+        fake_minimax.minimax_call = lambda model, prompt: {
+            "_raw_response": '{"direction":"neutral","rationale":"test","proposals":[]}',
+        }
+        sys.modules["openclaw.llm_minimax"] = fake_minimax
 
         from openclaw.strategy_optimizer import ReflectionAgent
         agent = ReflectionAgent(opt_db)
@@ -228,12 +235,12 @@ class TestReflectionAgent:
         assert isinstance(result, list)
 
     def test_reflect_no_crash_on_llm_error(self, opt_db, monkeypatch):
-        """Gemini 拋出例外時 reflect_weekly 回傳空 list 不崩潰"""
+        """LLM 拋出例外時 reflect_weekly 回傳空 list 不崩潰"""
         import sys, types
-        fake_gemini = types.ModuleType("openclaw.llm_gemini")
-        def bad_call(*a, **kw): raise RuntimeError("Gemini timeout")
-        fake_gemini.call_gemini = bad_call
-        sys.modules["openclaw.llm_gemini"] = fake_gemini
+        fake_minimax = types.ModuleType("openclaw.llm_minimax")
+        def bad_call(model, prompt): raise RuntimeError("MiniMax timeout")
+        fake_minimax.minimax_call = bad_call
+        sys.modules["openclaw.llm_minimax"] = fake_minimax
 
         from openclaw.strategy_optimizer import ReflectionAgent
         result = ReflectionAgent(opt_db).reflect_weekly()


### PR DESCRIPTION
## 變更摘要

### 修復
- `_ensure_optimizer_schema`：冪等建立 `param_bounds` 表並初始化 `trailing_pct` 護欄；用 `WHERE NOT EXISTS` 避免重複插入 `risk_limits` 初始值（解決舊版 `INSERT OR IGNORE` 每次生成新 UUID 造成多行的問題）
- `_adjust_param` SQL：欄位名稱從舊版 `name`/`value` 修正為 production schema 的 `rule_name`/`rule_value`（舊版因欄位不符，靜默失敗從未實際調整過任何參數）
- `eod_ingest.main()`：在 `finally` 區塊串接 `OptimizationGateway`，`status=success` 時自動觸發盤後優化，失敗只寫 stderr 不影響主流程

### 測試
- `test_strategy_optimizer.py`：`risk_limits` fixture schema 對齊 production（`limit_id/scope/rule_name/rule_value/enabled/updated_at`）；`TestReflectionAgent` mock 改為 `minimax_call`（跟隨 PR #257 LLM 遷移）
- 全套 2042 tests 通過 ✅

## 影響評估
- HIGH: `_adjust_param` SQL 修正讓自動調整邏輯首次實際生效，`eod_ingest` 每日觸發 optimizer
- LOW: fixture schema 更新、無業務行為變更

Closes #258