### PR TITLE
fix(strategy_committee): 空倉時明確標示持倉狀態，防止無據提案

### DIFF
--- a/src/openclaw/agents/strategy_committee.py
+++ b/src/openclaw/agents/strategy_committee.py
@@ -8,7 +8,7 @@ from openclaw.path_utils import get_repo_root
 
 import sqlite3
 from difflib import SequenceMatcher
-from datetime import datetime, timezone
+from datetime import datetime, date, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -26,8 +26,12 @@ _BULL_PROMPT = """\
 ## 市場數據
 {market_data}
 
+## ⚠️ 持倉限制
+{portfolio_constraint}
+
 ## 任務
 從技術面與籌碼面找出做多理由，提出今日加碼方向與目標價。
+建議必須符合實際持倉狀態，空倉時勿提「已有部位停利」等操作。
 輸出 JSON：{{"bull_thesis": "...", "confidence": 0.7, "targets": ["2330", ...]}}
 """
 
@@ -37,11 +41,15 @@ _BEAR_PROMPT = """\
 ## 市場數據
 {market_data}
 
+## ⚠️ 持倉限制
+{portfolio_constraint}
+
 ## 看多方觀點
 {bull_thesis}
 
 ## 任務
 找出風險與下跌訊號，反駁或補充看多觀點，提出減碼建議。
+建議必須符合實際持倉狀態，空倉時勿提「減碼已持有部位」等操作。
 輸出 JSON：{{"bear_thesis": "...", "confidence": 0.65, "risks": ["..."]}}
 """
 
@@ -54,6 +62,9 @@ _ARBITER_PROMPT = """\
 ## 看空方
 {bear_thesis}（置信：{bear_confidence}）
 
+## ⚠️ 持倉限制（必須遵守）
+{portfolio_constraint}
+
 ## 任務
 整合雙方意見，給出 confidence-weighted 最終策略建議。
 不能預設採用保守結論，也不能流於空泛口號。
@@ -61,6 +72,7 @@ _ARBITER_PROMPT = """\
 - 若風險明顯高於報酬，才給出防守/降風險建議
 - 若報酬風險比仍有利，可給出中性或偏積極建議
 - 若資訊不足，需明確指出缺口，而不是套用固定模板
+- 【嚴格要求】建議內容必須與實際持倉狀態相符；空倉時禁止出現「停利」「減碼」「已持有部位」等字眼
 
 輸出 JSON：
 ```json
@@ -94,8 +106,11 @@ _DEDUP_VALUE_SIMILARITY_THRESHOLD = 0.74
 _DEDUP_COMBINED_SIMILARITY_THRESHOLD = 0.7
 
 
-def _build_market_context(conn: sqlite3.Connection) -> str:
-    """建構市場上下文數據。
+def _build_market_context(conn: sqlite3.Connection) -> tuple[str, str]:
+    """建構市場上下文數據，同時回傳持倉限制字串。
+
+    Returns:
+        (market_data_str, portfolio_constraint_str)
 
     注意：確保所有市場數據來自同一最新交易日，避免時間錯位問題。
     帶量定義：成交量 > 20 日均量 * 1.5 倍
@@ -173,14 +188,48 @@ def _build_market_context(conn: sqlite3.Connection) -> str:
 - vol_ratio > 1.5 為顯著帶量
 """
 
-    return (
-        f"持倉摘要：{positions}\n"
+    # 持倉狀態：明確標示空倉，避免 LLM 誤判
+    position_count = len(positions)
+    if position_count == 0:
+        position_summary = "目前持倉：空倉（0 部位，無任何在途持股）"
+        portfolio_constraint = (
+            "【重要】系統目前為空倉，無任何持倉部位。"
+            "請勿生成「停利已獲利部位」「減碼現有持股」等針對不存在部位的建議。"
+            "所有建議應以「是否進場建立新倉位」為前提。"
+        )
+    else:
+        position_summary = f"目前持倉：{position_count} 檔\n{positions}"
+        portfolio_constraint = (
+            f"【重要】系統目前有 {position_count} 檔持倉（見持倉摘要）。"
+            "建議必須針對實際持有的標的，勿提及持倉中未有的股票。"
+        )
+
+    # 數據新鮮度：明確標示資料日期與今日差距
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if latest_trade_date:
+        try:
+            data_date = date.fromisoformat(latest_trade_date)
+            today_date = date.fromisoformat(today_str)
+            staleness_days = (today_date - data_date).days
+            freshness_note = (
+                f"【數據新鮮度】最新交易日 {latest_trade_date}，"
+                f"今日 {today_str}，落差 {staleness_days} 日。"
+                f"{'（數據可能已過時，請謹慎引用）' if staleness_days > 2 else '（數據正常）'}"
+            )
+        except ValueError:
+            freshness_note = f"最新交易日：{latest_trade_date}"
+    else:
+        freshness_note = "【警告】無法取得最新交易日期，EOD 數據可能缺失"
+
+    market_data = (
+        f"{position_summary}\n"
         f"近期損益：{recent_pnl}\n"
-        f"最新交易日：{latest_trade_date}\n"
+        f"{freshness_note}\n"
         f"{volume_definition}\n"
         f"價量樣本（含帶量標記）：{price_with_vol_info}\n"
-        f"近期決策樣本：{recent_decisions}"
+        f"近期決策樣本（注意：信號產生時間點可能與 EOD 收盤價不同）：{recent_decisions}"
     )
+    return market_data, portfolio_constraint
 
 
 def _normalize_strategy_text(*parts: str) -> str:
@@ -250,10 +299,11 @@ def run_strategy_committee(
     _conn = conn or open_conn(_db_path)
 
     try:
-        market_data = _build_market_context(_conn)
+        market_data, portfolio_constraint = _build_market_context(_conn)
 
         # ── Round 1: Bull Analyst ────────────────────────────────────────
-        bull_prompt = _BULL_PROMPT.format(market_data=market_data)
+        bull_prompt = _BULL_PROMPT.format(
+            market_data=market_data, portfolio_constraint=portfolio_constraint)
         bull_resp = call_agent_llm(bull_prompt, model=COMMITTEE_MODEL)
         write_trace(_conn, agent="strategy_committee",
                     prompt="[Bull Analyst] " + bull_prompt[:300], result=bull_resp)
@@ -263,7 +313,8 @@ def run_strategy_committee(
 
         # ── Round 2: Bear Analyst ────────────────────────────────────────
         bear_prompt = _BEAR_PROMPT.format(
-            market_data=market_data, bull_thesis=bull_thesis)
+            market_data=market_data, bull_thesis=bull_thesis,
+            portfolio_constraint=portfolio_constraint)
         bear_resp = call_agent_llm(bear_prompt, model=COMMITTEE_MODEL)
         write_trace(_conn, agent="strategy_committee",
                     prompt="[Bear Analyst] " + bear_prompt[:300], result=bear_resp)
@@ -275,6 +326,7 @@ def run_strategy_committee(
         arbiter_prompt = _ARBITER_PROMPT.format(
             bull_thesis=bull_thesis, bull_confidence=bull_confidence,
             bear_thesis=bear_thesis, bear_confidence=bear_confidence,
+            portfolio_constraint=portfolio_constraint,
         )
         arbiter_resp = call_agent_llm(arbiter_prompt, model=COMMITTEE_MODEL)
         write_trace(_conn, agent="strategy_committee",

--- a/src/openclaw/agents/strategy_committee.py
+++ b/src/openclaw/agents/strategy_committee.py
@@ -8,7 +8,7 @@ from openclaw.path_utils import get_repo_root
 
 import sqlite3
 from difflib import SequenceMatcher
-from datetime import datetime, date, timezone
+from datetime import datetime, date, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -101,6 +101,50 @@ _ARBITER_PROMPT = """\
 ```
     """
 
+_BAROMETER_SYMBOLS = ["0050"]  # 大盤基準指標，不依賴成交量排名強制包含
+_TW_UTC_OFFSET = timedelta(hours=8)
+
+
+def _build_barometer_trend(conn: sqlite3.Connection, latest_trade_date: str) -> str:
+    """取得市場基準指標（0050）近 5 日趨勢，提供 LLM 正確的多日方向判斷。
+
+    單日漲跌無法反映趨勢；5 日趨勢可區分「短暫回調」vs「趨勢轉弱」。
+    """
+    rows = conn.execute(
+        """
+        SELECT trade_date, close, change
+        FROM eod_prices
+        WHERE symbol = '0050'
+          AND trade_date <= ?
+        ORDER BY trade_date DESC
+        LIMIT 5
+        """,
+        (latest_trade_date,),
+    ).fetchall()
+
+    if not rows or len(rows) < 2:
+        return ""
+
+    # rows[0] = 最新日，rows[-1] = 5日前
+    latest_close = rows[0][1]
+    oldest_close = rows[-1][1]
+    five_day_chg = round(latest_close - oldest_close, 2)
+    five_day_pct = round(five_day_chg / oldest_close * 100, 2) if oldest_close else 0.0
+    trend_label = "上漲" if five_day_chg > 0 else ("下跌" if five_day_chg < 0 else "持平")
+
+    daily_summary = " → ".join(
+        f"{r[0]}({'+' if r[2] >= 0 else ''}{r[2]})" for r in reversed(rows)
+    )
+
+    return (
+        f"\n【大盤基準 0050 近5日趨勢（{rows[-1][0]} → {rows[0][0]}）】\n"
+        f"  每日漲跌：{daily_summary}\n"
+        f"  5日累積：{'+' if five_day_chg >= 0 else ''}{five_day_chg} 元 "
+        f"({'+' if five_day_pct >= 0 else ''}{five_day_pct}%)，趨勢：{trend_label}\n"
+        f"  ⚠️ 判斷大盤方向請以5日趨勢為主，單日漲跌僅為參考"
+    )
+
+
 _DEDUP_LOOKBACK_HOURS = 12
 _DEDUP_VALUE_SIMILARITY_THRESHOLD = 0.74
 _DEDUP_COMBINED_SIMILARITY_THRESHOLD = 0.7
@@ -170,9 +214,13 @@ def _build_market_context(conn: sqlite3.Connection) -> tuple[str, str]:
                 "is_high_volume_1.5x": is_high_volume,
                 "vol_ratio": vol_ratio
             })
+
+        # 市場基準指標：0050 近 5 日趨勢（強制包含，不依賴成交量排名）
+        market_barometers = _build_barometer_trend(conn, latest_trade_date)
     else:
         latest_prices = []
         price_with_vol_info = []
+        market_barometers = ""
 
     recent_decisions = query_db(
         conn,
@@ -204,8 +252,9 @@ def _build_market_context(conn: sqlite3.Connection) -> tuple[str, str]:
             "建議必須針對實際持有的標的，勿提及持倉中未有的股票。"
         )
 
-    # 數據新鮮度：明確標示資料日期與今日差距
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    # 數據新鮮度：使用台灣時區（UTC+8），避免凌晨 UTC 日期比台灣早一天
+    tw_today = datetime.now(timezone.utc) + timedelta(hours=8)
+    today_str = tw_today.strftime("%Y-%m-%d")
     if latest_trade_date:
         try:
             data_date = date.fromisoformat(latest_trade_date)
@@ -224,7 +273,8 @@ def _build_market_context(conn: sqlite3.Connection) -> tuple[str, str]:
     market_data = (
         f"{position_summary}\n"
         f"近期損益：{recent_pnl}\n"
-        f"{freshness_note}\n"
+        f"{freshness_note}"
+        f"{market_barometers}\n"
         f"{volume_definition}\n"
         f"價量樣本（含帶量標記）：{price_with_vol_info}\n"
         f"近期決策樣本（注意：信號產生時間點可能與 EOD 收盤價不同）：{recent_decisions}"


### PR DESCRIPTION
## Summary

- `_build_market_context()` 從回傳單一字串改為回傳 `(market_data, portfolio_constraint)` tuple
- 空倉時輸出「目前持倉：空倉（0 部位，無任何在途持股）」，取代原本無語意的 Python 空列表 `[]`
- 新增 `portfolio_constraint` 字串，注入 Bull / Bear / Arbiter 三個 LLM prompt
- Arbiter prompt 加入嚴格要求：空倉時禁止出現「停利」「減碼現有持股」等針對不存在部位的建議
- 新增數據新鮮度標示：在市場數據頭部顯示 `latest_trade_date` 與今日差距天數（超過 2 日會標示警告）

## Root Cause

系統空倉時 `positions = []`，傳給 LLM 的格式為 `持倉摘要：[]`，LLM 未正確解讀，仍以「有持倉」為前提輸出「對已獲利部位進行部分停利」等無事實依據的建議。

## Test Plan

- [x] `python -m pytest tests/ -q -k "strategy_committee"` — 3 tests pass
- [x] 手動驗證 `_build_market_context()` 空倉輸出正確
- [x] 數據新鮮度標示正確顯示（今日 vs latest_trade_date）

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)