### PR TITLE
fix(broker): ShioajiAdapter 實際手續費與證交稅計算

### DIFF
--- a/src/openclaw/broker.py
+++ b/src/openclaw/broker.py
@@ -207,7 +207,7 @@ class ShioajiAdapter:
                 trade = self.api.place_order(contract, order)
 
                 broker_order_id = getattr(trade.status, "id", "") or f"SHIOAJI-{order_id}"
-                self._trades[broker_order_id] = trade
+                self._trades[broker_order_id] = {"trade": trade, "side": candidate.side}
                 return BrokerSubmission(broker_order_id=broker_order_id, status="submitted")
             except Exception as exc:
                 last_exc = exc
@@ -231,22 +231,33 @@ class ShioajiAdapter:
         Query latest broker status for an order.
         """
         try:
-            trade = self._trades.get(broker_order_id)
-            if trade is None:
+            entry = self._trades.get(broker_order_id)
+            if entry is None:
                 return None
+
+            trade = entry["trade"]
+            side = entry["side"]
 
             self.api.update_status(self.account)
             raw_status = str(getattr(trade.status, "status", "")).lower()
             mapped_status = map_shioaji_exec_status(raw_status)
             filled_qty = int(getattr(trade.status, "deal_quantity", 0) or 0)
             avg_price = float(getattr(trade.status, "avg_price", 0.0) or 0.0)
+
+            # 台股交易成本：手續費 0.1425%（買賣雙向），證交稅 0.3%（sell only）
+            _COMMISSION_RATE = 0.001425
+            _TAX_RATE_SELL = 0.003
+            trade_value = avg_price * filled_qty
+            fee = round(trade_value * _COMMISSION_RATE)
+            tax = round(trade_value * _TAX_RATE_SELL) if side == "sell" else 0
+
             return BrokerOrderStatus(
                 broker_order_id=broker_order_id,
                 status=mapped_status,
                 filled_qty=filled_qty,
                 avg_fill_price=avg_price,
-                fee=0.0,
-                tax=0.0,
+                fee=float(fee),
+                tax=float(tax),
             )
         except Exception as exc:
             reason_code = map_shioaji_error_to_reason_code(getattr(exc, "code", None), str(exc))
@@ -259,14 +270,15 @@ class ShioajiAdapter:
 
     def cancel_order(self, broker_order_id: str) -> BrokerSubmission:
         try:
-            trade = self._trades.get(broker_order_id)
-            if trade is None:
+            entry = self._trades.get(broker_order_id)
+            if entry is None:
                 return BrokerSubmission(
                     broker_order_id=broker_order_id,
                     status="rejected",
                     reason="order not found",
                     reason_code="EXEC_BROKER_UNKNOWN",
                 )
+            trade = entry["trade"]
             self.api.cancel_order(trade)
             return BrokerSubmission(
                 broker_order_id=broker_order_id,

--- a/src/tests/test_broker.py
+++ b/src/tests/test_broker.py
@@ -357,7 +357,7 @@ def test_shioaji_adapter_poll_order_status_none_if_not_found():
 def test_shioaji_adapter_poll_order_status_success():
     api, trade = _make_mock_api(broker_id="SJ-100", status_str="filled", deal_qty=1000, avg_price=580.0)
     adapter = ShioajiAdapter(api, MagicMock())
-    adapter._trades["SJ-100"] = trade
+    adapter._trades["SJ-100"] = {"trade": trade, "side": "buy"}
     result = adapter.poll_order_status("SJ-100")
     assert result is not None
     assert result.status == "filled"
@@ -371,7 +371,7 @@ def test_shioaji_adapter_poll_order_status_exception():
     api.update_status.side_effect = Exception("network connection reset")
     trade = MagicMock()
     adapter = ShioajiAdapter(api, MagicMock())
-    adapter._trades["SJ-200"] = trade
+    adapter._trades["SJ-200"] = {"trade": trade, "side": "buy"}
     result = adapter.poll_order_status("SJ-200")
     assert result is not None
     assert result.status == "rejected"
@@ -390,7 +390,7 @@ def test_shioaji_adapter_cancel_order_not_found():
 def test_shioaji_adapter_cancel_order_success():
     api, trade = _make_mock_api()
     adapter = ShioajiAdapter(api, MagicMock())
-    adapter._trades["SJ-300"] = trade
+    adapter._trades["SJ-300"] = {"trade": trade, "side": "buy"}
     result = adapter.cancel_order("SJ-300")
     assert result.status == "submitted"
     api.cancel_order.assert_called_once_with(trade)
@@ -401,7 +401,7 @@ def test_shioaji_adapter_cancel_order_exception():
     api.cancel_order.side_effect = Exception("timeout")
     trade = MagicMock()
     adapter = ShioajiAdapter(api, MagicMock())
-    adapter._trades["SJ-400"] = trade
+    adapter._trades["SJ-400"] = {"trade": trade, "side": "buy"}
     result = adapter.cancel_order("SJ-400")
     assert result.status == "rejected"
     assert result.reason_code == "EXEC_NETWORK_TIMEOUT"
@@ -415,7 +415,7 @@ def test_wait_for_terminal_returns_filled_immediately():
     """When first poll returns 'filled', we get it back without looping."""
     api, trade = _make_mock_api(broker_id="SJ-T1", status_str="filled", deal_qty=1000, avg_price=580.0)
     adapter = ShioajiAdapter(api, MagicMock(), poll_interval_sec=0.01, max_poll_seconds=2.0)
-    adapter._trades["SJ-T1"] = trade
+    adapter._trades["SJ-T1"] = {"trade": trade, "side": "buy"}
 
     with patch("openclaw.broker.time.sleep") as mock_sleep:
         result = adapter.wait_for_terminal("SJ-T1")
@@ -437,7 +437,7 @@ def test_wait_for_terminal_returns_cancelled():
 
     api.update_status.return_value = None
     adapter = ShioajiAdapter(api, account, poll_interval_sec=0.01, max_poll_seconds=2.0)
-    adapter._trades["SJ-CANCEL"] = trade
+    adapter._trades["SJ-CANCEL"] = {"trade": trade, "side": "buy"}
 
     with patch("openclaw.broker.time.sleep"):
         result = adapter.wait_for_terminal("SJ-CANCEL")
@@ -459,7 +459,7 @@ def test_wait_for_terminal_times_out_returns_latest():
 
     api.update_status.return_value = None
     adapter = ShioajiAdapter(api, account, poll_interval_sec=0.01, max_poll_seconds=0.0)
-    adapter._trades["SJ-SLOW"] = trade
+    adapter._trades["SJ-SLOW"] = {"trade": trade, "side": "buy"}
 
     # With max_poll_seconds=0, deadline is already in the past
     result = adapter.wait_for_terminal("SJ-SLOW")

--- a/tests/test_broker_shioaji.py
+++ b/tests/test_broker_shioaji.py
@@ -17,11 +17,29 @@ def test_poll_order_status_filled():
     mock_trade.status.status = "Filled"
     mock_trade.status.deal_quantity = 100
     mock_trade.status.avg_price = 600.0
-    adapter._trades["test-oid"] = mock_trade
+    adapter._trades["test-oid"] = {"trade": mock_trade, "side": "buy"}
     result = adapter.poll_order_status("test-oid")
     assert result is not None
     assert result.status == "filled"
     assert result.filled_qty == 100
+    # fee = round(600.0 * 100 * 0.001425) = round(85.5) = 86; tax = 0 (buy)
+    assert result.fee == round(600.0 * 100 * 0.001425)
+    assert result.tax == 0
+
+
+def test_poll_order_status_filled_sell():
+    adapter = _make_adapter()
+    mock_trade = MagicMock()
+    mock_trade.status.status = "Filled"
+    mock_trade.status.deal_quantity = 100
+    mock_trade.status.avg_price = 600.0
+    adapter._trades["test-oid"] = {"trade": mock_trade, "side": "sell"}
+    result = adapter.poll_order_status("test-oid")
+    assert result is not None
+    assert result.status == "filled"
+    # fee = round(600.0 * 100 * 0.001425); tax = round(600.0 * 100 * 0.003)
+    assert result.fee == round(600.0 * 100 * 0.001425)
+    assert result.tax == round(600.0 * 100 * 0.003)
 
 
 def test_poll_order_status_partial():
@@ -30,7 +48,7 @@ def test_poll_order_status_partial():
     mock_trade.status.status = "Part_Filled"
     mock_trade.status.deal_quantity = 50
     mock_trade.status.avg_price = 600.0
-    adapter._trades["test-oid"] = mock_trade
+    adapter._trades["test-oid"] = {"trade": mock_trade, "side": "buy"}
     result = adapter.poll_order_status("test-oid")
     assert result is not None
     assert result.status == "partially_filled"
@@ -155,7 +173,7 @@ def test_cancel_order_success():
     """Cancel existing order → submitted."""
     adapter = _make_adapter()
     mock_trade = MagicMock()
-    adapter._trades["test-oid"] = mock_trade
+    adapter._trades["test-oid"] = {"trade": mock_trade, "side": "sell"}
     result = adapter.cancel_order("test-oid")
     assert result.status == "submitted"
     adapter.api.cancel_order.assert_called_once_with(mock_trade)
@@ -165,7 +183,7 @@ def test_cancel_order_api_exception():
     """Cancel API throws → rejected with reason_code."""
     adapter = _make_adapter()
     mock_trade = MagicMock()
-    adapter._trades["test-oid"] = mock_trade
+    adapter._trades["test-oid"] = {"trade": mock_trade, "side": "sell"}
     adapter.api.cancel_order.side_effect = Exception("network error")
     result = adapter.cancel_order("test-oid")
     assert result.status == "rejected"
@@ -184,7 +202,7 @@ def test_wait_for_terminal_filled():
     mock_trade.status.status = "Filled"
     mock_trade.status.deal_quantity = 100
     mock_trade.status.avg_price = 600.0
-    adapter._trades["test-oid"] = mock_trade
+    adapter._trades["test-oid"] = {"trade": mock_trade, "side": "buy"}
     with patch("time.sleep"):
         result = adapter.wait_for_terminal("test-oid")
     assert result.status == "filled"
@@ -198,7 +216,7 @@ def test_wait_for_terminal_timeout():
     mock_trade.status.status = "Submitted"
     mock_trade.status.deal_quantity = 0
     mock_trade.status.avg_price = 0.0
-    adapter._trades["test-oid"] = mock_trade
+    adapter._trades["test-oid"] = {"trade": mock_trade, "side": "buy"}
     # With max_poll_seconds=0, the while loop never executes; returns initial "submitted"
     result = adapter.wait_for_terminal("test-oid")
     assert result.broker_order_id == "test-oid"


### PR DESCRIPTION
## Summary
- `ShioajiAdapter.poll_order_status()` 原本 `fee=0.0, tax=0.0` 硬編碼
- 修正為正確公式：`fee = round(price × qty × 0.001425)`，`tax = round(price × qty × 0.003)` (sell only)
- 新增 `tests/test_broker_shioaji.py` 驗證費用計算

## Test plan
- [ ] `pytest tests/test_broker_shioaji.py -q` 通過
- [ ] 確認 sell 訂單產生正確 fee + tax
- [ ] 確認 buy 訂單 tax=0

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)