### PR TITLE
fix(quick-wins): requests 依賴補充 + LLM temperature 參數化

### DIFF
--- a/frontend/backend/requirements.txt
+++ b/frontend/backend/requirements.txt
@@ -17,5 +17,7 @@ google-genai>=1.0
 # Anthropic Claude (for chat feature — optional, falls back to Gemini)
 anthropic>=0.84
 
+requests>=2.28.0
+
 # Optional: install separately for live/simulation broker mode
 # pip install shioaji>=1.0

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "shioaji>=1.0",
+        "requests>=2.28.0",
     ],
     python_requires=">=3.10",
 )

--- a/src/openclaw/agents/base.py
+++ b/src/openclaw/agents/base.py
@@ -39,10 +39,11 @@ def query_db(conn: sqlite3.Connection, sql: str, params: tuple = ()) -> List[Dic
 def call_agent_llm(
     prompt: str,
     model: str = DEFAULT_MODEL,
+    temperature: float = 0.2,
 ) -> Dict[str, Any]:
     """呼叫 MiniMax M2.5，回傳解析後的 dict。失敗時回傳 fallback dict。"""
     try:
-        return minimax_call(model, prompt)
+        return minimax_call(model, prompt, temperature=temperature)
     except Exception as e:
         return {
             "summary": f"LLM 呼叫失敗：{e}",

--- a/src/openclaw/llm_minimax.py
+++ b/src/openclaw/llm_minimax.py
@@ -47,12 +47,13 @@ def _extract_json(text: str) -> Dict[str, Any]:
     raise ValueError(f"Cannot parse JSON from MiniMax response: {text[:300]}")
 
 
-def minimax_call(model: str, prompt: str) -> Dict[str, Any]:
+def minimax_call(model: str, prompt: str, temperature: float = 0.2) -> Dict[str, Any]:
     """呼叫 MiniMax M2.5，回傳解析後的 JSON dict。
 
     Args:
         model: MiniMax 模型 ID，e.g. "MiniMax-M2.5"。
         prompt: 完整 prompt 字串。
+        temperature: 生成溫度，預設 0.2（策略審查用低溫度確保確定性）。
 
     Returns:
         解析後的 dict，包含 '_raw_response', '_prompt', '_latency_ms', '_model'。
@@ -74,7 +75,7 @@ def minimax_call(model: str, prompt: str) -> Dict[str, Any]:
         "model": model,
         "messages": [{"role": "user", "content": prompt}],
         "response_format": {"type": "json_object"},
-        "temperature": 0.7,
+        "temperature": temperature,
     }
 
     t0 = time.time()


### PR DESCRIPTION
## Summary
- **#271** `setup.py` / `requirements.txt` 新增 `requests>=2.28.0`
- **#274** `call_minimax()` 新增 `temperature: float = 0.2` 參數（原本 0.7 硬編碼）；strategy committee 維持 0.2 保守推斷模式

## Test plan
- [ ] `pip install -e .` 無 missing dependency 錯誤
- [ ] `pytest src/tests/test_agents.py -q` 通過

Closes #271
Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)