### PR TITLE
fix(trading-calendar): T+2 交割日正確排除台股國定假日

### DIFF
--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -167,18 +167,13 @@ def _utc_now_iso() -> str:
 
 
 def _t2_settlement_date(trade_date: "dt.date") -> str:
-    """計算台股 T+2 交割日（跳過週六、週日）。
+    """計算台股 T+2 交割日（跳過週末與國定假日）。
 
-    台灣股市無公眾假日邏輯（依 trading calendar），這裡簡化為僅跳過週末。
+    使用 trading_calendar.get_settlement_date() 正確排除台灣國定假日。
     Returns: YYYY-MM-DD 字串
     """
-    d = trade_date
-    added = 0
-    while added < 2:
-        d += dt.timedelta(days=1)
-        if d.weekday() < 5:  # 0=Mon … 4=Fri
-            added += 1
-    return d.strftime("%Y-%m-%d")
+    from openclaw.trading_calendar import get_settlement_date
+    return get_settlement_date(trade_date).strftime("%Y-%m-%d")
 
 
 # ── Logging ──────────────────────────────────────────────────────────────────

--- a/src/openclaw/trading_calendar.py
+++ b/src/openclaw/trading_calendar.py
@@ -1,11 +1,106 @@
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import sqlite3
 from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+# ── 台灣股票交易所國定假日（2025–2026）────────────────────────────────────────
+TAIWAN_HOLIDAYS_2024_2026: set[date] = {
+    # 2025 Taiwan public holidays (TSE calendar)
+    date(2025, 1, 1),   # New Year's Day 元旦
+    date(2025, 1, 27),  # Lunar New Year eve 農曆除夕
+    date(2025, 1, 28),  # Lunar New Year Day 1 春節
+    date(2025, 1, 29),  # Lunar New Year Day 2 春節
+    date(2025, 1, 30),  # Lunar New Year Day 3 春節
+    date(2025, 1, 31),  # Lunar New Year Day 4 春節
+    date(2025, 2, 28),  # Peace Memorial Day 和平紀念日
+    date(2025, 4, 3),   # Children's Day 兒童節
+    date(2025, 4, 4),   # Tomb Sweeping Day 清明節
+    date(2025, 5, 1),   # Labor Day 勞動節
+    date(2025, 5, 30),  # Dragon Boat Festival eve 端午節補假
+    date(2025, 5, 31),  # Dragon Boat Festival 端午節
+    date(2025, 10, 6),  # Mid-Autumn Festival 中秋節
+    date(2025, 10, 10), # National Day 國慶日
+    # 2026 Taiwan public holidays (TSE calendar)
+    date(2026, 1, 1),   # New Year's Day 元旦
+    date(2026, 2, 16),  # Lunar New Year Day 1 春節
+    date(2026, 2, 17),  # Lunar New Year Day 2 春節
+    date(2026, 2, 18),  # Lunar New Year Day 3 春節
+    date(2026, 2, 19),  # Lunar New Year Day 4 春節
+    date(2026, 2, 20),  # Lunar New Year Day 5 春節
+    date(2026, 3, 28),  # Tomb Sweeping Day makeup 清明節補假
+    date(2026, 4, 3),   # Children's Day 兒童節
+    date(2026, 4, 4),   # Tomb Sweeping Day 清明節
+    date(2026, 6, 19),  # Dragon Boat Festival 端午節
+    date(2026, 9, 25),  # Mid-Autumn Festival 中秋節
+    date(2026, 10, 9),  # National Day makeup 國慶日補假
+    date(2026, 10, 10), # National Day 國慶日
+}
+
+
+def is_trading_day(d: date) -> bool:
+    """判斷指定日期是否為台股交易日。
+
+    非交易日條件：週六、週日、或在 TAIWAN_HOLIDAYS_2024_2026 中的國定假日。
+
+    Args:
+        d: 要判斷的日期。
+
+    Returns:
+        True 表示為交易日；False 表示非交易日。
+    """
+    if d.weekday() >= 5:  # 5=Saturday, 6=Sunday
+        return False
+    if d in TAIWAN_HOLIDAYS_2024_2026:
+        return False
+    return True
+
+
+def next_trading_day(d: date) -> date:
+    """回傳指定日期之後（不含當天）的下一個交易日。
+
+    Args:
+        d: 起始日期（不含）。
+
+    Returns:
+        下一個交易日。
+    """
+    candidate = d + _dt.timedelta(days=1)
+    while not is_trading_day(candidate):
+        candidate += _dt.timedelta(days=1)
+    return candidate
+
+
+def add_trading_days(d: date, n: int) -> date:
+    """從指定日期向後推進 n 個交易日。
+
+    Args:
+        d: 起始日期（不含在計數內）。
+        n: 要推進的交易日數量，必須為正整數。
+
+    Returns:
+        推進 n 個交易日後的日期。
+    """
+    result = d
+    for _ in range(n):
+        result = next_trading_day(result)
+    return result
+
+
+def get_settlement_date(trade_date: date) -> date:
+    """計算台股 T+2 交割日，正確排除週末與國定假日。
+
+    Args:
+        trade_date: 交易日期。
+
+    Returns:
+        T+2 交割日（date 物件）。
+    """
+    return add_trading_days(trade_date, 2)
 
 
 class SeasonalEffectType(str, Enum):

--- a/src/tests/test_trading_calendar.py
+++ b/src/tests/test_trading_calendar.py
@@ -106,3 +106,70 @@ def test_get_effects_for_date_builtin_festival_match():
     assert SeasonalEffectType.FESTIVAL in types
     names = [e.name for e in eff if e.effect_type == SeasonalEffectType.FESTIVAL]
     assert any("春節" in n for n in names)
+
+
+# ── is_trading_day / get_settlement_date / add_trading_days (Issue #269) ─────
+
+from openclaw.trading_calendar import (
+    TAIWAN_HOLIDAYS_2024_2026,
+    add_trading_days,
+    get_settlement_date,
+    is_trading_day,
+    next_trading_day,
+)
+
+
+class TestIsTradingDay:
+    def test_saturday_is_not_trading_day(self):
+        assert is_trading_day(date(2025, 3, 1)) is False
+
+    def test_sunday_is_not_trading_day(self):
+        assert is_trading_day(date(2025, 3, 2)) is False
+
+    def test_regular_weekday_is_trading_day(self):
+        assert is_trading_day(date(2025, 3, 3)) is True
+
+    def test_new_year_2025_is_not_trading_day(self):
+        assert is_trading_day(date(2025, 1, 1)) is False
+
+    def test_tomb_sweeping_2025(self):
+        assert is_trading_day(date(2025, 4, 3)) is False
+        assert is_trading_day(date(2025, 4, 4)) is False
+
+    def test_national_day_2026(self):
+        assert is_trading_day(date(2026, 10, 9)) is False
+        assert is_trading_day(date(2026, 10, 10)) is False
+
+
+class TestGetSettlementDate:
+    def test_t2_normal_weekday(self):
+        # Mon 2025-03-03 → T+2 = Wed 2025-03-05
+        assert get_settlement_date(date(2025, 3, 3)) == date(2025, 3, 5)
+
+    def test_t2_skips_weekend(self):
+        # Thu 2025-03-06 → skip Sat/Sun → Mon 10
+        assert get_settlement_date(date(2025, 3, 6)) == date(2025, 3, 10)
+
+    def test_t2_skips_holiday_tomb_sweeping_2025(self):
+        # 2025-04-02 (Wed) → skip 04-03 + 04-04 holidays → T+1=04-07, T+2=04-08
+        assert get_settlement_date(date(2025, 4, 2)) == date(2025, 4, 8)
+
+    def test_t2_mid_autumn_2025(self):
+        # 2025-10-03 (Fri) → skip 04 Sat, 05 Sun, 06 Mon (holiday) → T+1=07, T+2=08
+        assert get_settlement_date(date(2025, 10, 3)) == date(2025, 10, 8)
+
+
+class TestAddTradingDays:
+    def test_add_five_skips_weekend(self):
+        # Mon 2025-03-03 +5 → Mon 2025-03-10
+        assert add_trading_days(date(2025, 3, 3), 5) == date(2025, 3, 10)
+
+
+class TestHolidaySet:
+    def test_contains_key_2025_holidays(self):
+        assert date(2025, 1, 1) in TAIWAN_HOLIDAYS_2024_2026
+        assert date(2025, 2, 28) in TAIWAN_HOLIDAYS_2024_2026
+
+    def test_contains_key_2026_holidays(self):
+        assert date(2026, 1, 1) in TAIWAN_HOLIDAYS_2024_2026
+        assert date(2026, 6, 19) in TAIWAN_HOLIDAYS_2024_2026

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -1,0 +1,182 @@
+"""tests/test_trading_calendar.py
+
+測試 trading_calendar 新增的交易日判斷與 T+2 交割日計算功能。
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from openclaw.trading_calendar import (
+    TAIWAN_HOLIDAYS_2024_2026,
+    add_trading_days,
+    get_settlement_date,
+    is_trading_day,
+    next_trading_day,
+)
+
+
+# ── is_trading_day ────────────────────────────────────────────────────────────
+
+class TestIsTradingDay:
+    def test_saturday_is_not_trading_day(self):
+        # 2025-03-01 is Saturday
+        assert is_trading_day(date(2025, 3, 1)) is False
+
+    def test_sunday_is_not_trading_day(self):
+        # 2025-03-02 is Sunday
+        assert is_trading_day(date(2025, 3, 2)) is False
+
+    def test_regular_weekday_is_trading_day(self):
+        # 2025-03-03 is Monday (no holiday)
+        assert is_trading_day(date(2025, 3, 3)) is True
+
+    def test_another_regular_weekday(self):
+        # 2025-03-05 is Wednesday
+        assert is_trading_day(date(2025, 3, 5)) is True
+
+    def test_new_year_2025_is_not_trading_day(self):
+        assert is_trading_day(date(2025, 1, 1)) is False
+
+    def test_lunar_new_year_2025_days_are_not_trading_days(self):
+        for d in [27, 28, 29, 30, 31]:
+            assert is_trading_day(date(2025, 1, d)) is False, f"2025-01-{d} should be holiday"
+
+    def test_peace_memorial_day_2025(self):
+        assert is_trading_day(date(2025, 2, 28)) is False
+
+    def test_tomb_sweeping_2025(self):
+        assert is_trading_day(date(2025, 4, 3)) is False
+        assert is_trading_day(date(2025, 4, 4)) is False
+
+    def test_labor_day_2025(self):
+        assert is_trading_day(date(2025, 5, 1)) is False
+
+    def test_dragon_boat_2025(self):
+        assert is_trading_day(date(2025, 5, 30)) is False
+        assert is_trading_day(date(2025, 5, 31)) is False
+
+    def test_mid_autumn_2025(self):
+        assert is_trading_day(date(2025, 10, 6)) is False
+
+    def test_national_day_2025(self):
+        assert is_trading_day(date(2025, 10, 10)) is False
+
+    def test_new_year_2026_is_not_trading_day(self):
+        assert is_trading_day(date(2026, 1, 1)) is False
+
+    def test_lunar_new_year_2026_days_are_not_trading_days(self):
+        for d in [16, 17, 18, 19, 20]:
+            assert is_trading_day(date(2026, 2, d)) is False, f"2026-02-{d} should be holiday"
+
+    def test_dragon_boat_2026(self):
+        assert is_trading_day(date(2026, 6, 19)) is False
+
+    def test_mid_autumn_2026(self):
+        assert is_trading_day(date(2026, 9, 25)) is False
+
+    def test_national_day_2026(self):
+        assert is_trading_day(date(2026, 10, 9)) is False
+        assert is_trading_day(date(2026, 10, 10)) is False
+
+    def test_regular_day_around_holiday_is_trading(self):
+        # 2025-04-02 (Wednesday) is NOT a holiday
+        assert is_trading_day(date(2025, 4, 2)) is True
+        # 2025-04-07 (Monday) is NOT a holiday
+        assert is_trading_day(date(2025, 4, 7)) is True
+
+
+# ── get_settlement_date ───────────────────────────────────────────────────────
+
+class TestGetSettlementDate:
+    def test_t2_normal_weekday(self):
+        # Monday 2025-03-03 → T+2 = Wednesday 2025-03-05
+        result = get_settlement_date(date(2025, 3, 3))
+        assert result == date(2025, 3, 5)
+
+    def test_t2_skips_weekend(self):
+        # Thursday 2025-03-06 → skip Sat/Sun → T+1 = Fri 07, T+2 = Mon 10
+        result = get_settlement_date(date(2025, 3, 6))
+        assert result == date(2025, 3, 10)
+
+    def test_t2_skips_holiday_tomb_sweeping_2025(self):
+        # 2025-04-02 (Wed) → T+1 = Thu 04-03 (holiday Children's Day), skip →
+        # T+1 lands on 04-07 (Mon), T+2 lands on 04-08 (Tue)
+        # Actually: from 04-02, next trading day skipping 04-03 & 04-04 = 04-07 (Mon) = +1
+        # then +2 = 04-08 (Tue)
+        result = get_settlement_date(date(2025, 4, 2))
+        assert result == date(2025, 4, 8)
+
+    def test_t2_skips_holiday_national_day_2026(self):
+        # 2026-10-08 (Thu) → T+1: skip 10-09 (holiday) = 10-12 (Mon)?
+        # 10-09 Fri holiday, 10-10 Sat (weekend+holiday), so next = 10-12 Mon
+        # T+2 from 10-12 Mon = 10-13 Tue
+        result = get_settlement_date(date(2026, 10, 8))
+        assert result == date(2026, 10, 13)
+
+    def test_t2_mid_autumn_2025(self):
+        # 2025-10-03 (Fri) → next trading: skip 10-04 Sat, 10-05 Sun, 10-06 Mon (holiday)
+        # → 10-07 Tue = T+1, 10-08 Wed = T+2
+        result = get_settlement_date(date(2025, 10, 3))
+        assert result == date(2025, 10, 8)
+
+    def test_t2_result_is_date_object(self):
+        result = get_settlement_date(date(2025, 3, 10))
+        assert isinstance(result, date)
+
+
+# ── add_trading_days ──────────────────────────────────────────────────────────
+
+class TestAddTradingDays:
+    def test_add_zero(self):
+        d = date(2025, 3, 3)
+        # add_trading_days with n=0 should return same date (loop doesn't run)
+        result = add_trading_days(d, 0)
+        assert result == d
+
+    def test_add_one(self):
+        # Mon 2025-03-03, +1 = Tue 2025-03-04
+        assert add_trading_days(date(2025, 3, 3), 1) == date(2025, 3, 4)
+
+    def test_add_five_skips_weekend(self):
+        # Mon 2025-03-03 +5 trading days → Mon 2025-03-10
+        assert add_trading_days(date(2025, 3, 3), 5) == date(2025, 3, 10)
+
+
+# ── next_trading_day ──────────────────────────────────────────────────────────
+
+class TestNextTradingDay:
+    def test_next_from_friday(self):
+        # Fri 2025-03-07 → Mon 2025-03-10
+        assert next_trading_day(date(2025, 3, 7)) == date(2025, 3, 10)
+
+    def test_next_from_holiday(self):
+        # 2025-04-03 (holiday) → next = 2025-04-07 (Mon, skipping 04-04 also holiday)
+        assert next_trading_day(date(2025, 4, 3)) == date(2025, 4, 7)
+
+    def test_next_from_regular_day(self):
+        # Tue 2025-03-04 → Wed 2025-03-05
+        assert next_trading_day(date(2025, 3, 4)) == date(2025, 3, 5)
+
+
+# ── TAIWAN_HOLIDAYS_2024_2026 set ─────────────────────────────────────────────
+
+class TestHolidaySet:
+    def test_holiday_set_not_empty(self):
+        assert len(TAIWAN_HOLIDAYS_2024_2026) > 0
+
+    def test_all_entries_are_date_objects(self):
+        for d in TAIWAN_HOLIDAYS_2024_2026:
+            assert isinstance(d, date)
+
+    def test_contains_key_2025_holidays(self):
+        assert date(2025, 1, 1) in TAIWAN_HOLIDAYS_2024_2026
+        assert date(2025, 2, 28) in TAIWAN_HOLIDAYS_2024_2026
+        assert date(2025, 10, 10) in TAIWAN_HOLIDAYS_2024_2026
+
+    def test_contains_key_2026_holidays(self):
+        assert date(2026, 1, 1) in TAIWAN_HOLIDAYS_2024_2026
+        assert date(2026, 6, 19) in TAIWAN_HOLIDAYS_2024_2026
+        assert date(2026, 10, 10) in TAIWAN_HOLIDAYS_2024_2026


### PR DESCRIPTION
## Summary
- `_t2_settlement_date()` 原本只跳週末（忽略國定假日）
- 改呼叫 `trading_calendar.get_settlement_date()` 正確處理春節、清明、端午、中秋、國慶等 TSE 假日
- 新增 `TestIsTradingDay`, `TestGetSettlementDate`, `TestAddTradingDays` 測試至 `src/tests/test_trading_calendar.py`

## Test plan
- [ ] `pytest src/tests/test_trading_calendar.py -q` 通過（20 個案例）
- [ ] `pytest src/tests/test_ticker_watcher.py -q` 通過
- [ ] 驗證 2025-04-02 T+2 = 2025-04-08（跳過清明假期）

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)