### PR TITLE
fix(risk): EOD 自動取消未成交 pending/submitted 訂單

### DIFF
--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -32,6 +32,9 @@ from typing import Dict, List, Optional
 # Graceful shutdown flag — set by SIGTERM/SIGINT handler
 _shutdown_requested: bool = False
 
+# EOD 清理旗標：記錄最後一次執行取消未成交訂單的日期，確保每日只執行一次
+_eod_cleanup_done_date: Optional[dt.date] = None
+
 
 def _handle_shutdown_signal(signum: int, frame: object) -> None:  # noqa: ARG001
     global _shutdown_requested
@@ -597,6 +600,41 @@ def _check_live_mode_safety(
     if not trading_enabled:
         return False, "trading_enabled is False"
     return True, "OK"
+
+
+# ── EOD 盤後清理：取消當日未成交的 pending/submitted 訂單 ─────────────────────
+def _cancel_stale_pending_orders(conn: sqlite3.Connection, broker) -> int:
+    """收盤前取消所有今日未成交的 pending/submitted 訂單。
+
+    台股收盤後（13:30+）呼叫，避免未成交限價單在隔日以過期價格成交。
+    使用 date(ts_submit, '+8 hours') 將 UTC ISO 時間戳轉換為台北日期比對。
+
+    Returns: number of orders cancelled
+    """
+    today_str = dt.datetime.now(tz=_TZ_TWN).strftime("%Y-%m-%d")
+    rows = conn.execute(
+        """SELECT order_id, broker_order_id, symbol
+           FROM orders
+           WHERE status IN ('pending', 'submitted')
+             AND date(ts_submit, '+8 hours') = ?""",
+        (today_str,),
+    ).fetchall()
+
+    cancelled = 0
+    for row in rows:
+        order_id, broker_order_id, symbol = row[0], row[1], row[2]
+        try:
+            broker.cancel_order(broker_order_id or order_id)
+            conn.execute(
+                "UPDATE orders SET status='cancelled' WHERE order_id=?",
+                (order_id,),
+            )
+            conn.commit()
+            log.info("[EOD] Cancelled stale order %s (%s)", order_id[:8], symbol)
+            cancelled += 1
+        except Exception as e:  # noqa: BLE001 — broker API; can't predict exceptions
+            log.warning("[EOD] Failed to cancel order %s: %s", order_id[:8], e)
+    return cancelled
 
 
 # ── 主迴圈 ────────────────────────────────────────────────────────────────────
@@ -1185,6 +1223,19 @@ def run_watcher() -> None:
                     log.info("[tg_approver] Processed %d approval callbacks", n_cb)
             except Exception as _ta:  # noqa: BLE001 — dynamic import + Telegram API
                 log.warning("[tg_approver] error: %s", _ta)
+
+            # ── EOD 盤後清理：收盤後取消未成交訂單（每日只執行一次）────────
+            global _eod_cleanup_done_date
+            now_twn = dt.datetime.now(tz=_TZ_TWN)
+            if now_twn.hour > 13 or (now_twn.hour == 13 and now_twn.minute >= 30):
+                if _eod_cleanup_done_date != today:
+                    try:
+                        n = _cancel_stale_pending_orders(conn, broker)
+                        if n > 0:
+                            log.info("[EOD] Cancelled %d stale orders", n)
+                        _eod_cleanup_done_date = today
+                    except Exception as _eod_e:  # noqa: BLE001 — cleanup guard; must not crash scan loop
+                        log.warning("[EOD] cleanup failed: %s", _eod_e)
 
         except Exception as e:  # noqa: BLE001 — outer scan cycle guard; must catch all
             log.error("Scan cycle error: %s", e, exc_info=True)

--- a/tests/test_cancel_eod_orders.py
+++ b/tests/test_cancel_eod_orders.py
@@ -1,0 +1,195 @@
+"""tests/test_cancel_eod_orders.py
+
+Unit tests for _cancel_stale_pending_orders():
+  1. Cancels today's pending order — updates status to 'cancelled'
+  2. Cancels today's submitted order
+  3. Does NOT cancel already-filled orders
+  4. Does NOT cancel orders from a previous day
+  5. Returns correct count of cancelled orders
+  6. Handles broker cancel failure gracefully (logs warning, continues)
+"""
+import datetime as dt
+import sqlite3
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openclaw.ticker_watcher import _cancel_stale_pending_orders, _TZ_TWN
+
+
+# ─── DB fixture ─────────────────────────────────────────────────────────────
+
+def _make_db() -> sqlite3.Connection:
+    """Build an in-memory DB with the orders table matching production schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """CREATE TABLE orders (
+            order_id        TEXT PRIMARY KEY,
+            decision_id     TEXT,
+            broker_order_id TEXT,
+            ts_submit       TEXT NOT NULL,
+            symbol          TEXT,
+            side            TEXT,
+            qty             INTEGER,
+            price           REAL,
+            order_type      TEXT,
+            tif             TEXT,
+            status          TEXT,
+            strategy_version TEXT,
+            settlement_date TEXT
+        )"""
+    )
+    conn.commit()
+    return conn
+
+
+def _insert_order(conn: sqlite3.Connection, *, order_id: str, symbol: str,
+                  status: str, ts_submit_utc: str) -> None:
+    conn.execute(
+        """INSERT INTO orders
+           (order_id, decision_id, broker_order_id, ts_submit, symbol, side,
+            qty, price, order_type, tif, status, strategy_version, settlement_date)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (order_id, str(uuid.uuid4()), "broker-" + order_id[:4], ts_submit_utc,
+         symbol, "buy", 1000, 100.0, "limit", "IOC", status, "watcher_v1", None),
+    )
+    conn.commit()
+
+
+def _today_utc_iso() -> str:
+    """Return a UTC ISO timestamp that corresponds to today in TWN (+8h)."""
+    now_twn = dt.datetime.now(tz=_TZ_TWN)
+    # Express today's noon TWN time as UTC
+    noon_twn = now_twn.replace(hour=12, minute=0, second=0, microsecond=0)
+    noon_utc = noon_twn.astimezone(dt.timezone.utc)
+    return noon_utc.isoformat()
+
+
+def _yesterday_utc_iso() -> str:
+    """Return a UTC ISO timestamp for yesterday in TWN."""
+    now_twn = dt.datetime.now(tz=_TZ_TWN)
+    yesterday_twn = (now_twn - dt.timedelta(days=1)).replace(
+        hour=12, minute=0, second=0, microsecond=0
+    )
+    yesterday_utc = yesterday_twn.astimezone(dt.timezone.utc)
+    return yesterday_utc.isoformat()
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+def test_cancels_today_pending_order():
+    """Today's 'pending' order is cancelled and DB status updated."""
+    conn = _make_db()
+    oid = str(uuid.uuid4())
+    _insert_order(conn, order_id=oid, symbol="2330", status="pending",
+                  ts_submit_utc=_today_utc_iso())
+
+    broker = MagicMock()
+    n = _cancel_stale_pending_orders(conn, broker)
+
+    assert n == 1
+    broker.cancel_order.assert_called_once()
+    row = conn.execute("SELECT status FROM orders WHERE order_id=?", (oid,)).fetchone()
+    assert row[0] == "cancelled"
+
+
+def test_cancels_today_submitted_order():
+    """Today's 'submitted' order is also cancelled."""
+    conn = _make_db()
+    oid = str(uuid.uuid4())
+    _insert_order(conn, order_id=oid, symbol="2317", status="submitted",
+                  ts_submit_utc=_today_utc_iso())
+
+    broker = MagicMock()
+    n = _cancel_stale_pending_orders(conn, broker)
+
+    assert n == 1
+    row = conn.execute("SELECT status FROM orders WHERE order_id=?", (oid,)).fetchone()
+    assert row[0] == "cancelled"
+
+
+def test_does_not_cancel_filled_order():
+    """'filled' orders are not touched."""
+    conn = _make_db()
+    oid = str(uuid.uuid4())
+    _insert_order(conn, order_id=oid, symbol="2330", status="filled",
+                  ts_submit_utc=_today_utc_iso())
+
+    broker = MagicMock()
+    n = _cancel_stale_pending_orders(conn, broker)
+
+    assert n == 0
+    broker.cancel_order.assert_not_called()
+    row = conn.execute("SELECT status FROM orders WHERE order_id=?", (oid,)).fetchone()
+    assert row[0] == "filled"
+
+
+def test_does_not_cancel_previous_day_order():
+    """Yesterday's pending orders are not affected."""
+    conn = _make_db()
+    oid = str(uuid.uuid4())
+    _insert_order(conn, order_id=oid, symbol="2330", status="pending",
+                  ts_submit_utc=_yesterday_utc_iso())
+
+    broker = MagicMock()
+    n = _cancel_stale_pending_orders(conn, broker)
+
+    assert n == 0
+    broker.cancel_order.assert_not_called()
+    row = conn.execute("SELECT status FROM orders WHERE order_id=?", (oid,)).fetchone()
+    assert row[0] == "pending"
+
+
+def test_returns_correct_count_multiple_orders():
+    """Returns count of all cancelled orders."""
+    conn = _make_db()
+    today_iso = _today_utc_iso()
+    yesterday_iso = _yesterday_utc_iso()
+
+    oids_today = [str(uuid.uuid4()) for _ in range(3)]
+    for oid in oids_today:
+        _insert_order(conn, order_id=oid, symbol="2330", status="pending",
+                      ts_submit_utc=today_iso)
+
+    # one from yesterday — should not be cancelled
+    oid_old = str(uuid.uuid4())
+    _insert_order(conn, order_id=oid_old, symbol="2330", status="pending",
+                  ts_submit_utc=yesterday_iso)
+
+    broker = MagicMock()
+    n = _cancel_stale_pending_orders(conn, broker)
+
+    assert n == 3
+    assert broker.cancel_order.call_count == 3
+    for oid in oids_today:
+        row = conn.execute("SELECT status FROM orders WHERE order_id=?", (oid,)).fetchone()
+        assert row[0] == "cancelled"
+    old_row = conn.execute("SELECT status FROM orders WHERE order_id=?", (oid_old,)).fetchone()
+    assert old_row[0] == "pending"
+
+
+def test_broker_cancel_failure_is_handled_gracefully():
+    """If broker.cancel_order raises, the loop continues and warning is logged."""
+    conn = _make_db()
+    today_iso = _today_utc_iso()
+
+    oid1 = str(uuid.uuid4())
+    oid2 = str(uuid.uuid4())
+    _insert_order(conn, order_id=oid1, symbol="2330", status="pending",
+                  ts_submit_utc=today_iso)
+    _insert_order(conn, order_id=oid2, symbol="2317", status="pending",
+                  ts_submit_utc=today_iso)
+
+    broker = MagicMock()
+    # First call raises, second succeeds
+    broker.cancel_order.side_effect = [RuntimeError("broker timeout"), None]
+
+    with patch("openclaw.ticker_watcher.log") as mock_log:
+        n = _cancel_stale_pending_orders(conn, broker)
+
+    # Only the second order was successfully cancelled
+    assert n == 1
+    assert broker.cancel_order.call_count == 2
+    mock_log.warning.assert_called_once()
+    assert "Failed to cancel" in mock_log.warning.call_args[0][0]


### PR DESCRIPTION
## Summary

- 新增 `_cancel_stale_pending_orders(conn, broker)` helper，收盤後（13:30 TWN+）掃描當日所有 `pending`/`submitted` 訂單，逐一呼叫 `broker.cancel_order()` 並更新 DB `status='cancelled'`
- 在 `run_watcher()` 主迴圈加入 EOD cleanup 邏輯（每日只執行一次，由 `_eod_cleanup_done_date` 旗標去重）
- Broker 取消失敗時只記 warning，不中斷掃盤週期

## Test plan

- [ ] `tests/test_cancel_eod_orders.py` — 6 個單元測試全數通過
  - 取消今日 pending 訂單
  - 取消今日 submitted 訂單
  - 不影響已成交（filled）訂單
  - 不影響前一日訂單
  - 正確回傳取消數量
  - Broker 拋例外時優雅處理（log warning，繼續下一張）

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)