### PR TITLE
fix(test): mock apply_tw_session_risk_adjustments 修復 5 個邊界測試

### DIFF
--- a/tests/test_exact_boundaries.py
+++ b/tests/test_exact_boundaries.py
@@ -94,9 +94,17 @@ def _empty_portfolio(nav: float = 1_000_000) -> PortfolioState:
 
 @pytest.fixture(autouse=True)
 def _patch_helpers(monkeypatch):
-    """Suppress file-based helpers so all tests run in isolation."""
+    """Suppress file-based helpers so all tests run in isolation.
+
+    apply_tw_session_risk_adjustments is mocked as identity so boundary tests
+    evaluate pure limit values without session-time multipliers shrinking them.
+    """
     monkeypatch.setattr("openclaw.risk_engine._is_symbol_locked", lambda s: False)
     monkeypatch.setattr("openclaw.risk_engine._get_daily_pm_approval", lambda: True)
+    monkeypatch.setattr(
+        "openclaw.risk_engine.apply_tw_session_risk_adjustments",
+        lambda lim, **kw: dict(lim),
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 問題

\`tests/test_exact_boundaries.py\` 的 5 個邊界條件測試在 CI 失敗，阻擋 PR #304。

## 根本原因

\`evaluate_and_build_order\` 在評估前呼叫 \`apply_tw_session_risk_adjustments\`，
在 pre-open 時段對多個 limits 套用縮減係數：

- \`max_loss_per_trade_pct_nav\`: 0.005 → 0.0035（qty 500→349）
- \`max_price_deviation_pct\`: 0.02 → 0.016

導致：
- \`symbol_weight_after\` 從 0.05 縮至 0.035，低於測試設定的 0.049 上限 → 假通過
- price deviation 精確等於原始 limit 0.02 時，調整後超過 0.016 → 假拒絕

## 修復

在 \`_patch_helpers\` autouse fixture 加入 identity mock：
```python
monkeypatch.setattr(
    "openclaw.risk_engine.apply_tw_session_risk_adjustments",
    lambda lim, **kw: dict(lim),
)
```

## 測試結果

- `test_exact_boundaries.py`: 21/21 passed（原本 5 失敗）
- 全 core engine: 563 passed, 0 failed

Closes #305