### PR TITLE
fix(risk): 加入同日重複開倉(Wash Sale)防護

### DIFF
--- a/src/openclaw/risk_engine.py
+++ b/src/openclaw/risk_engine.py
@@ -93,6 +93,7 @@ class PortfolioState:
     unrealized_pnl: float
     positions: Dict[str, Position] = field(default_factory=dict)
     consecutive_losses: int = 0
+    same_day_fill_symbols: set = field(default_factory=set)
 
     def position_value(self, symbol: str) -> float:
         pos = self.positions.get(symbol)
@@ -233,6 +234,15 @@ def evaluate_and_build_order(
     if decision.signal_side == "sell" and _is_symbol_locked(decision.symbol):
         return EvaluationResult(False, "RISK_SYMBOL_LOCKED", metrics=base_metrics)
 
+    # WASH SALE PREVENTION — blocks buy re-entry on same day if symbol already filled today.
+    # Bypass with limits["wash_sale_prevention_enabled"] = 0.
+    if (
+        decision.signal_side == "buy"
+        and int(limits.get("wash_sale_prevention_enabled", 1))
+        and decision.symbol in portfolio.same_day_fill_symbols
+    ):
+        return EvaluationResult(False, "RISK_WASH_SALE", metrics=base_metrics)
+
     # DAILY PM APPROVAL — blocks all trading if today's review not approved.
     # Bypass with limits["pm_review_required"] = 0 (e.g. simulation / backtest).
     if int(limits.get("pm_review_required", 1)) and not _get_daily_pm_approval():
@@ -352,4 +362,5 @@ def default_limits() -> Dict[str, float]:
         "allow_auto_reduce_qty": 1,
         "position_sizing_method": "fixed_fractional",
         "sentinel_policy_path": "config/sentinel_policy_v1.json",
+        "wash_sale_prevention_enabled": 1,
     }

--- a/tests/test_wash_sale.py
+++ b/tests/test_wash_sale.py
@@ -1,0 +1,175 @@
+"""test_wash_sale.py — Wash Sale / Churning 防護測試
+
+涵蓋：
+- 同日已成交 symbol 阻止 buy re-entry (RISK_WASH_SALE)
+- 不同 symbol 不受影響
+- wash_sale_prevention_enabled=0 可關閉
+- sell 信號不受 wash sale 防護影響
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from openclaw.risk_engine import (
+    Decision,
+    MarketState,
+    PortfolioState,
+    SystemState,
+    default_limits,
+    evaluate_and_build_order,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _base_limits(**overrides) -> dict:
+    lim = default_limits()
+    lim["pm_review_required"] = 0  # bypass PM gate in unit tests
+    lim.update(overrides)
+    return lim
+
+
+def _normal_market(bid: float = 100.0, ask: float = 100.5) -> MarketState:
+    return MarketState(
+        best_bid=bid,
+        best_ask=ask,
+        volume_1m=100_000,
+        feed_delay_ms=0,
+    )
+
+
+def _normal_system(now_ms: int | None = None) -> SystemState:
+    return SystemState(
+        now_ms=now_ms or _now_ms(),
+        trading_locked=False,
+        broker_connected=True,
+        db_write_p99_ms=10,
+        orders_last_60s=0,
+        reduce_only_mode=False,
+    )
+
+
+def _portfolio(same_day_fill_symbols: set | None = None) -> PortfolioState:
+    return PortfolioState(
+        nav=1_000_000.0,
+        cash=1_000_000.0,
+        realized_pnl_today=0.0,
+        unrealized_pnl=0.0,
+        positions={},
+        consecutive_losses=0,
+        same_day_fill_symbols=same_day_fill_symbols or set(),
+    )
+
+
+def _decision(side: str, symbol: str = "2330", now: int | None = None) -> Decision:
+    ts = now or _now_ms()
+    return Decision(
+        decision_id="test-wash-sale",
+        ts_ms=ts,
+        symbol=symbol,
+        strategy_id="test",
+        signal_side=side,
+        signal_score=0.8,
+        signal_ttl_ms=30_000,
+        confidence=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestWashSaleBlocking:
+    """RISK_WASH_SALE: 同日已成交 symbol 阻止 buy re-entry"""
+
+    def test_wash_sale_blocks_same_day_reentry(self):
+        """同日已有成交記錄的 symbol，buy 應被拒絕（RISK_WASH_SALE）"""
+        portfolio = _portfolio(same_day_fill_symbols={"2330"})
+        result = evaluate_and_build_order(
+            _decision("buy", "2330"),
+            _normal_market(),
+            portfolio,
+            _base_limits(),
+            _normal_system(),
+        )
+        assert result.approved is False
+        assert result.reject_code == "RISK_WASH_SALE"
+
+    def test_wash_sale_allows_different_symbol(self):
+        """不同 symbol 不受 wash sale 防護影響，buy 應通過"""
+        portfolio = _portfolio(same_day_fill_symbols={"2330"})
+        result = evaluate_and_build_order(
+            _decision("buy", "2317"),  # 不同 symbol
+            _normal_market(),
+            portfolio,
+            _base_limits(),
+            _normal_system(),
+        )
+        # 不應因 wash sale 被拒（可能因其他原因被拒，但非 RISK_WASH_SALE）
+        assert result.reject_code != "RISK_WASH_SALE"
+
+    def test_wash_sale_allows_buy_when_no_same_day_fill(self):
+        """今日無成交記錄時，buy 不應被 wash sale 阻擋"""
+        portfolio = _portfolio(same_day_fill_symbols=set())
+        result = evaluate_and_build_order(
+            _decision("buy", "2330"),
+            _normal_market(),
+            portfolio,
+            _base_limits(),
+            _normal_system(),
+        )
+        assert result.reject_code != "RISK_WASH_SALE"
+
+    def test_wash_sale_allows_sell_on_same_day(self):
+        """sell 信號不受 wash sale 防護影響，即使今日已有成交"""
+        portfolio = _portfolio(same_day_fill_symbols={"2330"})
+        result = evaluate_and_build_order(
+            _decision("sell", "2330"),
+            _normal_market(),
+            portfolio,
+            _base_limits(),
+            _normal_system(),
+        )
+        assert result.reject_code != "RISK_WASH_SALE"
+
+
+class TestWashSaleToggle:
+    """wash_sale_prevention_enabled 開關測試"""
+
+    def test_wash_sale_allows_when_disabled(self):
+        """wash_sale_prevention_enabled=0 時，同日已成交 symbol 的 buy 不應被阻擋"""
+        portfolio = _portfolio(same_day_fill_symbols={"2330"})
+        result = evaluate_and_build_order(
+            _decision("buy", "2330"),
+            _normal_market(),
+            portfolio,
+            _base_limits(wash_sale_prevention_enabled=0),
+            _normal_system(),
+        )
+        assert result.reject_code != "RISK_WASH_SALE"
+
+    def test_wash_sale_enabled_by_default(self):
+        """default_limits() 應包含 wash_sale_prevention_enabled=1"""
+        limits = default_limits()
+        assert int(limits.get("wash_sale_prevention_enabled", 0)) == 1
+
+    def test_wash_sale_blocks_multiple_symbols(self):
+        """多個 symbol 在 same_day_fill_symbols 中，各自均應被阻擋"""
+        portfolio = _portfolio(same_day_fill_symbols={"2330", "2317", "0050"})
+        for symbol in ["2330", "2317", "0050"]:
+            result = evaluate_and_build_order(
+                _decision("buy", symbol),
+                _normal_market(),
+                portfolio,
+                _base_limits(),
+                _normal_system(),
+            )
+            assert result.reject_code == "RISK_WASH_SALE", f"Expected RISK_WASH_SALE for {symbol}"


### PR DESCRIPTION
## Summary

- `PortfolioState` 新增 `same_day_fill_symbols: set` 欄位，由呼叫方（ticker_watcher / pipeline）在建構 PortfolioState 時填入今日已成交 symbol
- `risk_engine.evaluate_and_build_order` 在 LOCK PROTECTION 後加入 Wash Sale check：buy 信號且 symbol 已在 `same_day_fill_symbols` 中 → 拒絕，reject_code = `RISK_WASH_SALE`
- 可透過 `limits["wash_sale_prevention_enabled"] = 0` 關閉（預設啟用）
- `default_limits()` 加入 `wash_sale_prevention_enabled: 1`

Closes #278

## Test plan

- [x] `pytest tests/test_wash_sale.py -v` — 7 tests passed
- [x] 同日重複 buy 被阻擋（RISK_WASH_SALE）
- [x] 不同 symbol 不受影響
- [x] sell 信號不受 wash sale 防護影響
- [x] `wash_sale_prevention_enabled=0` 可關閉防護
- [x] `default_limits()` 預設啟用

🤖 Generated with [Claude Code](https://claude.com/claude-code)