### PR TITLE
feat(ops): 加入 Telegram 遠端 Kill Switch

### DIFF
--- a/src/openclaw/tg_kill_switch.py
+++ b/src/openclaw/tg_kill_switch.py
@@ -1,0 +1,201 @@
+"""tg_kill_switch.py — Telegram 遠端 Kill Switch
+
+透過 Telegram Bot Polling 接收操作員指令：
+  /emergency_stop — 建立 .EMERGENCY_STOP，停止 watcher
+  /trading_status — 回報當前交易狀態
+
+只接受 TELEGRAM_CHAT_ID 的訊息（防止未授權操作）。
+
+環境變數：
+    TELEGRAM_BOT_TOKEN — 必填（未設定則不啟動）
+    TELEGRAM_CHAT_ID   — 授權的 chat ID（預設 1017252031）
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+from openclaw.path_utils import get_repo_root
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_CHAT_ID = "1017252031"
+_POLL_TIMEOUT = 30  # long-poll timeout (seconds)
+_EMERGENCY_STOP_FILENAME = ".EMERGENCY_STOP"
+
+# Module-level stop event — set to stop the polling thread gracefully
+_stop_event: Optional[threading.Event] = None
+
+
+def _get_emergency_stop_path() -> Path:
+    """返回 .EMERGENCY_STOP 的絕對路徑（repo root）。"""
+    return get_repo_root() / _EMERGENCY_STOP_FILENAME
+
+
+def _get_system_state() -> dict:
+    """讀取 config/system_state.json，失敗時回傳預設值。"""
+    state_path = get_repo_root() / "config" / "system_state.json"
+    try:
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        log.warning("tg_kill_switch: 無法讀取 system_state.json: %s", e)
+        return {}
+
+
+def _tg_request(token: str, method: str, params: dict) -> Optional[dict]:
+    """呼叫 Telegram Bot API，回傳 JSON 結果；失敗時回傳 None。"""
+    url = f"https://api.telegram.org/bot{token}/{method}"
+    payload = json.dumps(params).encode()
+    try:
+        req = urllib.request.Request(
+            url, data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=_POLL_TIMEOUT + 5) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as e:  # noqa: BLE001
+        log.debug("tg_kill_switch: API 呼叫失敗 %s/%s: %s", method, params.get("method"), e)
+        return None
+
+
+def _send_reply(token: str, chat_id: str, text: str) -> None:
+    """發送 Telegram 文字訊息。"""
+    _tg_request(token, "sendMessage", {
+        "chat_id": chat_id,
+        "text": text,
+        "parse_mode": "HTML",
+    })
+
+
+def _handle_command(command: str, chat_id: str, token: str) -> None:
+    """處理 /emergency_stop 或 /trading_status 指令。"""
+    cmd = command.strip().lower().split("@")[0]  # 去除 @bot_name 後綴
+
+    if cmd == "/emergency_stop":
+        stop_path = _get_emergency_stop_path()
+        try:
+            stop_path.touch(exist_ok=True)
+            log.warning("[kill_switch] EMERGENCY STOP triggered via Telegram. File: %s", stop_path)
+            _send_reply(token, chat_id,
+                        "🚨 <b>緊急停止已觸發</b>\n"
+                        f".EMERGENCY_STOP 已建立於 {stop_path}\n"
+                        "Watcher 將在下一個掃盤週期結束後停止自動交易。")
+        except OSError as e:
+            log.error("[kill_switch] 無法建立 .EMERGENCY_STOP: %s", e)
+            _send_reply(token, chat_id, f"❌ 建立 .EMERGENCY_STOP 失敗: {e}")
+        # 設定 stop event 讓 polling 執行緒退出
+        if _stop_event is not None:
+            _stop_event.set()
+
+    elif cmd == "/trading_status":
+        state = _get_system_state()
+        stop_exists = _get_emergency_stop_path().exists()
+
+        trading_enabled = state.get("trading_enabled", False)
+        simulation_mode = state.get("simulation_mode", True)
+        mode_str = "模擬盤" if simulation_mode else "實盤"
+
+        if stop_exists:
+            status_icon = "🛑"
+            status_text = "已觸發緊急停止"
+        elif trading_enabled:
+            status_icon = "✅"
+            status_text = "交易中"
+        else:
+            status_icon = "⏸️"
+            status_text = "暫停"
+
+        msg = (
+            f"{status_icon} <b>交易系統狀態</b>\n"
+            f"狀態：{status_text}\n"
+            f"模式：{mode_str}\n"
+            f"trading_enabled：{trading_enabled}\n"
+            f".EMERGENCY_STOP 存在：{stop_exists}"
+        )
+        _send_reply(token, chat_id, msg)
+
+    else:
+        _send_reply(token, chat_id,
+                    "可用指令：\n/emergency_stop — 緊急停止交易\n/trading_status — 查詢系統狀態")
+
+
+def _poll_loop(token: str, authorized_chat_id: str, stop_event: threading.Event) -> None:
+    """Telegram long-polling 主迴圈，在 daemon thread 中執行。"""
+    offset = 0
+    log.info("[kill_switch] Telegram Kill Switch 開始監聽 (chat_id=%s)", authorized_chat_id)
+
+    while not stop_event.is_set():
+        result = _tg_request(token, "getUpdates", {
+            "offset": offset,
+            "timeout": _POLL_TIMEOUT,
+            "allowed_updates": ["message"],
+        })
+
+        if result is None or not result.get("ok"):
+            # 網路暫時失敗，等一下再試
+            stop_event.wait(timeout=5)
+            continue
+
+        for update in result.get("result", []):
+            offset = update["update_id"] + 1
+            msg = update.get("message", {})
+            if not msg:
+                continue
+
+            sender_id = str(msg.get("from", {}).get("id", ""))
+            text = msg.get("text", "").strip()
+
+            # 授權檢查：只接受 TELEGRAM_CHAT_ID 的訊息
+            if sender_id != authorized_chat_id:
+                log.warning(
+                    "[kill_switch] 拒絕未授權訊息 from chat_id=%s (text=%r)",
+                    sender_id, text[:50],
+                )
+                continue
+
+            if text.startswith("/"):
+                log.info("[kill_switch] 收到指令: %r from %s", text, sender_id)
+                _handle_command(text, authorized_chat_id, token)
+
+    log.info("[kill_switch] Telegram Kill Switch 執行緒結束")
+
+
+def start_kill_switch_listener() -> Optional[threading.Thread]:
+    """啟動 Telegram Kill Switch 背景監聽執行緒。
+
+    若 TELEGRAM_BOT_TOKEN 未設定，則靜默跳過（不拋例外）。
+
+    Returns:
+        threading.Thread — 已啟動的背景執行緒；未設定 token 時回傳 None。
+    """
+    global _stop_event
+
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+    if not token:
+        log.debug("[kill_switch] TELEGRAM_BOT_TOKEN 未設定，跳過 Kill Switch 監聽")
+        return None
+
+    authorized_chat_id = os.environ.get("TELEGRAM_CHAT_ID", _DEFAULT_CHAT_ID).strip()
+
+    _stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_poll_loop,
+        args=(token, authorized_chat_id, _stop_event),
+        name="tg-kill-switch",
+        daemon=True,  # 主程式結束時自動清理
+    )
+    thread.start()
+    log.info("[kill_switch] Kill Switch 監聽執行緒已啟動 (authorized_chat_id=%s)", authorized_chat_id)
+    return thread
+
+
+def stop_kill_switch_listener() -> None:
+    """停止 Kill Switch 監聽（供測試或明確關閉使用）。"""
+    global _stop_event
+    if _stop_event is not None:
+        _stop_event.set()

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -696,6 +696,13 @@ def run_watcher() -> None:
     signal.signal(signal.SIGTERM, _handle_shutdown_signal)
     signal.signal(signal.SIGINT, _handle_shutdown_signal)
 
+    # 啟動 Telegram Kill Switch 背景監聽（需設定 TELEGRAM_BOT_TOKEN）
+    try:
+        from openclaw.tg_kill_switch import start_kill_switch_listener
+        start_kill_switch_listener()
+    except Exception as _ks_e:  # noqa: BLE001 — 選用元件，啟動失敗不中斷 watcher
+        log.warning("tg_kill_switch 啟動失敗（不影響 watcher 運作）: %s", _ks_e)
+
     from openclaw.risk_engine import (
         Decision, MarketState, PortfolioState, Position, SystemState,
         evaluate_and_build_order, default_limits,

--- a/tests/test_tg_kill_switch.py
+++ b/tests/test_tg_kill_switch.py
@@ -1,0 +1,315 @@
+"""tests/test_tg_kill_switch.py — Telegram Kill Switch 單元測試"""
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_update(update_id: int, chat_id: str, text: str) -> dict:
+    return {
+        "update_id": update_id,
+        "message": {
+            "message_id": 1,
+            "from": {"id": int(chat_id), "first_name": "Test"},
+            "chat": {"id": int(chat_id)},
+            "text": text,
+        },
+    }
+
+
+def _ok_result(updates: list) -> dict:
+    return {"ok": True, "result": updates}
+
+
+def _empty_result() -> dict:
+    return {"ok": True, "result": []}
+
+
+# ── test_emergency_stop_creates_file ─────────────────────────────────────────
+
+def test_emergency_stop_creates_file(tmp_path, monkeypatch):
+    """
+    /emergency_stop 指令應建立 .EMERGENCY_STOP 檔案並回覆確認訊息。
+    """
+    import openclaw.tg_kill_switch as ks
+
+    stop_path = tmp_path / ".EMERGENCY_STOP"
+    monkeypatch.setattr(ks, "_get_emergency_stop_path", lambda: stop_path)
+
+    sent_messages = []
+
+    def fake_send(token, chat_id, text):
+        sent_messages.append(text)
+
+    monkeypatch.setattr(ks, "_send_reply", fake_send)
+
+    # Reset module-level stop event
+    ks._stop_event = threading.Event()
+
+    ks._handle_command("/emergency_stop", "1017252031", "test-token")
+
+    assert stop_path.exists(), ".EMERGENCY_STOP 應已建立"
+    assert any("緊急停止" in m for m in sent_messages), "應回覆緊急停止確認訊息"
+    assert ks._stop_event.is_set(), "stop_event 應被設定"
+
+
+# ── test_unauthorized_message_ignored ────────────────────────────────────────
+
+def test_unauthorized_message_ignored(tmp_path, monkeypatch):
+    """
+    非授權 chat_id 的訊息應被忽略，不執行任何指令。
+    """
+    import openclaw.tg_kill_switch as ks
+
+    stop_path = tmp_path / ".EMERGENCY_STOP"
+    monkeypatch.setattr(ks, "_get_emergency_stop_path", lambda: stop_path)
+
+    sent_messages = []
+    monkeypatch.setattr(ks, "_send_reply", lambda t, c, m: sent_messages.append(m))
+
+    # 模擬兩個 updates：一個授權、一個未授權
+    authorized_id = "1017252031"
+    unauthorized_id = "9999999"
+
+    # Polling 在收到第二個 empty result 後停止
+    call_count = [0]
+    stop_event = threading.Event()
+
+    responses = [
+        _ok_result([
+            _make_update(1, unauthorized_id, "/emergency_stop"),
+        ]),
+        _empty_result(),  # 第二次呼叫後 stop
+    ]
+
+    def fake_tg_request(token, method, params):
+        if method == "getUpdates":
+            idx = call_count[0]
+            call_count[0] += 1
+            if call_count[0] >= len(responses):
+                stop_event.set()
+            return responses[idx] if idx < len(responses) else _empty_result()
+        return {"ok": True}
+
+    monkeypatch.setattr(ks, "_tg_request", fake_tg_request)
+
+    # 執行 poll_loop 一個 tick（直接測試邏輯，不啟動執行緒）
+    # 直接呼叫 _poll_loop 但透過 stop_event 在第一輪後停止
+    single_stop = threading.Event()
+
+    fake_responses = iter([
+        _ok_result([_make_update(1, unauthorized_id, "/emergency_stop")]),
+    ])
+
+    def fake_tg2(token, method, params):
+        if method == "getUpdates":
+            try:
+                result = next(fake_responses)
+                single_stop.set()  # 下次迴圈會停止
+                return result
+            except StopIteration:
+                return _empty_result()
+        return {"ok": True}
+
+    monkeypatch.setattr(ks, "_tg_request", fake_tg2)
+
+    # 跑一次 poll_loop iteration 邏輯：直接呼叫 _handle_command 並確認結果
+    # （不測執行緒邏輯，只驗 chat_id 授權過濾在 _poll_loop 中正確）
+    # 改為直接驗證：未授權者呼叫 _handle_command 仍會執行（因為 _poll_loop 負責過濾）
+    # 所以這裡測 _poll_loop 的過濾邏輯
+
+    handled_commands = []
+    original_handle = ks._handle_command
+
+    def tracking_handle(command, chat_id, token):
+        handled_commands.append((command, chat_id))
+        original_handle(command, chat_id, token)
+
+    monkeypatch.setattr(ks, "_handle_command", tracking_handle)
+
+    final_stop = threading.Event()
+    responses2 = [
+        _ok_result([_make_update(1, unauthorized_id, "/emergency_stop")]),
+        _ok_result([]),  # 第二次 polling 空結果，讓 loop 繼續直到 stop
+    ]
+    call_idx = [0]
+
+    def fake_tg3(token, method, params):
+        if method == "getUpdates":
+            i = call_idx[0]
+            call_idx[0] += 1
+            if i == 0:
+                return responses2[0]
+            # 第二次設定 stop 並回空
+            final_stop.set()
+            return _empty_result()
+        return {"ok": True}
+
+    monkeypatch.setattr(ks, "_tg_request", fake_tg3)
+
+    t = threading.Thread(
+        target=ks._poll_loop,
+        args=("test-token", authorized_id, final_stop),
+        daemon=True,
+    )
+    t.start()
+    t.join(timeout=3)
+
+    # 未授權的 chat_id 訊息不應觸發任何指令
+    assert not stop_path.exists(), "未授權訊息不應建立 .EMERGENCY_STOP"
+    assert len(handled_commands) == 0, "未授權訊息不應呼叫 _handle_command"
+
+
+# ── test_trading_status_reply ─────────────────────────────────────────────────
+
+def test_trading_status_reply(tmp_path, monkeypatch):
+    """
+    /trading_status 應回報 trading_enabled 與 simulation_mode 狀態。
+    """
+    import openclaw.tg_kill_switch as ks
+
+    stop_path = tmp_path / ".EMERGENCY_STOP"
+    monkeypatch.setattr(ks, "_get_emergency_stop_path", lambda: stop_path)
+
+    state = {"trading_enabled": True, "simulation_mode": False}
+    monkeypatch.setattr(ks, "_get_system_state", lambda: state)
+
+    sent_messages = []
+    monkeypatch.setattr(ks, "_send_reply", lambda t, c, m: sent_messages.append(m))
+
+    ks._handle_command("/trading_status", "1017252031", "test-token")
+
+    assert len(sent_messages) == 1
+    reply = sent_messages[0]
+    assert "trading_enabled" in reply
+    assert "True" in reply      # trading_enabled=True
+    assert "實盤" in reply       # simulation_mode=False
+
+
+def test_trading_status_shows_simulation_mode(tmp_path, monkeypatch):
+    """
+    simulation_mode=True 時應顯示「模擬盤」。
+    """
+    import openclaw.tg_kill_switch as ks
+
+    stop_path = tmp_path / ".EMERGENCY_STOP"
+    monkeypatch.setattr(ks, "_get_emergency_stop_path", lambda: stop_path)
+
+    state = {"trading_enabled": False, "simulation_mode": True}
+    monkeypatch.setattr(ks, "_get_system_state", lambda: state)
+
+    sent_messages = []
+    monkeypatch.setattr(ks, "_send_reply", lambda t, c, m: sent_messages.append(m))
+
+    ks._handle_command("/trading_status", "1017252031", "test-token")
+
+    assert "模擬盤" in sent_messages[0]
+
+
+def test_trading_status_shows_emergency_stop_active(tmp_path, monkeypatch):
+    """
+    .EMERGENCY_STOP 存在時，/trading_status 應標示已觸發緊急停止。
+    """
+    import openclaw.tg_kill_switch as ks
+
+    stop_path = tmp_path / ".EMERGENCY_STOP"
+    stop_path.touch()  # 預先建立
+    monkeypatch.setattr(ks, "_get_emergency_stop_path", lambda: stop_path)
+    monkeypatch.setattr(ks, "_get_system_state", lambda: {"trading_enabled": False, "simulation_mode": True})
+
+    sent_messages = []
+    monkeypatch.setattr(ks, "_send_reply", lambda t, c, m: sent_messages.append(m))
+
+    ks._handle_command("/trading_status", "1017252031", "test-token")
+
+    assert "緊急停止" in sent_messages[0]
+    assert "True" in sent_messages[0]  # .EMERGENCY_STOP 存在 = True
+
+
+# ── test_kill_switch_skips_if_no_token ───────────────────────────────────────
+
+def test_kill_switch_skips_if_no_token(monkeypatch):
+    """
+    TELEGRAM_BOT_TOKEN 未設定時，start_kill_switch_listener 應回傳 None，不啟動執行緒。
+    """
+    import openclaw.tg_kill_switch as ks
+
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+
+    result = ks.start_kill_switch_listener()
+
+    assert result is None, "未設定 token 時應回傳 None"
+
+
+def test_kill_switch_starts_thread_when_token_set(monkeypatch):
+    """
+    TELEGRAM_BOT_TOKEN 有設定時，start_kill_switch_listener 應回傳已啟動的 daemon thread。
+    """
+    import openclaw.tg_kill_switch as ks
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "1017252031")
+
+    # Mock _tg_request 以避免真實 API 呼叫
+    def fake_tg_request(token, method, params):
+        # 直接設定 stop event 讓執行緒退出
+        if ks._stop_event:
+            ks._stop_event.set()
+        return {"ok": True, "result": []}
+
+    monkeypatch.setattr(ks, "_tg_request", fake_tg_request)
+
+    thread = ks.start_kill_switch_listener()
+
+    try:
+        assert thread is not None, "有設定 token 時應回傳執行緒"
+        assert thread.daemon, "執行緒應為 daemon"
+        assert thread.name == "tg-kill-switch"
+        thread.join(timeout=3)
+    finally:
+        ks.stop_kill_switch_listener()
+
+
+# ── test_unknown_command_reply ────────────────────────────────────────────────
+
+def test_unknown_command_reply(tmp_path, monkeypatch):
+    """
+    未知指令應回覆可用指令清單。
+    """
+    import openclaw.tg_kill_switch as ks
+
+    monkeypatch.setattr(ks, "_get_emergency_stop_path", lambda: tmp_path / ".EMERGENCY_STOP")
+
+    sent_messages = []
+    monkeypatch.setattr(ks, "_send_reply", lambda t, c, m: sent_messages.append(m))
+
+    ks._handle_command("/unknown_cmd", "1017252031", "test-token")
+
+    assert len(sent_messages) == 1
+    assert "/emergency_stop" in sent_messages[0]
+    assert "/trading_status" in sent_messages[0]
+
+
+# ── test_command_with_bot_name_suffix ────────────────────────────────────────
+
+def test_command_with_bot_name_suffix(tmp_path, monkeypatch):
+    """
+    /emergency_stop@MyBot 格式的指令應正確解析（去除 @bot_name 後綴）。
+    """
+    import openclaw.tg_kill_switch as ks
+
+    stop_path = tmp_path / ".EMERGENCY_STOP"
+    monkeypatch.setattr(ks, "_get_emergency_stop_path", lambda: stop_path)
+
+    sent_messages = []
+    monkeypatch.setattr(ks, "_send_reply", lambda t, c, m: sent_messages.append(m))
+
+    ks._stop_event = threading.Event()
+
+    ks._handle_command("/emergency_stop@MyTradingBot", "1017252031", "test-token")
+
+    assert stop_path.exists(), "@bot_name 後綴不應影響指令解析"


### PR DESCRIPTION
Closes #275

## Summary
- 新增 `src/openclaw/tg_kill_switch.py`：透過 Telegram Bot long-polling 接受遠端指令
- `/emergency_stop` — 建立 `.EMERGENCY_STOP` 檔案並停止 watcher 的 Kill Switch 執行緒
- `/trading_status` — 讀取 `config/system_state.json`，回報 trading_enabled / simulation_mode / .EMERGENCY_STOP 狀態
- 僅接受 `TELEGRAM_CHAT_ID` 的訊息，未授權 chat_id 一律靜默拒絕
- 在 `ticker_watcher.run_watcher()` 啟動時以 daemon thread 開啟背景監聽

## Test plan
- [x] `pytest tests/test_tg_kill_switch.py` — 9 tests passed
- [x] `test_emergency_stop_creates_file` — 驗證 .EMERGENCY_STOP 建立與回覆
- [x] `test_unauthorized_message_ignored` — 未授權 chat_id 不觸發任何動作
- [x] `test_trading_status_reply` — 回報實盤/模擬盤狀態
- [x] `test_kill_switch_skips_if_no_token` — 未設 token 時回傳 None
- [x] `test_kill_switch_starts_thread_when_token_set` — 有 token 時啟動 daemon thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)