### PR TITLE
fix(ops): EOD cancel 補 partially_filled；tg_kill_switch log 修正

### DIFF
--- a/src/openclaw/tg_kill_switch.py
+++ b/src/openclaw/tg_kill_switch.py
@@ -59,7 +59,7 @@ def _tg_request(token: str, method: str, params: dict) -> Optional[dict]:
         with urllib.request.urlopen(req, timeout=_POLL_TIMEOUT + 5) as resp:
             return json.loads(resp.read().decode())
     except Exception as e:  # noqa: BLE001
-        log.debug("tg_kill_switch: API 呼叫失敗 %s/%s: %s", method, params.get("method"), e)
+        log.debug("tg_kill_switch: API 呼叫失敗 %s: %s", method, e)
         return None
 
 

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -668,7 +668,7 @@ def _cancel_stale_pending_orders(conn: sqlite3.Connection, broker) -> int:
     rows = conn.execute(
         """SELECT order_id, broker_order_id, symbol
            FROM orders
-           WHERE status IN ('pending', 'submitted')
+           WHERE status IN ('pending', 'submitted', 'partially_filled')
              AND date(ts_submit, '+8 hours') = ?""",
         (today_str,),
     ).fetchall()


### PR DESCRIPTION
## 問題

### Closes #310 — EOD cancel 遺漏 partially_filled 狀態
`_cancel_stale_pending_orders` 的 SQL 查詢只涵蓋 `('pending', 'submitted')`，
commit `8f7d958` 引入 `partially_filled` 狀態後，逾時的部分成交訂單在收盤時無法被取消，
會繼續留在 DB 中，影響隔日的風控判斷。

### Closes #311 — tg_kill_switch debug log 永遠印 None
`_tg_request` debug log 用 `params.get("method")` 取值，
但 `params` 是請求 body（如 `{"offset": 0, "timeout": 30}`），根本沒有 `"method"` key，
導致每條 debug log 都多一個 `None`，增加噪音。

## 修正

| 檔案 | 修改 |
|------|------|
| `src/openclaw/ticker_watcher.py:671` | `IN ('pending', 'submitted')` → `IN ('pending', 'submitted', 'partially_filled')` |
| `src/openclaw/tg_kill_switch.py:62` | 移除 `params.get("method")` 多餘欄位 |

## 測試

```
pytest tests/test_cancel_eod_orders.py tests/test_wash_sale.py tests/test_tg_kill_switch.py -q
# 22 passed
pytest -q
# 539 passed, 2 skipped
```