### PR TITLE
fix(eod): cancel partially_filled orders at EOD; fix tg_kill_switch debug log None

### DIFF
--- a/src/openclaw/tg_kill_switch.py
+++ b/src/openclaw/tg_kill_switch.py
@@ -59,7 +59,7 @@ def _tg_request(token: str, method: str, params: dict) -> Optional[dict]:
         with urllib.request.urlopen(req, timeout=_POLL_TIMEOUT + 5) as resp:
             return json.loads(resp.read().decode())
     except Exception as e:  # noqa: BLE001
-        log.debug("tg_kill_switch: API 呼叫失敗 %s/%s: %s", method, params.get("method"), e)
+        log.debug("tg_kill_switch: API 呼叫失敗 %s: %s", method, e)
         return None
 
 

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -668,7 +668,7 @@ def _cancel_stale_pending_orders(conn: sqlite3.Connection, broker) -> int:
     rows = conn.execute(
         """SELECT order_id, broker_order_id, symbol
            FROM orders
-           WHERE status IN ('pending', 'submitted')
+           WHERE status IN ('pending', 'submitted', 'partially_filled')
              AND date(ts_submit, '+8 hours') = ?""",
         (today_str,),
     ).fetchall()


### PR DESCRIPTION
## 修復摘要

### Bug #310 — EOD cancel 遺漏 partially_filled 訂單
- `ticker_watcher.py` EOD 取消查詢 `WHERE status IN ('pending', 'submitted')` 缺少 `'partially_filled'`
- PR #304 引入了 `partially_filled` 狀態，但 EOD 清場邏輯未同步更新
- 修復：加入 `'partially_filled'` 至 IN 子句，確保部分成交的訂單也會在收盤時取消

### Bug #311 — tg_kill_switch debug log 印出 None
- `log.debug("... %s/%s: %s", method, params.get("method"), e)` 中 `params.get("method")` 永遠回傳 None（`params` 是請求 body，不含 "method" key）
- 修復：移除多餘的 `params.get("method")` 格式佔位符

## 測試
- `tests/test_cancel_eod_orders.py` ✅ 15 passed
- `tests/test_tg_kill_switch.py` ✅ passed

Closes #310
Closes #311