### PR TITLE
fix(risk): wash sale 防護補注入 same_day_fill_symbols

### DIFF
--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -109,6 +109,22 @@ def _get_realized_pnl_today(conn: sqlite3.Connection) -> float:
         return 0.0
 
 
+def _get_today_buy_filled_symbols(conn: sqlite3.Connection) -> set:
+    """返回今日（UTC+8）已有 fills 的 buy 訂單 symbol 集合，供 wash sale 防護使用。"""
+    try:
+        rows = conn.execute(
+            """SELECT DISTINCT o.symbol
+               FROM orders o
+               JOIN fills f ON f.order_id = o.order_id
+               WHERE o.side = 'buy'
+                 AND date(o.ts_submit, '+8 hours') = date('now', '+8 hours')"""
+        ).fetchall()
+        return {r[0] for r in rows}
+    except sqlite3.Error as e:
+        log.warning("_get_today_buy_filled_symbols failed: %s", e)
+        return set()
+
+
 def _check_broker_connected(sj_instance) -> bool:
     """True 只有在 sj_instance 非 None 且 list_accounts() 不拋例外。"""
     if sj_instance is None:
@@ -958,6 +974,7 @@ def run_watcher() -> None:
                     nav=sim_nav, cash=sim_cash,
                     realized_pnl_today=_get_realized_pnl_today(conn), unrealized_pnl=0.0,
                     positions=all_pos_map,
+                    same_day_fill_symbols=_get_today_buy_filled_symbols(conn),
                 )
                 _exit_system = SystemState(
                     now_ms=scan_ms,
@@ -1096,6 +1113,7 @@ def run_watcher() -> None:
                     nav=sim_nav, cash=sim_cash,
                     realized_pnl_today=_get_realized_pnl_today(conn), unrealized_pnl=0.0,
                     positions=all_pos_map,   # ← 包含全部持倉，gross_exposure 正確累計
+                    same_day_fill_symbols=_get_today_buy_filled_symbols(conn),
                 )
                 system = SystemState(
                     now_ms=scan_ms,

--- a/tests/test_wash_sale.py
+++ b/tests/test_wash_sale.py
@@ -173,3 +173,72 @@ class TestWashSaleToggle:
                 _normal_system(),
             )
             assert result.reject_code == "RISK_WASH_SALE", f"Expected RISK_WASH_SALE for {symbol}"
+
+
+# ---------------------------------------------------------------------------
+# Integration: _get_today_buy_filled_symbols populates same_day_fill_symbols
+# ---------------------------------------------------------------------------
+
+class TestGetTodayBuyFilledSymbols:
+    """驗證 ticker_watcher._get_today_buy_filled_symbols 能正確從 DB 回傳今日 buy 成交 symbol。"""
+
+    def _setup_db(self, conn):
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS orders (
+               order_id TEXT PRIMARY KEY, symbol TEXT, side TEXT, status TEXT,
+               ts_submit TEXT, qty INTEGER, price REAL)"""
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS fills (
+               fill_id INTEGER PRIMARY KEY AUTOINCREMENT,
+               order_id TEXT, qty INTEGER, price REAL, fee REAL, tax REAL)"""
+        )
+        conn.commit()
+
+    def test_returns_today_buy_symbols(self):
+        import sqlite3
+        from openclaw.ticker_watcher import _get_today_buy_filled_symbols
+
+        conn = sqlite3.connect(":memory:")
+        self._setup_db(conn)
+        # 今日 buy 訂單 + fill
+        conn.execute("INSERT INTO orders VALUES ('o1','2330','buy','filled',datetime('now','+8 hours'),1000,100.0)")
+        conn.execute("INSERT INTO fills VALUES (NULL,'o1',1000,100.0,0,0)")
+        conn.commit()
+
+        result = _get_today_buy_filled_symbols(conn)
+        assert "2330" in result
+
+    def test_excludes_sell_orders(self):
+        import sqlite3
+        from openclaw.ticker_watcher import _get_today_buy_filled_symbols
+
+        conn = sqlite3.connect(":memory:")
+        self._setup_db(conn)
+        conn.execute("INSERT INTO orders VALUES ('o2','2317','sell','filled',datetime('now','+8 hours'),500,80.0)")
+        conn.execute("INSERT INTO fills VALUES (NULL,'o2',500,80.0,0,0)")
+        conn.commit()
+
+        result = _get_today_buy_filled_symbols(conn)
+        assert "2317" not in result
+
+    def test_excludes_orders_without_fills(self):
+        import sqlite3
+        from openclaw.ticker_watcher import _get_today_buy_filled_symbols
+
+        conn = sqlite3.connect(":memory:")
+        self._setup_db(conn)
+        conn.execute("INSERT INTO orders VALUES ('o3','0050','buy','pending',datetime('now','+8 hours'),1000,50.0)")
+        conn.commit()
+
+        result = _get_today_buy_filled_symbols(conn)
+        assert "0050" not in result
+
+    def test_returns_empty_set_on_db_error(self):
+        import sqlite3
+        from openclaw.ticker_watcher import _get_today_buy_filled_symbols
+
+        conn = sqlite3.connect(":memory:")
+        # 故意不建 orders/fills 表 → OperationalError
+        result = _get_today_buy_filled_symbols(conn)
+        assert result == set()


### PR DESCRIPTION
## 問題

commit `7639436` 加入 wash sale 防護，但 `ticker_watcher.py` 建構 `PortfolioState` 時（兩處）均未傳 `same_day_fill_symbols`，永遠是預設空 `set()`，**防護在 production 完全失效**。測試因手動構造 `_portfolio(same_day_fill_symbols=...)` 而全綠，掩蓋了缺口。

## 修正

- 新增 `_get_today_buy_filled_symbols(conn)` — 查詢今日（UTC+8）所有有 fills 的 buy 訂單 symbol
- 兩處 `PortfolioState(...)` 均加入 `same_day_fill_symbols=_get_today_buy_filled_symbols(conn)`
- `tests/test_wash_sale.py` 補 4 個 integration tests 驗證 helper 行為（包含 DB error graceful degradation）

## 測試

```
pytest tests/test_wash_sale.py -v   # 11 passed
pytest                              # 2134 passed
```

Closes #313