### PR TITLE
fix(signal): EOD 完成判斷補分鐘精度，14:00→14:30 切點

### DIFF
--- a/src/openclaw/signal_generator.py
+++ b/src/openclaw/signal_generator.py
@@ -13,6 +13,7 @@ from openclaw.signal_logic import SignalParams, evaluate_entry, evaluate_exit
 _TZ_TWN = timezone(timedelta(hours=8))
 # 盤後收盤基準：14:30 TWN（台股 13:30 收盤，ingest 約 14:00–14:30 完成）
 _EOD_COMPLETE_HOUR = 14
+_EOD_COMPLETE_MINUTE = 30
 
 _TAKE_PROFIT_PCT:          float = float(os.environ.get("TAKE_PROFIT_PCT",   "0.02"))
 _STOP_LOSS_PCT:            float = float(os.environ.get("STOP_LOSS_PCT",     "0.03"))
@@ -36,7 +37,7 @@ def _fetch_candles(
     """
     if max_date is None:
         twn = datetime.now(tz=_TZ_TWN)
-        if twn.hour >= _EOD_COMPLETE_HOUR:
+        if (twn.hour, twn.minute) >= (_EOD_COMPLETE_HOUR, _EOD_COMPLETE_MINUTE):
             max_date = twn.strftime("%Y-%m-%d")
         else:
             max_date = (twn - timedelta(days=1)).strftime("%Y-%m-%d")


### PR DESCRIPTION
## 問題

commit `3f1a342` 加入 `_EOD_COMPLETE_HOUR = 14`，comment 說 `盤後收盤基準：14:30 TWN（ingest 約 14:00–14:30 完成）`，但 `_fetch_candles` 的判斷是：

```python
if twn.hour >= _EOD_COMPLETE_HOUR:  # 14:00 即觸發，非 14:30
```

這在 14:00–14:29 這 30 分鐘內，若 ticker_watcher 觸發信號計算，會把尚未完整寫入的今日 OHLCV 納入 MA/RSI/MACD，造成信號失真。

## 修正

增加 `_EOD_COMPLETE_MINUTE = 30`，以 tuple 比較實現分鐘精度：

```python
if (twn.hour, twn.minute) >= (_EOD_COMPLETE_HOUR, _EOD_COMPLETE_MINUTE):
```

## 測試

```
pytest src/tests/test_signal_generator.py  # 9 passed
pytest                                      # 2130 passed
```

Closes #319