### PR TITLE
fix(committee): _build_barometer_trend 補 close/change NULL 過濾防 TypeError

### DIFF
--- a/src/openclaw/agents/strategy_committee.py
+++ b/src/openclaw/agents/strategy_committee.py
@@ -116,6 +116,8 @@ def _build_barometer_trend(conn: sqlite3.Connection, latest_trade_date: str) -> 
         FROM eod_prices
         WHERE symbol = '0050'
           AND trade_date <= ?
+          AND close IS NOT NULL
+          AND change IS NOT NULL
         ORDER BY trade_date DESC
         LIMIT 5
         """,

--- a/tests/test_strategy_committee_context.py
+++ b/tests/test_strategy_committee_context.py
@@ -83,3 +83,69 @@ def test_only_recent_decisions_returned_when_mixed(tmp_path):
     ).fetchall()
     assert len(rows) == 1
     assert rows[0][0] == "d3"
+
+
+# ---------------------------------------------------------------------------
+# _build_barometer_trend NULL guard tests (Issue #321)
+# ---------------------------------------------------------------------------
+
+def _make_barometer_db(tmp_path, rows):
+    """建立含 eod_prices 的測試 DB，rows = [(trade_date, close, change), ...]。"""
+    conn = sqlite3.connect(str(tmp_path / "trades.db"))
+    conn.execute("""CREATE TABLE eod_prices (
+        trade_date TEXT, symbol TEXT, open REAL, high REAL, low REAL,
+        close REAL, volume REAL, change REAL,
+        PRIMARY KEY (trade_date, symbol)
+    )""")
+    for trade_date, close, change in rows:
+        conn.execute(
+            "INSERT INTO eod_prices VALUES (?,?,?,?,?,?,?,?)",
+            (trade_date, "0050", 100.0, 101.0, 99.0, close, 1e6, change)
+        )
+    conn.commit()
+    return conn
+
+
+def test_barometer_skips_null_change_rows(tmp_path):
+    """change IS NULL の行は SQL でフィルタされ TypeError を発生させない。"""
+    from openclaw.agents.strategy_committee import _build_barometer_trend
+    # 5 rows but 3 have NULL change — after filter only 2 remain, meets len >= 2
+    rows = [
+        ("2026-03-10", 100.0, None),
+        ("2026-03-11", 101.0, None),
+        ("2026-03-12", 102.0, None),
+        ("2026-03-13", 103.0, 1.0),
+        ("2026-03-14", 104.0, 1.0),
+    ]
+    conn = _make_barometer_db(tmp_path, rows)
+    # Should not raise TypeError; returns str (possibly "")
+    result = _build_barometer_trend(conn, "2026-03-14")
+    assert isinstance(result, str)
+
+
+def test_barometer_returns_empty_when_all_change_null(tmp_path):
+    """全部 change 為 NULL 時，過濾後 rows < 2，回傳空字串。"""
+    from openclaw.agents.strategy_committee import _build_barometer_trend
+    rows = [
+        ("2026-03-13", 103.0, None),
+        ("2026-03-14", 104.0, None),
+    ]
+    conn = _make_barometer_db(tmp_path, rows)
+    result = _build_barometer_trend(conn, "2026-03-14")
+    assert result == ""
+
+
+def test_barometer_normal_data(tmp_path):
+    """正常資料應回傳包含趨勢資訊的字串。"""
+    from openclaw.agents.strategy_committee import _build_barometer_trend
+    rows = [
+        ("2026-03-10", 100.0, 0.5),
+        ("2026-03-11", 101.0, 1.0),
+        ("2026-03-12", 102.0, 1.0),
+        ("2026-03-13", 103.0, 1.0),
+        ("2026-03-14", 104.0, 1.0),
+    ]
+    conn = _make_barometer_db(tmp_path, rows)
+    result = _build_barometer_trend(conn, "2026-03-14")
+    assert "0050" in result
+    assert "趨勢" in result


### PR DESCRIPTION
## Summary

- `eod_prices.close` 與 `.change` 均為 NULLABLE（schema 定義 `REAL`，可為 NULL）
- `_build_barometer_trend` 的 SQL 未過濾 NULL 列，導致：
  - `r[2] >= 0` → `TypeError: '>=' not supported between NoneType and int`
  - `latest_close - oldest_close` → `TypeError: unsupported operand type(s) for -: 'NoneType'`
- 補 `AND close IS NOT NULL AND change IS NOT NULL` WHERE 條件修正

## Test plan

- [x] `test_barometer_skips_null_change_rows` — NULL 列被過濾，不丟 TypeError
- [x] `test_barometer_returns_empty_when_all_change_null` — 全 NULL 時回 `""` 不崩潰
- [x] `test_barometer_normal_data` — 正常資料仍回傳含 "0050" 與 "趨勢" 的字串

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)