### PR TITLE
fix(committee): filter NULL close/change in _build_barometer_trend to prevent TypeError

### DIFF
--- a/src/openclaw/agents/strategy_committee.py
+++ b/src/openclaw/agents/strategy_committee.py
@@ -116,6 +116,8 @@ def _build_barometer_trend(conn: sqlite3.Connection, latest_trade_date: str) -> 
         FROM eod_prices
         WHERE symbol = '0050'
           AND trade_date <= ?
+          AND close IS NOT NULL
+          AND change IS NOT NULL
         ORDER BY trade_date DESC
         LIMIT 5
         """,


### PR DESCRIPTION
## 問題

`_build_barometer_trend` 的 SQL 未過濾 NULL：

- `close IS NULL` → `latest_close - oldest_close` 拋 `TypeError`
- `change IS NULL` → `r[2] >= 0` 拋 `TypeError: '>=' not supported between instances of 'NoneType' and 'int'`

`eod_ingest.py` 的 `close`/`change` 欄位均為 `Optional`（`_to_float()` 可回傳 NULL），因此這是可觸發的 production bug。

## 修正

SQL 加入 `AND close IS NOT NULL AND change IS NOT NULL`，已有 `len(rows) < 2` 資料不足守衛，過濾後若不足兩筆仍會提前返回空字串。

## 測試

- 現有 committee 測試 ✅

Closes #321