### PR TITLE
feat(ops): 加入 SQLite 每日備份機制

### DIFF
--- a/bin/run_backup.sh
+++ b/bin/run_backup.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# bin/run_backup.sh — SQLite 每日備份腳本 [Issue #279]
+#
+# 將 trades.db dump 壓縮至 data/backup/，保留最近 30 份。
+# 環境變數（可 override）：
+#   DB_PATH         — SQLite 路徑（預設 <repo>/data/sqlite/trades.db）
+#   BACKUP_DIR      — 備份目錄（預設 <repo>/data/backup）
+#   BACKUP_RETAIN   — 保留份數（預設 30）
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+OPENCLAW_ENV="${OPENCLAW_ROOT_ENV:-$HOME/.openclaw/.env}"
+if [ -f "$OPENCLAW_ENV" ]; then
+    set -a
+    source "$OPENCLAW_ENV"
+    set +a
+fi
+
+if [ -f "$REPO/frontend/backend/.env" ]; then
+    set -a
+    source "$REPO/frontend/backend/.env"
+    set +a
+fi
+
+DB_PATH="${DB_PATH:-$REPO/data/sqlite/trades.db}"
+BACKUP_DIR="${BACKUP_DIR:-$REPO/data/backup}"
+BACKUP_RETAIN="${BACKUP_RETAIN:-30}"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="$BACKUP_DIR/trades_${TIMESTAMP}.sql.gz"
+
+echo "[run_backup] DB_PATH=$DB_PATH BACKUP_DIR=$BACKUP_DIR retain=${BACKUP_RETAIN}"
+
+# DB が存在しない場合はスキップ
+if [ ! -f "$DB_PATH" ]; then
+    echo "[run_backup] WARN: DB not found at $DB_PATH, skipping"
+    exit 0
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+# dump + compress
+sqlite3 "$DB_PATH" .dump | gzip > "$BACKUP_FILE"
+SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+echo "[run_backup] OK: $BACKUP_FILE ($SIZE)"
+
+# 超過保留數量的舊備份刪除（最舊的先刪）
+COUNT=$(ls -1 "$BACKUP_DIR"/trades_*.sql.gz 2>/dev/null | wc -l | tr -d ' ')
+if [ "$COUNT" -gt "$BACKUP_RETAIN" ]; then
+    EXCESS=$(( COUNT - BACKUP_RETAIN ))
+    ls -1t "$BACKUP_DIR"/trades_*.sql.gz | tail -n "$EXCESS" | xargs rm -f
+    echo "[run_backup] pruned $EXCESS old backup(s), keeping $BACKUP_RETAIN"
+fi

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -97,6 +97,21 @@ module.exports = {
         DB_PATH: path.join(REPO, "data/sqlite/trades.db"),
         INCIDENT_HYGIENE_OUTPUT_DIR: path.join(REPO, "data/ops/incident_hygiene")
       }
+    },
+    {
+      name: "ai-trader-db-backup",
+      script: path.join(REPO, "bin/run_backup.sh"),
+      cwd: REPO,
+      interpreter: "bash",
+      instances: 1,
+      autorestart: false,
+      watch: false,
+      cron_restart: "0 2 * * *",
+      env: {
+        DB_PATH: path.join(REPO, "data/sqlite/trades.db"),
+        BACKUP_DIR: path.join(REPO, "data/backup"),
+        BACKUP_RETAIN: "30"
+      }
     }
   ]
 };

--- a/tests/test_backup_db.py
+++ b/tests/test_backup_db.py
@@ -1,0 +1,93 @@
+"""tests/test_backup_db.py — bin/run_backup.sh 單元測試 [Issue #279]"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKUP_SCRIPT = REPO_ROOT / "bin" / "run_backup.sh"
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """建立含 eod_prices 資料的測試 SQLite。"""
+    db = tmp_path / "trades.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE eod_prices (trade_date TEXT, symbol TEXT, close REAL)")
+    conn.execute("INSERT INTO eod_prices VALUES ('2024-01-02', '2330', 560.0)")
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _run_backup(db_path: Path, backup_dir: Path, retain: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(BACKUP_SCRIPT)],
+        env={
+            **os.environ,
+            "DB_PATH": str(db_path),
+            "BACKUP_DIR": str(backup_dir),
+            "BACKUP_RETAIN": str(retain),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestRunBackup:
+    def test_creates_backup_file(self, tmp_path):
+        db = _make_db(tmp_path)
+        backup_dir = tmp_path / "backup"
+        result = _run_backup(db, backup_dir)
+        assert result.returncode == 0, result.stderr
+        backups = list(backup_dir.glob("trades_*.sql.gz"))
+        assert len(backups) == 1
+
+    def test_backup_file_is_nonempty(self, tmp_path):
+        db = _make_db(tmp_path)
+        backup_dir = tmp_path / "backup"
+        _run_backup(db, backup_dir)
+        backup = next((backup_dir).glob("trades_*.sql.gz"))
+        assert backup.stat().st_size > 0
+
+    def test_backup_dir_created_if_missing(self, tmp_path):
+        db = _make_db(tmp_path)
+        backup_dir = tmp_path / "nested" / "backup"
+        assert not backup_dir.exists()
+        result = _run_backup(db, backup_dir)
+        assert result.returncode == 0
+        assert backup_dir.exists()
+
+    def test_skips_gracefully_when_db_missing(self, tmp_path):
+        backup_dir = tmp_path / "backup"
+        result = _run_backup(tmp_path / "nonexistent.db", backup_dir)
+        assert result.returncode == 0
+        assert "WARN" in result.stdout
+        assert not list(backup_dir.glob("trades_*.sql.gz"))
+
+    def test_prunes_old_backups_beyond_retain(self, tmp_path):
+        db = _make_db(tmp_path)
+        backup_dir = tmp_path / "backup"
+        backup_dir.mkdir()
+
+        # 預先建 5 個假備份（timestamps 遞增）
+        for i in range(5):
+            (backup_dir / f"trades_2024010{i}_000000.sql.gz").write_bytes(b"x")
+
+        # retain=3 → 跑完後最多 3+1=4 個（新的1個 + 保留3個）
+        result = _run_backup(db, backup_dir, retain=3)
+        assert result.returncode == 0
+        remaining = list(backup_dir.glob("trades_*.sql.gz"))
+        assert len(remaining) <= 4  # 3 old retained + 1 new
+
+    def test_ecosystem_config_contains_backup_entry(self):
+        """ecosystem.config.js 應包含 ai-trader-db-backup entry。"""
+        config = (REPO_ROOT / "ecosystem.config.js").read_text()
+        assert "ai-trader-db-backup" in config
+        assert "run_backup.sh" in config
+        assert "0 2 * * *" in config
+
+    def test_backup_script_is_executable(self):
+        assert os.access(BACKUP_SCRIPT, os.X_OK), f"{BACKUP_SCRIPT} 未設定 executable bit"


### PR DESCRIPTION
## Summary

- 新增 `bin/run_backup.sh`：每日凌晨 2 點 `sqlite3 .dump | gzip` 備份 `trades.db`
- 保留最近 30 份備份（`BACKUP_RETAIN` 可 override），超出自動刪除最舊備份
- DB 不存在時 graceful skip（exit 0），不中斷 PM2 服務
- `ecosystem.config.js` 加入 `ai-trader-db-backup` PM2 entry（`cron_restart: "0 2 * * *"`）
- 備份目錄：`data/backup/`，檔名格式：`trades_YYYYMMDD_HHMMSS.sql.gz`

## Test plan

- [ ] `test_creates_backup_file` — 執行後出現 `.sql.gz` 備份檔
- [ ] `test_backup_file_is_nonempty` — 備份檔非空
- [ ] `test_backup_dir_created_if_missing` — 目錄不存在時自動建立
- [ ] `test_skips_gracefully_when_db_missing` — DB 不存在時 exit 0 + WARN 訊息
- [ ] `test_prunes_old_backups_beyond_retain` — 超出保留數量時修剪最舊備份
- [ ] `test_ecosystem_config_contains_backup_entry` — ecosystem.config.js 設定驗證
- [ ] `test_backup_script_is_executable` — executable bit 檢查
- [ ] 7/7 全通過

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)