### PR TITLE
feat(ops): 每日 NAV 快照寫入 daily_nav 表

### DIFF
--- a/src/openclaw/daily_snapshot.py
+++ b/src/openclaw/daily_snapshot.py
@@ -1,0 +1,191 @@
+# src/openclaw/daily_snapshot.py
+"""daily_snapshot.py — 每日 NAV 快照寫入 daily_nav 表 [Issue #282]
+
+在 EOD 收盤後（eod_prices 已入庫）計算：
+  cash              = initial_capital + cumulative_realized_pnl - open_position_book_value
+  unrealized_pnl    = Σ( (eod_close - avg_price) * qty ) for all open positions
+  nav               = cash + Σ( eod_close * qty )
+  realized_pnl_cumulative = Σ realized_pnl from fills (all time)
+
+呼叫方式：
+  from openclaw.daily_snapshot import write_nav_snapshot
+  write_nav_snapshot(conn, trade_date="2024-01-02", initial_capital=1_000_000.0)
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+
+def _ensure_daily_nav_table(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS daily_nav (
+            trade_date              TEXT PRIMARY KEY,
+            nav                     REAL NOT NULL,
+            cash                    REAL NOT NULL,
+            unrealized_pnl          REAL NOT NULL,
+            realized_pnl_cumulative REAL NOT NULL,
+            recorded_at             INTEGER NOT NULL  -- epoch ms
+        )
+    """)
+
+
+def _calc_cash_and_realized(
+    conn: sqlite3.Connection, initial_capital: float
+) -> tuple[float, float]:
+    """
+    Returns (cash, realized_pnl_cumulative).
+
+    Cash accounting:
+        cash = initial_capital + sell_proceeds - buy_costs
+
+    Realized PnL:
+        realized = sell_proceeds - cost_basis_of_sold_shares
+        cost_basis_of_sold = buy_costs - open_position_book_value
+
+    This correctly handles open positions: unrealized gain is NOT counted
+    as realized profit until shares are actually sold.
+    """
+    sell_proceeds = float(conn.execute(
+        """SELECT COALESCE(SUM(f.price * f.qty - f.fee - f.tax), 0.0)
+           FROM fills f JOIN orders o ON f.order_id = o.order_id
+           WHERE o.side = 'sell'"""
+    ).fetchone()[0] or 0.0)
+
+    buy_costs = float(conn.execute(
+        """SELECT COALESCE(SUM(f.price * f.qty + f.fee), 0.0)
+           FROM fills f JOIN orders o ON f.order_id = o.order_id
+           WHERE o.side = 'buy'"""
+    ).fetchone()[0] or 0.0)
+
+    open_book = float(conn.execute(
+        "SELECT COALESCE(SUM(avg_price * quantity), 0.0) FROM positions WHERE quantity > 0"
+    ).fetchone()[0] or 0.0)
+
+    cash = initial_capital + sell_proceeds - buy_costs
+    # cost_basis_of_what_was_sold = total_buy_costs - what_is_still_held
+    cost_basis_of_sold = buy_costs - open_book
+    realized = sell_proceeds - cost_basis_of_sold
+
+    return cash, realized
+
+
+def _calc_positions_nav(
+    conn: sqlite3.Connection, trade_date: str
+) -> tuple[float, float]:
+    """
+    Returns (position_market_value, unrealized_pnl) using eod_prices close.
+    Falls back to avg_price if eod_prices not available for a symbol.
+    """
+    rows = conn.execute(
+        "SELECT symbol, quantity, avg_price FROM positions WHERE quantity > 0"
+    ).fetchall()
+
+    market_value = 0.0
+    unrealized = 0.0
+    for sym, qty, avg_price in rows:
+        close_row = conn.execute(
+            "SELECT close FROM eod_prices WHERE symbol=? AND trade_date=?",
+            (sym, trade_date),
+        ).fetchone()
+        close = float(close_row[0]) if close_row and close_row[0] else float(avg_price)
+        market_value += close * qty
+        unrealized += (close - avg_price) * qty
+
+    return market_value, unrealized
+
+
+def write_nav_snapshot(
+    conn: sqlite3.Connection,
+    trade_date: str,
+    initial_capital: float,
+    *,
+    overwrite: bool = False,
+) -> dict:
+    """計算並寫入 daily_nav 快照，回傳 dict（nav, cash, unrealized_pnl, realized_pnl_cumulative）。
+
+    Args:
+        conn:             SQLite 連線（需 rw）
+        trade_date:       "YYYY-MM-DD"
+        initial_capital:  初始資金（通常從 config/capital.json 讀取）
+        overwrite:        True = 已存在時覆蓋；False = 跳過（冪等）
+
+    Returns:
+        dict with keys: trade_date, nav, cash, unrealized_pnl, realized_pnl_cumulative
+    """
+    _ensure_daily_nav_table(conn)
+
+    if not overwrite:
+        existing = conn.execute(
+            "SELECT 1 FROM daily_nav WHERE trade_date=?", (trade_date,)
+        ).fetchone()
+        if existing:
+            log.debug("daily_nav: %s 已存在，跳過（overwrite=False）", trade_date)
+            row = conn.execute(
+                "SELECT nav, cash, unrealized_pnl, realized_pnl_cumulative FROM daily_nav WHERE trade_date=?",
+                (trade_date,),
+            ).fetchone()
+            return {
+                "trade_date": trade_date,
+                "nav": row[0], "cash": row[1],
+                "unrealized_pnl": row[2], "realized_pnl_cumulative": row[3],
+            }
+
+    cash, realized_cumulative = _calc_cash_and_realized(conn, initial_capital)
+    position_market_value, unrealized_pnl = _calc_positions_nav(conn, trade_date)
+    nav = cash + position_market_value
+
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO daily_nav
+            (trade_date, nav, cash, unrealized_pnl, realized_pnl_cumulative, recorded_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (trade_date, round(nav, 2), round(cash, 2),
+         round(unrealized_pnl, 2), round(realized_cumulative, 2), now_ms),
+    )
+    conn.commit()
+
+    log.info(
+        "daily_nav: %s  NAV=%.0f  cash=%.0f  unrealized=%.0f  realized_cum=%.0f",
+        trade_date, nav, cash, unrealized_pnl, realized_cumulative,
+    )
+    return {
+        "trade_date": trade_date,
+        "nav": round(nav, 2),
+        "cash": round(cash, 2),
+        "unrealized_pnl": round(unrealized_pnl, 2),
+        "realized_pnl_cumulative": round(realized_cumulative, 2),
+    }
+
+
+def get_nav_history(
+    conn: sqlite3.Connection, days: int = 60
+) -> list[dict]:
+    """回傳最近 days 天的 daily_nav 記錄（由舊至新）。表不存在時回傳空清單。"""
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='daily_nav'"
+    ).fetchone()
+    if not table_exists:
+        return []
+    rows = conn.execute(
+        """
+        SELECT trade_date, nav, cash, unrealized_pnl, realized_pnl_cumulative
+        FROM daily_nav
+        ORDER BY trade_date DESC
+        LIMIT ?
+        """,
+        (days,),
+    ).fetchall()
+    return [
+        {
+            "trade_date": r[0], "nav": r[1], "cash": r[2],
+            "unrealized_pnl": r[3], "realized_pnl_cumulative": r[4],
+        }
+        for r in reversed(rows)
+    ]

--- a/src/openclaw/eod_ingest.py
+++ b/src/openclaw/eod_ingest.py
@@ -387,6 +387,29 @@ def main() -> None:
                     file=__import__("sys").stderr,
                 )
 
+        # ── NAV 快照（daily_nav 表）─────────────────────────────────────
+        nav_snapshot: dict = {}
+        try:
+            from openclaw.daily_snapshot import write_nav_snapshot
+            _capital_path = _REPO_ROOT / "config" / "capital.json"
+            _initial_capital = 1_000_000.0
+            if _capital_path.exists():
+                try:
+                    _initial_capital = float(
+                        json.loads(_capital_path.read_text()).get("total_capital_twd", 1_000_000.0)
+                    )
+                except Exception:
+                    pass
+            conn.row_factory = sqlite3.Row
+            nav_snapshot = write_nav_snapshot(
+                conn, trade_date=args.trade_date, initial_capital=_initial_capital
+            )
+        except Exception as nav_exc:
+            print(
+                f"[eod_ingest] daily_nav snapshot skipped: {nav_exc}",
+                file=__import__("sys").stderr,
+            )
+
         try:
             print(
                 json.dumps(
@@ -399,6 +422,7 @@ def main() -> None:
                         "margin_data": margin_rows,
                         "institution_error": inst_error,
                         "optimizer_adjustments": optimizer_adjustments,
+                        "nav_snapshot": nav_snapshot,
                         "error": error_text,
                     },
                     ensure_ascii=True,

--- a/tests/test_daily_snapshot.py
+++ b/tests/test_daily_snapshot.py
@@ -1,0 +1,171 @@
+"""tests/test_daily_snapshot.py — daily_snapshot 單元測試 [Issue #282]"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from openclaw.daily_snapshot import (
+    get_nav_history,
+    write_nav_snapshot,
+)
+
+INITIAL = 1_000_000.0
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
+    # orders + fills
+    conn.execute("""
+        CREATE TABLE orders (
+            order_id TEXT PRIMARY KEY,
+            symbol TEXT,
+            side TEXT,
+            qty INTEGER,
+            price REAL,
+            status TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE fills (
+            fill_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            order_id TEXT,
+            qty INTEGER,
+            price REAL,
+            fee REAL DEFAULT 0,
+            tax REAL DEFAULT 0
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE positions (
+            symbol TEXT PRIMARY KEY,
+            quantity INTEGER,
+            avg_price REAL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE eod_prices (
+            trade_date TEXT,
+            symbol TEXT,
+            open REAL, high REAL, low REAL, close REAL, volume INTEGER,
+            PRIMARY KEY (trade_date, symbol)
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+def _buy(conn, symbol, qty, price, fee=0.0):
+    oid = f"buy-{symbol}-{qty}"
+    conn.execute("INSERT OR REPLACE INTO orders VALUES (?,?,?,?,?,?)",
+                 (oid, symbol, "buy", qty, price, "filled"))
+    conn.execute("INSERT INTO fills (order_id, qty, price, fee, tax) VALUES (?,?,?,?,0)",
+                 (oid, qty, price, fee))
+    conn.execute("INSERT OR REPLACE INTO positions (symbol, quantity, avg_price) VALUES (?,?,?)",
+                 (symbol, qty, price))
+    conn.commit()
+
+
+def _sell(conn, symbol, qty, price, avg_price, fee=0.0, tax=0.0):
+    oid = f"sell-{symbol}-{qty}"
+    conn.execute("INSERT OR REPLACE INTO orders VALUES (?,?,?,?,?,?)",
+                 (oid, symbol, "sell", qty, price, "filled"))
+    conn.execute("INSERT INTO fills (order_id, qty, price, fee, tax) VALUES (?,?,?,?,?)",
+                 (oid, qty, price, fee, tax))
+    # 賣出後清除持倉
+    conn.execute("DELETE FROM positions WHERE symbol=?", (symbol,))
+    conn.commit()
+
+
+class TestWriteNavSnapshot:
+    def test_no_positions_no_trades(self):
+        """無交易無持倉 → NAV ≈ initial_capital。"""
+        conn = _make_conn()
+        result = write_nav_snapshot(conn, "2024-01-02", INITIAL)
+        assert abs(result["nav"] - INITIAL) < 0.01
+        assert abs(result["cash"] - INITIAL) < 0.01
+        assert result["unrealized_pnl"] == 0.0
+        assert result["realized_pnl_cumulative"] == 0.0
+
+    def test_open_position_uses_eod_close(self):
+        """有持倉且有 EOD 收盤 → unrealized_pnl 正確。"""
+        conn = _make_conn()
+        _buy(conn, "2330", 1000, 500.0)
+        conn.execute("INSERT INTO eod_prices VALUES ('2024-01-02','2330',0,0,0,520.0,0)")
+        conn.commit()
+        result = write_nav_snapshot(conn, "2024-01-02", INITIAL)
+        # unrealized = (520 - 500) * 1000 = 20,000
+        assert abs(result["unrealized_pnl"] - 20_000.0) < 0.01
+        # nav = cash + 520*1000
+        assert result["nav"] > INITIAL
+
+    def test_open_position_fallback_avg_price_when_no_eod(self):
+        """無 EOD 收盤時 fallback avg_price → unrealized = 0。"""
+        conn = _make_conn()
+        _buy(conn, "0050", 500, 200.0)
+        result = write_nav_snapshot(conn, "2024-01-02", INITIAL)
+        assert result["unrealized_pnl"] == 0.0
+
+    def test_realized_pnl_after_sell(self):
+        """賣出後 realized_pnl_cumulative 正確反映獲利。"""
+        conn = _make_conn()
+        _buy(conn, "2454", 1000, 100.0)
+        _sell(conn, "2454", 1000, 120.0, avg_price=100.0)
+        result = write_nav_snapshot(conn, "2024-01-03", INITIAL)
+        # 賣出收入 = 120*1000 = 120,000; 買入成本 = 100*1000 = 100,000 → realized = 20,000
+        assert result["realized_pnl_cumulative"] > 0
+
+    def test_idempotent_second_call_skips(self):
+        """相同 trade_date 第二次呼叫（overwrite=False）應跳過，回傳已有資料。"""
+        conn = _make_conn()
+        r1 = write_nav_snapshot(conn, "2024-01-02", INITIAL)
+        r2 = write_nav_snapshot(conn, "2024-01-02", INITIAL, overwrite=False)
+        assert r1["nav"] == r2["nav"]
+        count = conn.execute("SELECT COUNT(*) FROM daily_nav WHERE trade_date='2024-01-02'").fetchone()[0]
+        assert count == 1
+
+    def test_overwrite_updates_record(self):
+        """overwrite=True 應覆蓋既有記錄。"""
+        conn = _make_conn()
+        write_nav_snapshot(conn, "2024-01-02", INITIAL)
+        # 加入持倉後強制覆蓋
+        _buy(conn, "2330", 1000, 500.0)
+        conn.execute("INSERT INTO eod_prices VALUES ('2024-01-02','2330',0,0,0,600.0,0)")
+        conn.commit()
+        r2 = write_nav_snapshot(conn, "2024-01-02", INITIAL, overwrite=True)
+        assert r2["unrealized_pnl"] == 100_000.0  # (600-500)*1000
+
+    def test_table_created_automatically(self):
+        """daily_nav 表不存在時應自動建立。"""
+        conn = _make_conn()
+        write_nav_snapshot(conn, "2024-01-02", INITIAL)
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+        assert "daily_nav" in tables
+
+    def test_result_dict_has_required_keys(self):
+        conn = _make_conn()
+        result = write_nav_snapshot(conn, "2024-01-02", INITIAL)
+        for key in ("trade_date", "nav", "cash", "unrealized_pnl", "realized_pnl_cumulative"):
+            assert key in result
+
+
+class TestGetNavHistory:
+    def test_returns_chronological_order(self):
+        conn = _make_conn()
+        for d in ("2024-01-02", "2024-01-03", "2024-01-04"):
+            write_nav_snapshot(conn, d, INITIAL, overwrite=True)
+        history = get_nav_history(conn, days=10)
+        dates = [r["trade_date"] for r in history]
+        assert dates == sorted(dates)
+
+    def test_limits_results(self):
+        conn = _make_conn()
+        for i in range(5):
+            write_nav_snapshot(conn, f"2024-01-0{i+2}", INITIAL, overwrite=True)
+        assert len(get_nav_history(conn, days=3)) == 3
+
+    def test_empty_returns_empty_list(self):
+        conn = _make_conn()
+        assert get_nav_history(conn) == []


### PR DESCRIPTION
## Summary

- 新增 `src/openclaw/daily_snapshot.py` — 每日 NAV 快照模組
- `write_nav_snapshot()` 計算並寫入 `daily_nav` 表（自動建表，idempotent）
- `get_nav_history()` 查詢最近 N 天歷史記錄
- `eod_ingest.py` EOD 結束後自動呼叫，讀取 `config/capital.json` 取得初始資金

**現金公式：**
```
cash = initial_capital + sell_proceeds - buy_costs
nav  = cash + Σ(eod_close × qty)
```

**daily_nav 表結構：**
```sql
CREATE TABLE IF NOT EXISTS daily_nav (
    trade_date              TEXT PRIMARY KEY,
    nav                     REAL NOT NULL,
    cash                    REAL NOT NULL,
    unrealized_pnl          REAL NOT NULL,
    realized_pnl_cumulative REAL NOT NULL,
    recorded_at             INTEGER NOT NULL
)
```

## Test plan

- [ ] `test_no_positions_no_trades` — NAV ≈ initial_capital
- [ ] `test_open_position_uses_eod_close` — unrealized_pnl 正確計算
- [ ] `test_open_position_fallback_avg_price_when_no_eod` — fallback avg_price
- [ ] `test_realized_pnl_after_sell` — 賣出後 realized_pnl_cumulative > 0
- [ ] `test_idempotent_second_call_skips` — 冪等性，不重複寫入
- [ ] `test_overwrite_updates_record` — overwrite=True 覆蓋既有記錄
- [ ] `test_table_created_automatically` — 自動建表
- [ ] `test_result_dict_has_required_keys` — 回傳欄位完整
- [ ] `test_returns_chronological_order` — 歷史記錄由舊至新
- [ ] `test_limits_results` — days 參數截斷
- [ ] `test_empty_returns_empty_list` — 表不存在時回傳 []
- [ ] 11/11 全通過

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)