### PR TITLE
fix(optimizer): 新增 Walk-Forward out-of-sample 驗證防過度擬合

### DIFF
--- a/src/openclaw/strategy_optimizer.py
+++ b/src/openclaw/strategy_optimizer.py
@@ -28,6 +28,11 @@ _CONFIDENCE_THRESHOLD = 0.6  # 低於此值不觸發調整
 _LOW_WIN_RATE_THRESHOLD = 0.35     # 勝率 < 35% → 收緊 trailing_pct
 _TRAILING_PCT_DELTA = 0.005        # 每次調整幅度
 
+# Walk-Forward 驗證窗口設定 [Issue #281]
+_WF_TRAIN_DAYS = 60   # 訓練期（用於計算基準指標）
+_WF_VALID_DAYS = 20   # 驗證期（t-20 至今；驗證期必須確認同一問題）
+_WF_MIN_VALID_TRADES = 3  # 驗證期最少成交筆數（不足則 bypass 驗證）
+
 
 @dataclass
 class MetricsReport:
@@ -140,10 +145,66 @@ def _ensure_optimizer_schema(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+class WalkForwardValidator:
+    """Walk-Forward Out-of-Sample 驗證閘門 [Issue #281]
+
+    在套用自動調整前，確認問題在驗證期（最近 _WF_VALID_DAYS 天）同樣存在。
+    若驗證期訓練不足（< _WF_MIN_VALID_TRADES），則 bypass 驗證（保守通過）。
+
+    驗證邏輯：
+        訓練期 = [t - (_WF_TRAIN_DAYS + _WF_VALID_DAYS),  t - _WF_VALID_DAYS]
+        驗證期 = [t - _WF_VALID_DAYS,  t]
+
+    如果驗證期的指標沒有確認訓練期所觀察到的問題，則拒絕調整以防過度擬合。
+    """
+
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self._metrics_engine = StrategyMetricsEngine(conn)
+
+    def validate(self, condition: str, train_metrics: MetricsReport) -> tuple[bool, str]:
+        """
+        Args:
+            condition: 觸發調整的條件名稱（目前支援 "low_win_rate"）
+            train_metrics: 訓練期指標（由呼叫者提供，避免重複計算）
+
+        Returns:
+            (passed: bool, reason: str)
+        """
+        valid_cutoff = (
+            datetime.now() - timedelta(days=_WF_VALID_DAYS)
+        ).isoformat()
+        valid_metrics = self._metrics_engine.compute(window_days=_WF_VALID_DAYS)
+
+        # 驗證期樣本不足 → bypass（保守通過）
+        if valid_metrics.sample_n < _WF_MIN_VALID_TRADES:
+            return True, (
+                f"bypass: 驗證期交易筆數 {valid_metrics.sample_n} < {_WF_MIN_VALID_TRADES}"
+            )
+
+        if condition == "low_win_rate":
+            # 驗證期也必須確認低勝率問題
+            if valid_metrics.win_rate is None:
+                return True, "bypass: 驗證期 win_rate=None"
+            if valid_metrics.win_rate < _LOW_WIN_RATE_THRESHOLD:
+                return True, (
+                    f"confirmed: 驗證期 win_rate={valid_metrics.win_rate:.1%}"
+                    f" < {_LOW_WIN_RATE_THRESHOLD:.0%}"
+                )
+            return False, (
+                f"rejected: 驗證期 win_rate={valid_metrics.win_rate:.1%}"
+                f" >= {_LOW_WIN_RATE_THRESHOLD:.0%}，問題未在驗證期確認"
+            )
+
+        # 未知條件 → 保守通過
+        return True, f"bypass: 未知條件 {condition!r}"
+
+
 class OptimizationGateway:
     def __init__(self, conn: sqlite3.Connection):
         self.conn = conn
         _ensure_optimizer_schema(conn)
+        self._validator = WalkForwardValidator(conn)
 
     def on_eod(self, metrics: MetricsReport) -> list[dict]:
         """根據 EOD 統計結果執行安全調整。
@@ -158,14 +219,20 @@ class OptimizationGateway:
 
         # 安全調整 1：低勝率 → 收緊 trailing_pct（讓更早鎖利）
         if metrics.win_rate is not None and metrics.win_rate < _LOW_WIN_RATE_THRESHOLD:
-            adj = self._adjust_param(
-                "trailing_pct",
-                delta=+_TRAILING_PCT_DELTA,   # 收緊（增大 trailing）
-                rationale=f"win_rate={metrics.win_rate:.1%} < {_LOW_WIN_RATE_THRESHOLD:.0%}",
-                metrics=metrics,
-            )
-            if adj:
-                adjustments.append(adj)
+            # Walk-Forward 驗證：確認問題在驗證期同樣存在
+            wf_passed, wf_reason = self._validator.validate("low_win_rate", metrics)
+            log.info("[optimizer] walk-forward validation (low_win_rate): %s", wf_reason)
+            if not wf_passed:
+                log.info("[optimizer] trailing_pct 調整被 walk-forward 驗證拒絕：%s", wf_reason)
+            else:
+                adj = self._adjust_param(
+                    "trailing_pct",
+                    delta=+_TRAILING_PCT_DELTA,   # 收緊（增大 trailing）
+                    rationale=f"win_rate={metrics.win_rate:.1%} < {_LOW_WIN_RATE_THRESHOLD:.0%}; wf={wf_reason}",
+                    metrics=metrics,
+                )
+                if adj:
+                    adjustments.append(adj)
 
         return [a.as_dict() for a in adjustments]
 

--- a/tests/test_strategy_optimizer.py
+++ b/tests/test_strategy_optimizer.py
@@ -219,6 +219,123 @@ class TestOptimizationGateway:
         assert row["last_auto_change_ts"] >= now
 
 
+class TestWalkForwardValidator:
+    """WalkForwardValidator 單元測試 [Issue #281]"""
+
+    def _insert_trades(self, conn, n_wins, n_losses, days_ago=5):
+        """在 days_ago 天前插入 n_wins 筆獲利 + n_losses 筆虧損交易。"""
+        from datetime import datetime, timedelta
+        for i in range(n_wins):
+            _insert_matched_trade(conn, "2330", 100, 110, days_ago=days_ago)
+        for i in range(n_losses):
+            _insert_matched_trade(conn, "2454", 100, 90, days_ago=days_ago)
+
+    def test_bypass_when_validation_sample_insufficient(self, opt_db):
+        """驗證期交易筆數 < _WF_MIN_VALID_TRADES → bypass（保守通過）。"""
+        from openclaw.strategy_optimizer import (
+            WalkForwardValidator, MetricsReport, _WF_MIN_VALID_TRADES
+        )
+        # 驗證期（最近 20 天）只有 1 筆交易
+        _insert_matched_trade(opt_db, "2330", 100, 90, days_ago=5)
+
+        vld = WalkForwardValidator(opt_db)
+        train_metrics = MetricsReport(sample_n=30, confidence=1.0,
+                                      win_rate=0.2, profit_factor=0.5)
+        passed, reason = vld.validate("low_win_rate", train_metrics)
+        assert passed is True
+        assert "bypass" in reason
+
+    def test_passes_when_validation_confirms_low_win_rate(self, opt_db):
+        """驗證期也是低勝率 → 通過（確認問題真實）。"""
+        from openclaw.strategy_optimizer import WalkForwardValidator, MetricsReport
+        # 插入足夠筆數的全虧損交易（在驗證期內）
+        for _ in range(10):
+            _insert_matched_trade(opt_db, "2330", 100, 90, days_ago=5)
+
+        vld = WalkForwardValidator(opt_db)
+        train_metrics = MetricsReport(sample_n=30, confidence=1.0,
+                                      win_rate=0.2, profit_factor=0.5)
+        passed, reason = vld.validate("low_win_rate", train_metrics)
+        assert passed is True
+        assert "confirmed" in reason
+
+    def test_rejects_when_validation_shows_good_win_rate(self, opt_db):
+        """驗證期勝率恢復（>= 0.35）→ 拒絕調整（避免過度擬合）。"""
+        from openclaw.strategy_optimizer import WalkForwardValidator, MetricsReport
+        # 插入驗證期全是獲利交易（win_rate = 1.0）
+        for _ in range(10):
+            _insert_matched_trade(opt_db, "2330", 100, 120, days_ago=5)
+
+        vld = WalkForwardValidator(opt_db)
+        train_metrics = MetricsReport(sample_n=30, confidence=1.0,
+                                      win_rate=0.2, profit_factor=0.5)
+        passed, reason = vld.validate("low_win_rate", train_metrics)
+        assert passed is False
+        assert "rejected" in reason
+
+    def test_unknown_condition_bypasses(self, opt_db):
+        """未知條件 → bypass（保守通過）。"""
+        from openclaw.strategy_optimizer import WalkForwardValidator, MetricsReport
+        for _ in range(5):
+            _insert_matched_trade(opt_db, "2330", 100, 90, days_ago=5)
+
+        vld = WalkForwardValidator(opt_db)
+        train_metrics = MetricsReport(sample_n=30, confidence=1.0,
+                                      win_rate=0.2, profit_factor=0.5)
+        passed, reason = vld.validate("unknown_condition", train_metrics)
+        assert passed is True
+        assert "bypass" in reason
+
+
+class TestOptimizationGatewayWalkForward:
+    """OptimizationGateway walk-forward 整合測試 [Issue #281]"""
+
+    def _setup_gateway(self, opt_db):
+        opt_db.execute(
+            "INSERT OR REPLACE INTO param_bounds VALUES (?,?,?,?,?,?)",
+            ("trailing_pct", 0.03, 0.10, 0.02, None, None)
+        )
+        _insert_trailing_pct(opt_db, 0.05)
+        opt_db.commit()
+
+    def test_adjustment_blocked_when_validation_recovers(self, opt_db):
+        """訓練期低勝率但驗證期已恢復 → 調整被 walk-forward 拒絕。"""
+        self._setup_gateway(opt_db)
+
+        # 60+ 天前插入 30 筆虧損（訓練期）
+        for _ in range(30):
+            _insert_matched_trade(opt_db, "2330", 100, 90, days_ago=50)
+
+        # 最近 20 天（驗證期）插入 10 筆全部獲利
+        for _ in range(10):
+            _insert_matched_trade(opt_db, "0050", 100, 120, days_ago=5)
+
+        from openclaw.strategy_optimizer import OptimizationGateway, StrategyMetricsEngine
+        # 訓練期 metrics（用 60 天窗口）
+        metrics = StrategyMetricsEngine(opt_db).compute(window_days=60)
+        adjustments = OptimizationGateway(opt_db).on_eod(metrics)
+
+        trailing_adjs = [a for a in adjustments if a["param_key"] == "trailing_pct"]
+        # 驗證期勝率恢復，不應發生調整
+        assert trailing_adjs == []
+
+    def test_adjustment_proceeds_when_validation_confirms(self, opt_db):
+        """訓練期與驗證期都是低勝率 → walk-forward 通過，調整生效。"""
+        self._setup_gateway(opt_db)
+
+        # 訓練期 + 驗證期都是虧損
+        for _ in range(30):
+            _insert_matched_trade(opt_db, "2330", 100, 90, days_ago=5)
+
+        from openclaw.strategy_optimizer import OptimizationGateway, StrategyMetricsEngine
+        metrics = StrategyMetricsEngine(opt_db).compute()
+        adjustments = OptimizationGateway(opt_db).on_eod(metrics)
+
+        trailing_adjs = [a for a in adjustments if a["param_key"] == "trailing_pct"]
+        assert len(trailing_adjs) == 1
+        assert trailing_adjs[0]["new_value"] > trailing_adjs[0]["old_value"]
+
+
 class TestReflectionAgent:
     def test_reflect_returns_list(self, opt_db, monkeypatch):
         """reflect_weekly 回傳 list（即使 LLM 未設定也不崩潰）"""


### PR DESCRIPTION
## Summary

- 新增 `WalkForwardValidator` 類別，在 `strategy_optimizer.py` 中加入雙重確認門檻
- 訓練期（60d）發現問題後，必須驗證期（20d）同樣確認問題存在，才觸發參數調整
- 驗證期交易筆數 < 3 時自動 bypass（避免樣本不足誤拒）
- 新增 6 個測試（`TestWalkForwardValidator` × 4 + `TestOptimizationGatewayWalkForward` × 2）

## Test plan

- [x] `pytest tests/test_strategy_optimizer.py -v` → 17 passed
- [x] Walk-forward bypass（樣本不足）測試通過
- [x] Walk-forward 確認（雙低勝率）→ 調整通過
- [x] Walk-forward 拒絕（驗證期恢復）→ 調整被阻擋
- [x] 整合測試：train低/valid恢復 → blocked；train低/valid低 → proceeds

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)