### PR TITLE
feat(ops): 新增實盤 vs 模擬執行品質比對報告

### DIFF
--- a/src/openclaw/execution_quality_report.py
+++ b/src/openclaw/execution_quality_report.py
@@ -1,0 +1,224 @@
+# src/openclaw/execution_quality_report.py
+"""execution_quality_report.py — 實盤 vs 模擬帳戶執行品質比對
+
+功能：
+- 比對同日同標的同方向的實盤與模擬成交價差
+- 計算執行滑點（basis points）
+- 輸出結構化比對結果，供 Telegram 週報使用
+
+Issue #284
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class SlippagePair:
+    """一組實盤 vs 模擬的比對結果。"""
+    symbol: str
+    trade_date: str
+    side: str
+    sim_avg_price: float
+    live_avg_price: float
+    sim_qty: int
+    live_qty: int
+
+    @property
+    def slippage_bps(self) -> float:
+        """
+        執行滑點（basis points）。
+        - buy：實盤比模擬貴多少（正值 = 實盤成本較高）
+        - sell：實盤比模擬少收多少（正值 = 實盤回收較少）
+        """
+        if self.sim_avg_price <= 0:
+            return 0.0
+        if self.side == "buy":
+            return (self.live_avg_price / self.sim_avg_price - 1) * 10_000
+        else:  # sell
+            return (self.sim_avg_price / self.live_avg_price - 1) * 10_000
+
+    @property
+    def slippage_pct(self) -> float:
+        return self.slippage_bps / 100
+
+
+@dataclass
+class ExecutionQualityReport:
+    """週期性執行品質報告。"""
+    period_days: int
+    pairs: list[SlippagePair] = field(default_factory=list)
+    sim_only_trades: int = 0   # 僅有模擬、無對應實盤的交易日數
+    live_only_trades: int = 0  # 僅有實盤、無對應模擬的交易日數
+
+    @property
+    def avg_slippage_bps(self) -> Optional[float]:
+        if not self.pairs:
+            return None
+        return round(sum(p.slippage_bps for p in self.pairs) / len(self.pairs), 2)
+
+    @property
+    def max_slippage_bps(self) -> Optional[float]:
+        if not self.pairs:
+            return None
+        return round(max(p.slippage_bps for p in self.pairs), 2)
+
+    @property
+    def has_data(self) -> bool:
+        return bool(self.pairs)
+
+
+def compute_execution_quality(
+    conn: sqlite3.Connection,
+    days: int = 7,
+) -> ExecutionQualityReport:
+    """計算近 N 日的執行品質比對。
+
+    查詢 orders + fills，以 (symbol, date(ts_submit, '+8 hours'), side)
+    為鍵，比對模擬帳戶與實盤帳戶的加權平均成交價。
+
+    Args:
+        conn: SQLite 連線（需有 orders、fills 表）
+        days: 回顧天數，預設 7（週報）
+
+    Returns:
+        ExecutionQualityReport
+    """
+    rows = conn.execute(
+        """
+        WITH filled_orders AS (
+            SELECT
+                o.order_id,
+                o.symbol,
+                o.side,
+                o.account_mode,
+                date(o.ts_submit, '+8 hours') AS trade_date,
+                SUM(f.qty)                      AS total_qty,
+                SUM(f.qty * f.price) / SUM(f.qty) AS avg_price
+            FROM orders o
+            JOIN fills f ON f.order_id = o.order_id
+            WHERE o.ts_submit >= datetime('now', ?)
+              AND o.status IN ('filled', 'partially_filled')
+            GROUP BY o.order_id
+        ),
+        by_mode AS (
+            SELECT
+                symbol, side, trade_date, account_mode,
+                SUM(total_qty * avg_price) / SUM(total_qty) AS wt_avg_price,
+                SUM(total_qty)                               AS total_qty
+            FROM filled_orders
+            GROUP BY symbol, side, trade_date, account_mode
+        )
+        SELECT
+            s.symbol, s.side, s.trade_date,
+            s.wt_avg_price AS sim_price, s.total_qty AS sim_qty,
+            l.wt_avg_price AS live_price, l.total_qty AS live_qty
+        FROM by_mode s
+        JOIN by_mode l
+            ON  l.symbol     = s.symbol
+            AND l.side       = s.side
+            AND l.trade_date = s.trade_date
+            AND l.account_mode = 'live'
+        WHERE s.account_mode = 'simulation'
+        ORDER BY s.trade_date DESC, s.symbol
+        """,
+        (f"-{days} days",),
+    ).fetchall()
+
+    pairs = [
+        SlippagePair(
+            symbol=row["symbol"],
+            trade_date=row["trade_date"],
+            side=row["side"],
+            sim_avg_price=row["sim_price"],
+            live_avg_price=row["live_price"],
+            sim_qty=row["sim_qty"],
+            live_qty=row["live_qty"],
+        )
+        for row in rows
+    ]
+
+    # 統計只在單一模式出現的交易（無法配對）
+    # SQLite 不支援 FULL OUTER JOIN，用 UNION + LEFT JOIN 模擬
+    unpaired = conn.execute(
+        """
+        WITH filled_keys AS (
+            SELECT
+                o.symbol, o.side, o.account_mode,
+                date(o.ts_submit, '+8 hours') AS trade_date
+            FROM orders o
+            JOIN fills f ON f.order_id = o.order_id
+            WHERE o.ts_submit >= datetime('now', ?)
+              AND o.status IN ('filled', 'partially_filled')
+            GROUP BY o.symbol, o.side, o.account_mode, trade_date
+        ),
+        sim_keys  AS (SELECT symbol, side, trade_date FROM filled_keys WHERE account_mode='simulation'),
+        live_keys AS (SELECT symbol, side, trade_date FROM filled_keys WHERE account_mode='live'),
+        sim_only AS (
+            SELECT COUNT(*) AS cnt FROM sim_keys s
+            WHERE NOT EXISTS (
+                SELECT 1 FROM live_keys l
+                WHERE l.symbol=s.symbol AND l.side=s.side AND l.trade_date=s.trade_date
+            )
+        ),
+        live_only AS (
+            SELECT COUNT(*) AS cnt FROM live_keys l
+            WHERE NOT EXISTS (
+                SELECT 1 FROM sim_keys s
+                WHERE s.symbol=l.symbol AND s.side=l.side AND s.trade_date=l.trade_date
+            )
+        )
+        SELECT (SELECT cnt FROM sim_only) AS sim_only,
+               (SELECT cnt FROM live_only) AS live_only
+        """,
+        (f"-{days} days",),
+    ).fetchone()
+
+    return ExecutionQualityReport(
+        period_days=days,
+        pairs=pairs,
+        sim_only_trades=unpaired["sim_only"] if unpaired else 0,
+        live_only_trades=unpaired["live_only"] if unpaired else 0,
+    )
+
+
+def format_telegram_report(report: ExecutionQualityReport) -> str:
+    """格式化為 Telegram 週報訊息。"""
+    lines = [
+        f"📊 *執行品質週報*（近 {report.period_days} 日）",
+        "",
+    ]
+
+    if not report.has_data:
+        lines.append("本期無實盤 vs 模擬配對交易，無法計算執行滑點。")
+        lines.append(f"（模擬單數：{report.sim_only_trades}，實盤單數：{report.live_only_trades}）")
+        return "\n".join(lines)
+
+    avg = report.avg_slippage_bps
+    max_slip = report.max_slippage_bps
+    lines += [
+        f"配對交易筆數：{len(report.pairs)}",
+        f"平均滑點：{avg:+.1f} bps",
+        f"最大滑點：{max_slip:+.1f} bps",
+        "",
+        "明細（前 5 筆）：",
+    ]
+
+    top5 = sorted(report.pairs, key=lambda p: abs(p.slippage_bps), reverse=True)[:5]
+    for p in top5:
+        direction = "↑買" if p.side == "buy" else "↓賣"
+        lines.append(
+            f"  {p.symbol} {direction} {p.trade_date}："
+            f" 模擬={p.sim_avg_price:.2f} 實盤={p.live_avg_price:.2f}"
+            f" 滑點={p.slippage_bps:+.1f}bps"
+        )
+
+    if report.sim_only_trades or report.live_only_trades:
+        lines += [
+            "",
+            f"⚠️ 無配對：模擬單 {report.sim_only_trades} 筆，實盤單 {report.live_only_trades} 筆",
+        ]
+
+    return "\n".join(lines)

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -159,6 +159,8 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         # Sprint 2
         "ALTER TABLE positions ADD COLUMN state TEXT DEFAULT 'HOLDING'",
         "ALTER TABLE positions ADD COLUMN entry_trading_day TEXT",
+        # Issue #284: execution quality comparison
+        "ALTER TABLE orders ADD COLUMN account_mode TEXT NOT NULL DEFAULT 'simulation'",
     ]
     for sql in migrations:
         try:
@@ -418,16 +420,17 @@ def _persist_risk_check(conn: sqlite3.Connection, *, decision_id: str, passed: b
 def _persist_order(conn: sqlite3.Connection, *, order_id: str, decision_id: str,
                     broker_order_id: str, symbol: str, side: str, qty: int,
                     price: float, status: str = "submitted",
-                    settlement_date: Optional[str] = None) -> None:
+                    settlement_date: Optional[str] = None,
+                    account_mode: str = "simulation") -> None:
     conn.execute(
         """INSERT INTO orders
            (order_id, decision_id, broker_order_id, ts_submit,
             symbol, side, qty, price, order_type, tif, status, strategy_version,
-            settlement_date)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            settlement_date, account_mode)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (order_id, decision_id, broker_order_id, _utc_now_iso(),
          symbol, side, qty, price, "limit", "IOC", status, STRATEGY_VERSION,
-         settlement_date),
+         settlement_date, account_mode),
     )
 
 
@@ -577,7 +580,8 @@ def _evaluate_cash_mode(
 # ── 模擬下單執行 ──────────────────────────────────────────────────────────────
 def _execute_sim_order(conn: sqlite3.Connection, *, broker, decision_id: str,
                         symbol: str, side: str, qty: int, price: float,
-                        candidate, guard_limits: dict | None = None) -> tuple[bool, str]:
+                        candidate, guard_limits: dict | None = None,
+                        account_mode: str = "simulation") -> tuple[bool, str]:
     """提交模擬單，poll 成交，寫入 orders/fills/order_events。"""
     from openclaw.pre_trade_guard import evaluate_pre_trade_guard
 
@@ -586,7 +590,7 @@ def _execute_sim_order(conn: sqlite3.Connection, *, broker, decision_id: str,
     if not guard_result.approved:
         _persist_order(conn, order_id=order_id, decision_id=decision_id,
                        broker_order_id="", symbol=symbol, side=side, qty=qty,
-                       price=price, status="rejected")
+                       price=price, status="rejected", account_mode=account_mode)
         _insert_order_event(conn, order_id=order_id, event_type="rejected",
                             from_status=None, to_status="rejected",
                             source="pre_trade_guard",
@@ -607,14 +611,14 @@ def _execute_sim_order(conn: sqlite3.Connection, *, broker, decision_id: str,
         _persist_order(conn, order_id=order_id, decision_id=decision_id,
                        broker_order_id=submission.broker_order_id or "",
                        symbol=symbol, side=side, qty=qty, price=price, status="rejected",
-                       settlement_date=settlement_date)
+                       settlement_date=settlement_date, account_mode=account_mode)
         log.warning("[%s] broker rejected: %s", symbol, submission.reason)
         return False, order_id
 
     _persist_order(conn, order_id=order_id, decision_id=decision_id,
                    broker_order_id=submission.broker_order_id,
                    symbol=symbol, side=side, qty=qty, price=price, status="submitted",
-                   settlement_date=settlement_date)
+                   settlement_date=settlement_date, account_mode=account_mode)
     _insert_order_event(conn, order_id=order_id, event_type="submitted",
                         from_status=None, to_status="submitted",
                         source="watcher", reason_code=None,
@@ -1007,6 +1011,7 @@ def run_watcher() -> None:
                         price=_exit_result.order.price,
                         candidate=_exit_result.order,
                         guard_limits=limits,
+                        account_mode="live" if not simulation else "simulation",
                     )
                     conn.commit()
                     if _ok:
@@ -1171,6 +1176,7 @@ def run_watcher() -> None:
                         price=result.order.price,
                         candidate=result.order,
                         guard_limits=limits,
+                        account_mode="live" if not simulation else "simulation",
                     )
                     conn.commit()
 
@@ -1249,6 +1255,7 @@ def run_watcher() -> None:
                             side="sell", qty=intent.qty,
                             price=intent.price, candidate=candidate,
                             guard_limits=limits,
+                            account_mode="live" if not simulation else "simulation",
                         )
                         conn.commit()
                         if ok:

--- a/src/sql/migration_v1_3_2_order_account_mode.sql
+++ b/src/sql/migration_v1_3_2_order_account_mode.sql
@@ -1,0 +1,9 @@
+-- migration_v1_3_2_order_account_mode.sql
+-- 為 orders 表加入 account_mode 欄位，記錄訂單是模擬還是實盤
+-- 支援 paper-vs-live execution quality 比對
+-- Issue #284
+
+ALTER TABLE orders ADD COLUMN account_mode TEXT NOT NULL DEFAULT 'simulation';
+
+CREATE INDEX IF NOT EXISTS idx_orders_account_mode_symbol
+ON orders(account_mode, symbol, ts_submit);

--- a/tests/test_execution_quality_report.py
+++ b/tests/test_execution_quality_report.py
@@ -1,0 +1,246 @@
+"""tests/test_execution_quality_report.py — 執行品質比對報告測試
+
+測試案例：
+1. SlippagePair.slippage_bps 買單計算正確
+2. SlippagePair.slippage_bps 賣單計算正確
+3. compute_execution_quality 空 DB 回傳空報告
+4. compute_execution_quality 有配對時正確計算滑點
+5. compute_execution_quality 無實盤時 sim_only 計數正確
+6. format_telegram_report 無資料時輸出合理訊息
+7. format_telegram_report 有資料時包含必要欄位
+8. SQL migration 正常加入 account_mode 欄位
+"""
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from openclaw.execution_quality_report import (
+    ExecutionQualityReport,
+    SlippagePair,
+    compute_execution_quality,
+    format_telegram_report,
+)
+
+
+# ─── DB helpers ───────────────────────────────────────────────────────────────
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE orders (
+            order_id TEXT PRIMARY KEY,
+            decision_id TEXT NOT NULL DEFAULT 'test-decision',
+            broker_order_id TEXT,
+            ts_submit TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            qty INTEGER NOT NULL,
+            price REAL,
+            order_type TEXT NOT NULL DEFAULT 'limit',
+            tif TEXT NOT NULL DEFAULT 'IOC',
+            status TEXT NOT NULL DEFAULT 'filled',
+            strategy_version TEXT NOT NULL DEFAULT '4.0',
+            settlement_date TEXT,
+            account_mode TEXT NOT NULL DEFAULT 'simulation'
+        );
+        CREATE TABLE fills (
+            fill_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL,
+            ts_fill TEXT NOT NULL DEFAULT (datetime('now')),
+            qty INTEGER NOT NULL,
+            price REAL NOT NULL,
+            fee REAL NOT NULL DEFAULT 0,
+            tax REAL NOT NULL DEFAULT 0
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _insert_order_fill(
+    conn: sqlite3.Connection,
+    *,
+    symbol: str,
+    side: str,
+    account_mode: str,
+    fill_price: float,
+    qty: int = 1000,
+    trade_date: str = "2026-03-18",  # Taiwan date (UTC+8)
+    status: str = "filled",
+) -> str:
+    """插入一筆訂單 + 成交，ts_submit 用 UTC 時間（+8h 後對應 trade_date）。"""
+    oid = str(uuid.uuid4())
+    # trade_date 2026-03-18 台北時間 = UTC 2026-03-17T16:00:00Z
+    ts = f"{trade_date}T08:00:00+00:00"  # 台北 16:00 = UTC 08:00，仍屬同日
+    conn.execute(
+        """INSERT INTO orders
+           (order_id, ts_submit, symbol, side, qty, price, status, account_mode)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (oid, ts, symbol, side, qty, fill_price, status, account_mode),
+    )
+    conn.execute(
+        """INSERT INTO fills (fill_id, order_id, qty, price)
+           VALUES (?, ?, ?, ?)""",
+        (str(uuid.uuid4()), oid, qty, fill_price),
+    )
+    conn.commit()
+    return oid
+
+
+# ─── Test 1 & 2: SlippagePair.slippage_bps ───────────────────────────────────
+
+def test_slippage_bps_buy_positive_when_live_more_expensive():
+    """買單：實盤比模擬貴 → 正值滑點。"""
+    pair = SlippagePair(
+        symbol="2330", trade_date="2026-03-18", side="buy",
+        sim_avg_price=100.0, live_avg_price=101.0,
+        sim_qty=1000, live_qty=1000,
+    )
+    # (101/100 - 1) * 10000 = 100 bps
+    assert abs(pair.slippage_bps - 100.0) < 0.01
+
+
+def test_slippage_bps_sell_positive_when_live_gets_less():
+    """賣單：實盤成交價比模擬低 → 正值滑點（實盤回收較少）。"""
+    pair = SlippagePair(
+        symbol="2330", trade_date="2026-03-18", side="sell",
+        sim_avg_price=100.0, live_avg_price=99.0,
+        sim_qty=1000, live_qty=1000,
+    )
+    # (100/99 - 1) * 10000 ≈ 101 bps
+    assert pair.slippage_bps > 0
+
+
+def test_slippage_bps_zero_when_prices_equal():
+    pair = SlippagePair(
+        symbol="0050", trade_date="2026-03-18", side="buy",
+        sim_avg_price=150.0, live_avg_price=150.0,
+        sim_qty=1000, live_qty=1000,
+    )
+    assert pair.slippage_bps == 0.0
+
+
+# ─── Test 3: 空 DB ───────────────────────────────────────────────────────────
+
+def test_empty_db_returns_empty_report():
+    conn = _make_db()
+    report = compute_execution_quality(conn, days=7)
+    assert not report.has_data
+    assert report.pairs == []
+    assert report.avg_slippage_bps is None
+
+
+# ─── Test 4: 有配對時正確計算 ────────────────────────────────────────────────
+
+def test_paired_orders_compute_slippage():
+    """模擬 100 實盤 101 → 買單滑點 100bps。"""
+    conn = _make_db()
+    _insert_order_fill(conn, symbol="2330", side="buy",
+                       account_mode="simulation", fill_price=100.0)
+    _insert_order_fill(conn, symbol="2330", side="buy",
+                       account_mode="live", fill_price=101.0)
+
+    report = compute_execution_quality(conn, days=7)
+
+    assert report.has_data
+    assert len(report.pairs) == 1
+    pair = report.pairs[0]
+    assert pair.symbol == "2330"
+    assert pair.side == "buy"
+    assert abs(pair.slippage_bps - 100.0) < 0.1
+    assert abs(report.avg_slippage_bps - 100.0) < 0.1
+
+
+def test_sell_pair_slippage():
+    """賣單：模擬 100 實盤 99 → 滑點約 101bps。"""
+    conn = _make_db()
+    _insert_order_fill(conn, symbol="0050", side="sell",
+                       account_mode="simulation", fill_price=100.0)
+    _insert_order_fill(conn, symbol="0050", side="sell",
+                       account_mode="live", fill_price=99.0)
+
+    report = compute_execution_quality(conn, days=7)
+
+    assert report.has_data
+    assert report.pairs[0].slippage_bps > 0
+
+
+# ─── Test 5: sim_only 計數 ────────────────────────────────────────────────────
+
+def test_sim_only_count_when_no_live():
+    """只有模擬訂單，無實盤 → sim_only > 0，pairs 為空。"""
+    conn = _make_db()
+    _insert_order_fill(conn, symbol="2330", side="buy",
+                       account_mode="simulation", fill_price=100.0)
+
+    report = compute_execution_quality(conn, days=7)
+
+    assert not report.has_data
+    assert report.sim_only_trades >= 1
+    assert report.live_only_trades == 0
+
+
+# ─── Test 6 & 7: format_telegram_report ─────────────────────────────────────
+
+def test_format_no_data():
+    report = ExecutionQualityReport(period_days=7)
+    msg = format_telegram_report(report)
+    assert "無實盤" in msg or "無法計算" in msg
+    assert "7" in msg
+
+
+def test_format_with_data():
+    report = ExecutionQualityReport(
+        period_days=7,
+        pairs=[
+            SlippagePair(
+                symbol="2330", trade_date="2026-03-18", side="buy",
+                sim_avg_price=100.0, live_avg_price=101.0,
+                sim_qty=1000, live_qty=1000,
+            )
+        ],
+    )
+    msg = format_telegram_report(report)
+    assert "2330" in msg
+    assert "bps" in msg
+    assert "100" in msg  # slippage value
+
+
+# ─── Test 8: SQL migration ───────────────────────────────────────────────────
+
+def test_migration_adds_account_mode_column(tmp_path):
+    from pathlib import Path
+    import sqlite3 as _sql
+
+    db = tmp_path / "test.db"
+    conn = _sql.connect(str(db))
+    conn.execute("""
+        CREATE TABLE orders (
+            order_id TEXT PRIMARY KEY,
+            decision_id TEXT NOT NULL,
+            broker_order_id TEXT,
+            ts_submit TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            qty INTEGER NOT NULL,
+            price REAL,
+            order_type TEXT NOT NULL DEFAULT 'limit',
+            tif TEXT NOT NULL DEFAULT 'IOC',
+            status TEXT NOT NULL,
+            strategy_version TEXT NOT NULL
+        )
+    """)
+    conn.commit()
+
+    migration = Path("src/sql/migration_v1_3_2_order_account_mode.sql")
+    conn.executescript(migration.read_text(encoding="utf-8"))
+    conn.commit()
+
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(orders)").fetchall()}
+    assert "account_mode" in cols
+    conn.close()


### PR DESCRIPTION
## Summary

- `orders` 表新增 `account_mode` 欄位（`simulation` / `live`）
- `ticker_watcher` 依 `TRADING_MODE` env 自動記錄帳戶模式至每筆訂單
- 新增 `execution_quality_report.py`：
  - `compute_execution_quality(conn, days=7)` — 以 `(symbol, date, side)` 配對實盤 vs 模擬成交，計算加權平均滑點（bps）
  - `format_telegram_report()` — 格式化為 Telegram 週報訊息
- SQL migration `v1_3_2_order_account_mode.sql` — `ALTER TABLE orders ADD COLUMN account_mode`

## Test plan

- [x] `pytest tests/test_execution_quality_report.py -v` → 10 passed
- [x] SlippagePair 買單/賣單滑點公式驗證
- [x] 有配對時正確計算 100bps 滑點
- [x] 無實盤時 `sim_only_trades` 計數正確
- [x] 格式化報告包含必要欄位
- [x] SQL migration 成功加入 `account_mode` 欄位
- [x] 完整測試套件 591 passed

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)