### PR TITLE
feat(ops): 多管道通知器 — Telegram 備援 Email SMTP fallback

### DIFF
--- a/src/openclaw/notifier.py
+++ b/src/openclaw/notifier.py
@@ -1,0 +1,241 @@
+"""notifier.py — 多管道通知器（Telegram 主 + Email 備援）
+
+解決 Telegram Bot 單點依賴問題（Issue #287）。
+
+優先順序：
+    1. Telegram（現有 tg_notify）
+    2. Email SMTP（備援）
+
+通知失敗時寫入 incidents 表；flush_pending() 在下次成功時補發。
+
+環境變數：
+    # Telegram（沿用原有）
+    TELEGRAM_BOT_TOKEN  — Telegram Bot token
+    TELEGRAM_CHAT_ID    — 目標 chat id（預設 1017252031）
+
+    # Email 備援
+    NOTIFY_EMAIL_TO     — 收件人（逗號分隔多位）
+    NOTIFY_EMAIL_FROM   — 寄件人 email
+    NOTIFY_EMAIL_SMTP_HOST — SMTP server（預設 smtp.gmail.com）
+    NOTIFY_EMAIL_SMTP_PORT — SMTP port（預設 587）
+    NOTIFY_EMAIL_USER   — SMTP 認證 username
+    NOTIFY_EMAIL_PASS   — SMTP 認證 password
+
+使用方式：
+    from openclaw.notifier import notify, flush_pending
+
+    # 一般通知（不需要 DB）
+    notify("🚨 風控警報：集中度超標")
+
+    # 附帶 DB 時支援失敗記錄與補發
+    notify("🚨 風控警報", conn=conn)
+    flush_pending(conn)
+"""
+from __future__ import annotations
+
+import email.mime.text
+import json
+import logging
+import os
+import smtplib
+import sqlite3
+import uuid
+from typing import Optional
+
+from openclaw.tg_notify import send_message as _tg_send
+
+log = logging.getLogger(__name__)
+
+_INCIDENT_SOURCE = "notifier"
+_INCIDENT_CODE = "NOTIFY_FAILURE"
+_PENDING_CODE = "NOTIFY_PENDING"
+
+
+# ──────────────────────────────────────────────
+# Email fallback
+# ──────────────────────────────────────────────
+
+def _send_email(text: str) -> bool:
+    """Send a plain-text notification email via SMTP.
+
+    Returns True on success, False on failure (never raises).
+    """
+    to_raw = os.environ.get("NOTIFY_EMAIL_TO", "").strip()
+    if not to_raw:
+        log.debug("[notifier] NOTIFY_EMAIL_TO 未設定，跳過 email 備援")
+        return False
+
+    from_addr = os.environ.get("NOTIFY_EMAIL_FROM", "").strip()
+    smtp_host = os.environ.get("NOTIFY_EMAIL_SMTP_HOST", "smtp.gmail.com").strip()
+    smtp_port = int(os.environ.get("NOTIFY_EMAIL_SMTP_PORT", "587"))
+    smtp_user = os.environ.get("NOTIFY_EMAIL_USER", "").strip()
+    smtp_pass = os.environ.get("NOTIFY_EMAIL_PASS", "").strip()
+
+    if not from_addr or not smtp_user or not smtp_pass:
+        log.debug("[notifier] Email 設定不完整，跳過備援")
+        return False
+
+    recipients = [addr.strip() for addr in to_raw.split(",") if addr.strip()]
+
+    msg = email.mime.text.MIMEText(text, "plain", "utf-8")
+    msg["Subject"] = "[AI-Trader] 通知"
+    msg["From"] = from_addr
+    msg["To"] = ", ".join(recipients)
+
+    try:
+        with smtplib.SMTP(smtp_host, smtp_port, timeout=15) as server:
+            server.ehlo()
+            server.starttls()
+            server.login(smtp_user, smtp_pass)
+            server.sendmail(from_addr, recipients, msg.as_string())
+        log.info("[notifier] Email 備援通知已發送至 %s", recipients)
+        return True
+    except Exception as exc:
+        log.warning("[notifier] Email 備援通知失敗: %s", exc)
+        return False
+
+
+# ──────────────────────────────────────────────
+# Incident persistence
+# ──────────────────────────────────────────────
+
+def _record_failure(
+    conn: Optional[sqlite3.Connection],
+    text: str,
+    channels_tried: list[str],
+) -> None:
+    """Write a NOTIFY_FAILURE incident so flush_pending() can retry later."""
+    if conn is None:
+        return
+    try:
+        conn.execute(
+            """INSERT INTO incidents
+               (incident_id, ts, severity, source, code, detail_json, resolved)
+               VALUES (?, datetime('now'), 'warn', ?, ?, ?, 0)""",
+            (
+                str(uuid.uuid4()),
+                _INCIDENT_SOURCE,
+                _INCIDENT_CODE,
+                json.dumps(
+                    {"message": text[:500], "channels_tried": channels_tried},
+                    ensure_ascii=True,
+                ),
+            ),
+        )
+        conn.commit()
+    except Exception as exc:
+        log.warning("[notifier] 無法寫入 NOTIFY_FAILURE incident: %s", exc)
+
+
+def _resolve_incidents(conn: sqlite3.Connection) -> None:
+    """Mark all pending NOTIFY_FAILURE incidents as resolved."""
+    try:
+        conn.execute(
+            "UPDATE incidents SET resolved=1 WHERE source=? AND code=? AND resolved=0",
+            (_INCIDENT_SOURCE, _INCIDENT_CODE),
+        )
+        conn.commit()
+    except Exception as exc:
+        log.warning("[notifier] 無法 resolve incidents: %s", exc)
+
+
+# ──────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────
+
+def notify(
+    text: str,
+    conn: Optional[sqlite3.Connection] = None,
+) -> bool:
+    """Send a notification via Telegram, falling back to Email on failure.
+
+    Args:
+        text: Message body (HTML tags accepted for Telegram; plain text for email).
+        conn: Optional SQLite connection.  When provided:
+              - Failed notifications are recorded in ``incidents``.
+              - A subsequent ``flush_pending(conn)`` will retry them.
+
+    Returns:
+        True if at least one channel succeeded, False otherwise.
+    """
+    channels_tried: list[str] = []
+
+    # ── Channel 1: Telegram ──────────────────────────────────────────────
+    try:
+        tg_ok = _tg_send(text)
+    except Exception as exc:
+        log.warning("[notifier] Telegram 呼叫異常: %s", exc)
+        tg_ok = False
+
+    if tg_ok:
+        if conn is not None:
+            _resolve_incidents(conn)   # clear any previous failures
+        return True
+
+    channels_tried.append("telegram")
+
+    # ── Channel 2: Email SMTP ────────────────────────────────────────────
+    email_ok = _send_email(text)
+    if email_ok:
+        if conn is not None:
+            _resolve_incidents(conn)
+        return True
+
+    channels_tried.append("email")
+
+    # ── All channels failed ──────────────────────────────────────────────
+    log.error("[notifier] 所有通知管道失敗（%s），訊息已記錄 incidents", channels_tried)
+    _record_failure(conn, text, channels_tried)
+    return False
+
+
+def flush_pending(conn: sqlite3.Connection) -> int:
+    """Retry failed notifications stored in the incidents table.
+
+    Queries unresolved NOTIFY_FAILURE incidents and re-sends each message.
+    Successfully sent incidents are marked as resolved.
+
+    Returns:
+        Number of incidents successfully re-sent.
+    """
+    try:
+        rows = conn.execute(
+            """SELECT incident_id, detail_json
+               FROM incidents
+               WHERE source=? AND code=? AND resolved=0
+               ORDER BY ts ASC""",
+            (_INCIDENT_SOURCE, _INCIDENT_CODE),
+        ).fetchall()
+    except Exception as exc:
+        log.warning("[notifier] flush_pending: 無法查詢 incidents: %s", exc)
+        return 0
+
+    if not rows:
+        return 0
+
+    sent = 0
+    for incident_id, detail_json in rows:
+        try:
+            detail = json.loads(detail_json or "{}")
+            msg = detail.get("message", "（訊息遺失）")
+        except Exception:
+            msg = "（訊息解析失敗）"
+
+        # Prepend a retry note
+        retry_msg = f"[補發] {msg}"
+        ok = notify(retry_msg)   # does not pass conn to avoid recursive incident writes
+        if ok:
+            try:
+                conn.execute(
+                    "UPDATE incidents SET resolved=1 WHERE incident_id=?",
+                    (incident_id,),
+                )
+                conn.commit()
+                sent += 1
+            except Exception as exc:
+                log.warning("[notifier] flush_pending: 無法 resolve %s: %s", incident_id, exc)
+
+    if sent:
+        log.info("[notifier] flush_pending: %d/%d 筆補發成功", sent, len(rows))
+
+    return sent

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,179 @@
+"""Tests for multi-channel notifier (Issue #287).
+
+Covers:
+- notify(): Telegram success → no fallback, returns True
+- notify(): Telegram failure → tries Email, Email success → returns True
+- notify(): Both fail → writes incident, returns False
+- notify(): Both fail, no conn → no crash, returns False
+- notify(): Telegram failure + Email not configured → incident written
+- flush_pending(): retries pending incidents
+- _send_email(): skips when env vars missing
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+import openclaw.notifier as notifier_mod
+from openclaw.notifier import notify, flush_pending
+
+
+# ──────────────────────────────────────────────
+# DB helper
+# ──────────────────────────────────────────────
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """CREATE TABLE incidents (
+            incident_id TEXT PRIMARY KEY,
+            ts          TEXT,
+            severity    TEXT,
+            source      TEXT,
+            code        TEXT,
+            detail_json TEXT,
+            resolved    INTEGER DEFAULT 0
+        )"""
+    )
+    conn.commit()
+    return conn
+
+
+# ──────────────────────────────────────────────
+# notify() — channel routing
+# ──────────────────────────────────────────────
+
+class TestNotify:
+    def test_telegram_success_returns_true_no_email(self, monkeypatch):
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: True)
+        email_called = []
+        monkeypatch.setattr(notifier_mod, "_send_email", lambda text: email_called.append(text) or True)
+        result = notify("hello")
+        assert result is True
+        assert email_called == []
+
+    def test_telegram_failure_tries_email_success(self, monkeypatch):
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: False)
+        monkeypatch.setattr(notifier_mod, "_send_email", lambda text: True)
+        result = notify("hello")
+        assert result is True
+
+    def test_both_fail_returns_false(self, monkeypatch):
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: False)
+        monkeypatch.setattr(notifier_mod, "_send_email", lambda text: False)
+        result = notify("hello")
+        assert result is False
+
+    def test_both_fail_writes_incident(self, monkeypatch):
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: False)
+        monkeypatch.setattr(notifier_mod, "_send_email", lambda text: False)
+        conn = _make_db()
+        notify("alert!", conn=conn)
+        row = conn.execute(
+            "SELECT code, detail_json, resolved FROM incidents WHERE code='NOTIFY_FAILURE'"
+        ).fetchone()
+        assert row is not None
+        assert row[2] == 0   # unresolved
+        detail = json.loads(row[1])
+        assert "telegram" in detail["channels_tried"]
+        assert "email" in detail["channels_tried"]
+        assert "alert!" in detail["message"]
+
+    def test_both_fail_no_conn_no_crash(self, monkeypatch):
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: False)
+        monkeypatch.setattr(notifier_mod, "_send_email", lambda text: False)
+        # Should not raise even without DB connection
+        result = notify("alert!", conn=None)
+        assert result is False
+
+    def test_telegram_success_resolves_incidents(self, monkeypatch):
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: True)
+        conn = _make_db()
+        # Pre-insert an unresolved incident
+        conn.execute(
+            """INSERT INTO incidents (incident_id, ts, severity, source, code, detail_json, resolved)
+               VALUES ('abc', datetime('now'), 'warn', 'notifier', 'NOTIFY_FAILURE', '{}', 0)"""
+        )
+        conn.commit()
+        notify("recovered", conn=conn)
+        row = conn.execute("SELECT resolved FROM incidents WHERE incident_id='abc'").fetchone()
+        assert row[0] == 1   # now resolved
+
+    def test_telegram_exception_treated_as_failure(self, monkeypatch):
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: (_ for _ in ()).throw(RuntimeError("timeout")))
+        monkeypatch.setattr(notifier_mod, "_send_email", lambda text: True)
+        result = notify("hello")
+        assert result is True   # email fallback succeeded
+
+
+# ──────────────────────────────────────────────
+# flush_pending()
+# ──────────────────────────────────────────────
+
+class TestFlushPending:
+    def _insert_pending(self, conn: sqlite3.Connection, msg: str, incident_id: str = "pid1") -> None:
+        conn.execute(
+            """INSERT INTO incidents (incident_id, ts, severity, source, code, detail_json, resolved)
+               VALUES (?, datetime('now'), 'warn', 'notifier', 'NOTIFY_FAILURE', ?, 0)""",
+            (incident_id, json.dumps({"message": msg, "channels_tried": ["telegram", "email"]})),
+        )
+        conn.commit()
+
+    def test_no_pending_returns_zero(self, monkeypatch):
+        conn = _make_db()
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: True)
+        assert flush_pending(conn) == 0
+
+    def test_retries_and_resolves_on_success(self, monkeypatch):
+        conn = _make_db()
+        self._insert_pending(conn, "original alert")
+        sent = []
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: sent.append(text) or True)
+        result = flush_pending(conn)
+        assert result == 1
+        assert any("補發" in m for m in sent)
+        row = conn.execute("SELECT resolved FROM incidents WHERE incident_id='pid1'").fetchone()
+        assert row[0] == 1
+
+    def test_does_not_resolve_on_continued_failure(self, monkeypatch):
+        conn = _make_db()
+        self._insert_pending(conn, "still failing")
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: False)
+        monkeypatch.setattr(notifier_mod, "_send_email", lambda text: False)
+        result = flush_pending(conn)
+        assert result == 0
+        row = conn.execute("SELECT resolved FROM incidents WHERE incident_id='pid1'").fetchone()
+        assert row[0] == 0   # still unresolved
+
+    def test_multiple_pending_all_resolved(self, monkeypatch):
+        conn = _make_db()
+        for i in range(3):
+            self._insert_pending(conn, f"msg{i}", f"pid{i}")
+        monkeypatch.setattr(notifier_mod, "_tg_send", lambda text: True)
+        result = flush_pending(conn)
+        assert result == 3
+
+    def test_missing_incidents_table_no_crash(self, monkeypatch):
+        conn = sqlite3.connect(":memory:")   # no table
+        result = flush_pending(conn)
+        assert result == 0
+
+
+# ──────────────────────────────────────────────
+# _send_email() env var guard
+# ──────────────────────────────────────────────
+
+class TestSendEmailEnvGuard:
+    def test_returns_false_when_no_recipient(self, monkeypatch):
+        monkeypatch.delenv("NOTIFY_EMAIL_TO", raising=False)
+        from openclaw.notifier import _send_email
+        assert _send_email("test") is False
+
+    def test_returns_false_when_incomplete_config(self, monkeypatch):
+        monkeypatch.setenv("NOTIFY_EMAIL_TO", "test@example.com")
+        monkeypatch.delenv("NOTIFY_EMAIL_FROM", raising=False)
+        monkeypatch.delenv("NOTIFY_EMAIL_USER", raising=False)
+        from openclaw.notifier import _send_email
+        assert _send_email("test") is False


### PR DESCRIPTION
## Summary

- 新增 `src/openclaw/notifier.py` — 統一通知入口，解決 Telegram 單點依賴
- `notify(text, conn=None)` — Telegram 主 → Email 備援；兩者均失敗寫入 `incidents`（`NOTIFY_FAILURE`）
- `flush_pending(conn)` — 查詢未解 `NOTIFY_FAILURE` incidents，重送成功後標記 `resolved`
- `_send_email(text)` — SMTP starttls 備援（Gmail 相容）

**必要環境變數（Email 備援，選填）：**
```
NOTIFY_EMAIL_TO=owner@example.com
NOTIFY_EMAIL_FROM=ai-trader@example.com
NOTIFY_EMAIL_SMTP_HOST=smtp.gmail.com
NOTIFY_EMAIL_SMTP_PORT=587
NOTIFY_EMAIL_USER=ai-trader@example.com
NOTIFY_EMAIL_PASS=<app-password>
```

**使用方式（逐步遷移現有呼叫點）：**
```python
from openclaw.notifier import notify, flush_pending
notify("🚨 風控警報", conn=conn)   # 替代 tg_notify.send_message()
flush_pending(conn)               # 在 ticker_watcher 每輪開頭補發
```

## Test plan

- [x] `tests/test_notifier.py` — 14 tests，全部通過
  - Telegram 成功 → 不觸 email，返回 True
  - Telegram 失敗 → email 備援成功，返回 True
  - 兩者均失敗 → incident 寫入 + 返回 False
  - 無 conn 不崩潰
  - Telegram 成功時 resolve 既有 incidents
  - Telegram 拋例外視同失敗
  - `flush_pending`: 無積壓返 0、成功重送 resolve、失敗不 resolve、缺表不崩潰
  - `_send_email`: 缺 env 返回 False

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)