### PR TITLE
feat(signals): 黑天鵝即時熔斷 — 市場跌超 3% 時強制切入 bear regime

### DIFF
--- a/src/openclaw/signal_aggregator.py
+++ b/src/openclaw/signal_aggregator.py
@@ -20,6 +20,11 @@ REGIME_WEIGHTS: dict[str, dict[str, float]] = {
     "range": {"technical": 0.40, "llm": 0.20, "risk_adj": 0.40},
 }
 
+# 黑天鵝即時熔斷：市場指數（0050）單日跌幅超過此門檻時強制切入 bear regime
+_BLACK_SWAN_DROP_THRESHOLD: float = float(
+    __import__("os").environ.get("BLACK_SWAN_DROP_THRESHOLD", "-0.03")
+)
+
 SIGNAL_TO_SCORE: dict[str, float] = {"buy": 0.8, "flat": 0.5, "sell": 0.2}
 
 _LIMIT_UP_THRESHOLD   = 0.095   # 漲幅 >= 9.5% 視為漲停
@@ -59,6 +64,7 @@ def aggregate(
     snap: dict,
     position_avg_price: Optional[float],
     high_water_mark: Optional[float],
+    market_snap: Optional[dict] = None,
 ) -> AggregatedSignal:
     """
     計算 Regime-based 加權信號。
@@ -72,6 +78,20 @@ def aggregate(
 
     # 1. Market regime
     regime, vol_mult = _get_regime(conn, symbol)
+
+    # 黑天鵝即時熔斷：市場指數單日跌幅超過門檻時強制切入 bear regime
+    if market_snap is not None:
+        _close = market_snap.get("close", 0.0)
+        _ref   = market_snap.get("reference", _close) or _close
+        if _ref > 0:
+            _market_drop = (_close - _ref) / _ref
+            if _market_drop <= _BLACK_SWAN_DROP_THRESHOLD:
+                regime = "bear"
+                reasons.append(
+                    f"BLACK_SWAN_OVERRIDE:market_drop={_market_drop:.2%}"
+                    f"<={_BLACK_SWAN_DROP_THRESHOLD:.2%}"
+                )
+
     weights = REGIME_WEIGHTS.get(regime, REGIME_WEIGHTS["range"])
     reasons.append(f"regime={regime}")
 

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -905,6 +905,10 @@ def run_watcher() -> None:
 
             # 一次性取得所有行情，並更新價格歷史
             snaps: Dict[str, dict] = {sym: _get_snapshot(api, sym) for sym in active_watchlist}
+            # 黑天鵝熔斷：無論 0050 是否在 watchlist，都取其即時快照供熔斷判斷
+            _BELLWETHER = "0050"
+            if _BELLWETHER not in snaps:
+                snaps[_BELLWETHER] = _get_snapshot(api, _BELLWETHER)
             for sym, s in snaps.items():
                 _update_price_history(price_history, sym, s["close"])
 
@@ -1067,6 +1071,7 @@ def run_watcher() -> None:
                         conn, symbol, snap,
                         position_avg_price=avg_price,
                         high_water_mark=high_water_marks.get(symbol),
+                        market_snap=snaps.get(_BELLWETHER),
                     )
                     sig = _agg_signal.action
                     # 將 aggregator 結果記入 trace metadata

--- a/src/tests/test_signal_aggregator.py
+++ b/src/tests/test_signal_aggregator.py
@@ -18,6 +18,7 @@ from openclaw.signal_aggregator import (
     _SELL_ACTION_THRESHOLD,
     _BUY_SCORE_LIMIT_UP,
     _SELL_SCORE_LIMIT_DOWN,
+    _BLACK_SWAN_DROP_THRESHOLD,
 )
 from openclaw.market_regime import MarketRegimeResult, MarketRegime
 
@@ -276,6 +277,94 @@ def test_high_volatility_lowers_risk_adj(mock_candles, mock_regime, mock_signal)
 
     # risk_adj = max(0.1, min(0.9, 0.5/2.0)) = 0.25
     assert "risk_adj=0.25" in " ".join(result.reasons)
+
+
+# ── Black Swan Circuit Breaker tests (Issue #289) ──
+
+@patch("openclaw.signal_aggregator.compute_signal", return_value="buy")
+@patch("openclaw.signal_aggregator.classify_market_regime")
+@patch("openclaw.signal_aggregator.fetch_candles")
+def test_black_swan_override_bull_to_bear(mock_candles, mock_regime, mock_signal):
+    """市場指數跌超 3%（黑天鵝）→ 強制將 bull regime 覆蓋為 bear。"""
+    mock_candles.return_value = [{"close": 100, "volume": 1000}] * 30
+    mock_regime.return_value = _mock_regime("bull", 1.0)
+
+    conn = _make_db()
+    snap = {"close": 105.0, "reference": 100.0}
+    # 0050 單日跌 4% → 超過 -3% 門檻
+    market_snap = {"close": 96.0, "reference": 100.0}
+
+    result = aggregate(
+        conn, "2330", snap,
+        position_avg_price=None, high_water_mark=None,
+        market_snap=market_snap,
+    )
+
+    assert result.regime == "bear", "黑天鵝熔斷應將 regime 強制切換為 bear"
+    assert result.weights_used == REGIME_WEIGHTS["bear"]
+    assert any("BLACK_SWAN_OVERRIDE" in r for r in result.reasons)
+
+
+@patch("openclaw.signal_aggregator.compute_signal", return_value="buy")
+@patch("openclaw.signal_aggregator.classify_market_regime")
+@patch("openclaw.signal_aggregator.fetch_candles")
+def test_black_swan_not_triggered_below_threshold(mock_candles, mock_regime, mock_signal):
+    """市場指數跌幅低於門檻（-2%）→ 不觸發熔斷，維持 bull regime。"""
+    mock_candles.return_value = [{"close": 100, "volume": 1000}] * 30
+    mock_regime.return_value = _mock_regime("bull", 1.0)
+
+    conn = _make_db()
+    snap = {"close": 105.0, "reference": 100.0}
+    # 0050 僅跌 2% → 未達 -3% 門檻
+    market_snap = {"close": 98.0, "reference": 100.0}
+
+    result = aggregate(
+        conn, "2330", snap,
+        position_avg_price=None, high_water_mark=None,
+        market_snap=market_snap,
+    )
+
+    assert result.regime == "bull", "跌幅 < 門檻時不應觸發熔斷"
+    assert not any("BLACK_SWAN_OVERRIDE" in r for r in result.reasons)
+
+
+@patch("openclaw.signal_aggregator.compute_signal", return_value="buy")
+@patch("openclaw.signal_aggregator.classify_market_regime")
+@patch("openclaw.signal_aggregator.fetch_candles")
+def test_black_swan_no_market_snap_backward_compat(mock_candles, mock_regime, mock_signal):
+    """market_snap=None（預設）→ 熔斷不觸發，向後相容。"""
+    mock_candles.return_value = [{"close": 100, "volume": 1000}] * 30
+    mock_regime.return_value = _mock_regime("bull", 1.0)
+
+    conn = _make_db()
+    snap = {"close": 105.0, "reference": 100.0}
+
+    result = aggregate(conn, "2330", snap, position_avg_price=None, high_water_mark=None)
+
+    assert result.regime == "bull"
+    assert not any("BLACK_SWAN_OVERRIDE" in r for r in result.reasons)
+
+
+@patch("openclaw.signal_aggregator.compute_signal", return_value="buy")
+@patch("openclaw.signal_aggregator.classify_market_regime")
+@patch("openclaw.signal_aggregator.fetch_candles")
+def test_black_swan_market_snap_zero_reference_no_override(mock_candles, mock_regime, mock_signal):
+    """market_snap.reference=0 → 不進行除法，不觸發熔斷。"""
+    mock_candles.return_value = [{"close": 100, "volume": 1000}] * 30
+    mock_regime.return_value = _mock_regime("bull", 1.0)
+
+    conn = _make_db()
+    snap = {"close": 105.0, "reference": 100.0}
+    market_snap = {"close": 0.0, "reference": 0.0}
+
+    result = aggregate(
+        conn, "2330", snap,
+        position_avg_price=None, high_water_mark=None,
+        market_snap=market_snap,
+    )
+
+    assert result.regime == "bull"
+    assert not any("BLACK_SWAN_OVERRIDE" in r for r in result.reasons)
 
 
 @patch("openclaw.signal_aggregator.compute_signal", return_value="flat")


### PR DESCRIPTION
## Summary

- `signal_aggregator.aggregate()` 新增 `market_snap` 參數：傳入市場指數（0050）即時快照
- 若 0050 單日跌幅 ≤ `BLACK_SWAN_DROP_THRESHOLD`（預設 -3%，可透過環境變數覆寫），立即覆蓋 regime 為 `bear`，並在 `reasons` 中記錄 `BLACK_SWAN_OVERRIDE`
- `ticker_watcher` 每輪強制取得 0050 快照（即使不在 watchlist），傳入熔斷判斷

## Test plan

- [ ] `test_black_swan_override_bull_to_bear` — 跌 4% → regime 強制 bear
- [ ] `test_black_swan_not_triggered_below_threshold` — 跌 2% → 不觸發
- [ ] `test_black_swan_no_market_snap_backward_compat` — `market_snap=None` 向後相容
- [ ] `test_black_swan_market_snap_zero_reference_no_override` — reference=0 安全防護
- [ ] 所有原有測試仍通過（16/16）

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)