### PR TITLE
fix(tests): avoid market_event_monitor import-time exit without yfinance [fix/issue-341]

### DIFF
--- a/tests/test_market_event_monitor.py
+++ b/tests/test_market_event_monitor.py
@@ -170,6 +170,11 @@ class TestMainIntegration:
         mock_tg.assert_called_once()
         mock_pm.assert_called_once()
 
+    def test_missing_yfinance_returns_2_without_import_exit(self):
+        with patch.object(mon, "yf", None):
+            rc = mon.main(dry_run=True)
+        assert rc == 2
+
 
 # ── send_telegram 網路失敗容錯 ───────────────────────────────────────────────
 

--- a/tools/market_event_monitor.py
+++ b/tools/market_event_monitor.py
@@ -38,8 +38,7 @@ from typing import Any
 try:
     import yfinance as yf
 except ImportError:
-    print("[market-monitor] ERROR: yfinance 未安裝。請執行: pip install yfinance", file=sys.stderr)
-    sys.exit(1)
+    yf = None
 
 # ── 監控閾值 ────────────────────────────────────────────────────────────────
 
@@ -109,10 +108,16 @@ _US_SYMBOLS = {
 _VIX_SYMBOL = "^VIX"
 
 
+def _require_yfinance():
+    if yf is None:
+        raise RuntimeError("yfinance 未安裝。請執行: pip install yfinance")
+    return yf
+
+
 def _pct_change(symbol: str, label: str) -> float | None:
     """抓取單一 symbol 前日收盤漲跌幅（%）。回傳 None 表示資料不可用。"""
     try:
-        ticker = yf.Ticker(symbol)
+        ticker = _require_yfinance().Ticker(symbol)
         hist = ticker.history(period="5d")
         if hist.empty or len(hist) < 2:
             log.warning("無法取得 %s (%s) 歷史資料", label, symbol)
@@ -129,6 +134,7 @@ def _pct_change(symbol: str, label: str) -> float | None:
 
 def fetch_us_market() -> dict[str, Any]:
     """抓取美股大盤及 VIX 前日漲跌幅。"""
+    _require_yfinance()
     result: dict[str, Any] = {}
     for label, symbol in _US_SYMBOLS.items():
         result[label] = _pct_change(symbol, label)
@@ -299,7 +305,11 @@ def main(dry_run: bool = False) -> int:
 
     # 1. 抓取美股大盤與 VIX
     log.info("抓取美股大盤與 VIX...")
-    us_data = fetch_us_market()
+    try:
+        us_data = fetch_us_market()
+    except RuntimeError as exc:
+        log.error("%s", exc)
+        return 2
     log.info("S&P 500: %s, Nasdaq: %s, VIX: %s",
              us_data.get("S&P 500"), us_data.get("Nasdaq"), us_data.get("VIX"))
 


### PR DESCRIPTION
## Scope
- remove import-time `sys.exit(1)` from `tools/market_event_monitor.py` when `yfinance` is absent
- require `yfinance` lazily at runtime and return a non-zero status from `main()` instead of aborting module import
- add regression coverage so pytest collection remains valid without `yfinance`

## Tests
- `pytest -q tests/test_market_event_monitor.py`
- `python -m py_compile tools/market_event_monitor.py tests/test_market_event_monitor.py`

## Risk
- CLI behavior changes from immediate import-time exit to runtime error handling with exit code `2`
- callers that imported the module expecting process termination on import will no longer get that side effect

## Related Issue
- Closes #341
