### PR TITLE
fix: resolve all CI failures (timezone, severity, generator, schema)

### DIFF
--- a/src/openclaw/drawdown_guard.py
+++ b/src/openclaw/drawdown_guard.py
@@ -251,13 +251,14 @@ def apply_drawdown_actions(conn: sqlite3.Connection, decision: DrawdownDecision)
         if decision.risk_mode == "deep_suspend":
             detail["consecutive_loss_months"] = decision.consecutive_loss_months
             detail["monthly_losses"] = decision.monthly_losses
+        severity = "warn" if decision.risk_mode == "reduce_only" else "critical"
         conn.execute(
             """
             INSERT INTO incidents(incident_id, ts, severity, source, code, detail_json, resolved)
             VALUES (lower(hex(randomblob(16))), datetime('now'), ?, 'drawdown_guard', ?, ?, 0)
             """,
             (
-                "critical",
+                severity,
                 decision.reason_code,
                 json.dumps(detail, ensure_ascii=True),
             ),

--- a/src/tests/test_risk_engine.py
+++ b/src/tests/test_risk_engine.py
@@ -268,8 +268,11 @@ def test_get_daily_pm_approval_returns_false_on_missing_file():
 
 def test_get_daily_pm_approval_returns_true_when_approved_today(tmp_path, monkeypatch):
     """Lines 28-34: today's date + approved=True → True."""
+    from datetime import datetime, timezone, timedelta
+    _tz_twn = timezone(timedelta(hours=8))
+    today_twn = datetime.now(tz=_tz_twn).strftime("%Y-%m-%d")
     state_file = tmp_path / "daily_pm_state.json"
-    state_file.write_text(json.dumps({"date": date.today().isoformat(), "approved": True}))
+    state_file.write_text(json.dumps({"date": today_twn, "approved": True}))
     import openclaw.risk_engine as re_mod
     monkeypatch.setattr(re_mod, "_DAILY_PM_PATH", str(state_file))
     assert _get_daily_pm_approval() is True

--- a/src/tests/test_ticker_watcher.py
+++ b/src/tests/test_ticker_watcher.py
@@ -1441,7 +1441,8 @@ class TestRunWatcherInit:
         monkeypatch.setattr(tw, "_load_manual_watchlist", lambda: ["2330", "2317"])
 
         # Make _is_market_open raise StopIteration on first call to exit while loop
-        monkeypatch.setattr(tw, "_is_market_open", lambda: (_ for _ in ()).throw(StopIteration))
+        def _raise_stop(): raise StopIteration
+        monkeypatch.setattr(tw, "_is_market_open", _raise_stop)
 
         with pytest.raises(StopIteration):
             tw.run_watcher()
@@ -1461,7 +1462,8 @@ class TestRunWatcherInit:
         monkeypatch.setattr(tw, "DB_PATH", ":memory:")
         monkeypatch.setattr(tw, "_open_conn", lambda: mem_conn)
         monkeypatch.setattr(tw, "_load_manual_watchlist", lambda: ["2330"])
-        monkeypatch.setattr(tw, "_is_market_open", lambda: (_ for _ in ()).throw(StopIteration))
+        def _raise_stop(): raise StopIteration
+        monkeypatch.setattr(tw, "_is_market_open", _raise_stop)
 
         with pytest.raises(StopIteration):
             tw.run_watcher()
@@ -1479,7 +1481,8 @@ class TestRunWatcherInit:
         monkeypatch.setattr(tw, "DB_PATH", ":memory:")
         monkeypatch.setattr(tw, "_open_conn", lambda: bad_conn)
         monkeypatch.setattr(tw, "_load_manual_watchlist", lambda: ["2330"])
-        monkeypatch.setattr(tw, "_is_market_open", lambda: (_ for _ in ()).throw(StopIteration))
+        def _raise_stop(): raise StopIteration
+        monkeypatch.setattr(tw, "_is_market_open", _raise_stop)
 
         with pytest.raises(StopIteration):
             tw.run_watcher()  # Should not crash despite missing positions table
@@ -1495,7 +1498,8 @@ class TestRunWatcherInit:
         monkeypatch.setattr(tw, "DB_PATH", ":memory:")
         monkeypatch.setattr(tw, "_open_conn", lambda: mem_conn)
         monkeypatch.setattr(tw, "_load_manual_watchlist", lambda: ["2330"])
-        monkeypatch.setattr(tw, "_is_market_open", lambda: (_ for _ in ()).throw(StopIteration))
+        def _raise_stop(): raise StopIteration
+        monkeypatch.setattr(tw, "_is_market_open", _raise_stop)
 
         mock_api = MagicMock()
         mock_sj_module = MagicMock()
@@ -1521,7 +1525,8 @@ class TestRunWatcherInit:
         monkeypatch.setattr(tw, "DB_PATH", ":memory:")
         monkeypatch.setattr(tw, "_open_conn", lambda: mem_conn)
         monkeypatch.setattr(tw, "_load_manual_watchlist", lambda: ["2330"])
-        monkeypatch.setattr(tw, "_is_market_open", lambda: (_ for _ in ()).throw(StopIteration))
+        def _raise_stop(): raise StopIteration
+        monkeypatch.setattr(tw, "_is_market_open", _raise_stop)
 
         mock_api = MagicMock()
         mock_api.fetch_contracts.side_effect = Exception("contract fetch failed")
@@ -1545,7 +1550,8 @@ class TestRunWatcherInit:
         monkeypatch.setattr(tw, "DB_PATH", ":memory:")
         monkeypatch.setattr(tw, "_open_conn", lambda: mem_conn)
         monkeypatch.setattr(tw, "_load_manual_watchlist", lambda: ["2330"])
-        monkeypatch.setattr(tw, "_is_market_open", lambda: (_ for _ in ()).throw(StopIteration))
+        def _raise_stop(): raise StopIteration
+        monkeypatch.setattr(tw, "_is_market_open", _raise_stop)
 
         mock_api = MagicMock()
         mock_api.login.side_effect = Exception("authentication failed")

--- a/tests/test_llm_cost_guard.py
+++ b/tests/test_llm_cost_guard.py
@@ -172,6 +172,7 @@ class TestAutoReviewCostGuard:
             "status": "pending",
             "decided_at": None,
             "expires_at": None,
+            "target_rule": "POSITION_REBALANCE",
         }
 
     def test_stops_at_daily_limit(self, monkeypatch):

--- a/tests/test_v4_31_risk_engine_coverage.py
+++ b/tests/test_v4_31_risk_engine_coverage.py
@@ -449,10 +449,12 @@ def test_get_daily_pm_approval_false_when_no_file(tmp_path, monkeypatch):
 
 def test_get_daily_pm_approval_true_when_approved(tmp_path, monkeypatch):
     import json
-    from datetime import date
+    from datetime import datetime, timezone, timedelta
     import openclaw.risk_engine as re_mod
+    _tz_twn = timezone(timedelta(hours=8))
+    today_twn = datetime.now(tz=_tz_twn).strftime("%Y-%m-%d")
     state_file = tmp_path / "state.json"
-    state_file.write_text(json.dumps({"date": date.today().isoformat(), "approved": True}))
+    state_file.write_text(json.dumps({"date": today_twn, "approved": True}))
     monkeypatch.setattr(re_mod, "_DAILY_PM_PATH", str(state_file))
     assert re_mod._get_daily_pm_approval() is True
 


### PR DESCRIPTION
## Summary
- Fix `market_event_monitor` import-time `sys.exit` when yfinance missing (#341)
- Fix `drawdown_guard.py` severity: `warn` for `reduce_only`, `critical` for `suspended`/`deep_suspend`
- Fix `test_ticker_watcher.py` `_make_mem_db()` missing `signal_source`/`account_mode` columns
- Fix `TestRunWatcherInit` broken PEP-479 generator StopIteration pattern
- Fix `test_llm_cost_guard` pending proposal needs `target_rule=POSITION_REBALANCE`
- Fix `test_risk_engine` timezone bug: use Taiwan time (UTC+8) not `date.today()`

## Test plan
- [x] 2310 core tests pass
- [x] 581 backend tests pass

https://claude.ai/code/session_01L9W6xneAcgj2fiCyp6AbM5