### PR TITLE
Fix operator CLI bootstrap for scheduled jobs

### DIFF
--- a/src/tests/test_operator_jobs.py
+++ b/src/tests/test_operator_jobs.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import subprocess
+import sys
 from pathlib import Path
 
 from openclaw.operator_jobs import (
@@ -350,3 +352,24 @@ def test_run_incident_hygiene_job_resolves_duplicates(tmp_path):
     assert result["summary"]["duplicates_resolved"] == 1
     latest = json.loads((out_dir / "latest.json").read_text(encoding="utf-8"))
     assert latest["summary"]["duplicates_resolved"] == 1
+
+
+def test_operator_cli_entrypoints_bootstrap_with_help():
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts = [
+        "tools/capture_ops_summary.py",
+        "tools/run_reconciliation.py",
+        "tools/run_incident_hygiene.py",
+        "tools/run_reconciliation_quarantine.py",
+        "tools/run_incident_resolution.py",
+    ]
+
+    for script in scripts:
+        proc = subprocess.run(
+            [sys.executable, str(repo_root / script), "--help"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, f"{script} failed: {proc.stderr}"

--- a/tools/capture_ops_summary.py
+++ b/tools/capture_ops_summary.py
@@ -7,12 +7,14 @@ import os
 import sys
 from pathlib import Path
 
-REPO_ROOT = get_repo_root()
+REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 sys.path.insert(0, str(REPO_ROOT / "frontend" / "backend"))
 
 from openclaw.operator_jobs import run_ops_summary_job
 from openclaw.path_utils import get_repo_root
+
+REPO_ROOT = get_repo_root()
 
 
 def main() -> int:

--- a/tools/run_incident_hygiene.py
+++ b/tools/run_incident_hygiene.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
-REPO_ROOT = get_repo_root()
+REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 sys.path.insert(0, str(REPO_ROOT / "frontend" / "backend"))
 
 from openclaw.operator_jobs import run_incident_hygiene_job
 from openclaw.path_utils import get_repo_root
+
+REPO_ROOT = get_repo_root()
 
 
 def main() -> int:

--- a/tools/run_incident_resolution.py
+++ b/tools/run_incident_resolution.py
@@ -4,17 +4,19 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from pathlib import Path
 import sqlite3
 import sys
+from pathlib import Path
 
-REPO_ROOT = get_repo_root()
+REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 sys.path.insert(0, str(REPO_ROOT / "frontend" / "backend"))
 
 from openclaw.incident_resolution import list_open_incident_clusters, resolve_open_incidents
 from openclaw.operator_remediation import list_operator_remediations
 from openclaw.path_utils import get_repo_root
+
+REPO_ROOT = get_repo_root()
 
 
 def main() -> int:

--- a/tools/run_reconciliation.py
+++ b/tools/run_reconciliation.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
-REPO_ROOT = get_repo_root()
+REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 sys.path.insert(0, str(REPO_ROOT / "frontend" / "backend"))
 
 from openclaw.operator_jobs import fetch_broker_snapshot, run_reconciliation_job
 from openclaw.path_utils import get_repo_root
+
+REPO_ROOT = get_repo_root()
 
 
 def _parse_simulation(raw: str | None) -> bool | None:

--- a/tools/run_reconciliation_quarantine.py
+++ b/tools/run_reconciliation_quarantine.py
@@ -4,21 +4,23 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from pathlib import Path
 import sqlite3
 import sys
+from pathlib import Path
 
-REPO_ROOT = get_repo_root()
+REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 sys.path.insert(0, str(REPO_ROOT / "frontend" / "backend"))
 
-from openclaw.position_quarantine import (
 from openclaw.path_utils import get_repo_root
+from openclaw.position_quarantine import (
     apply_quarantine_plan,
     build_reconciliation_quarantine_plan,
     clear_quarantine_symbols,
     get_quarantine_status,
 )
+
+REPO_ROOT = get_repo_root()
 
 
 def _load_latest_report(path: Path) -> dict:


### PR DESCRIPTION
## Scope
- Fix operator CLI bootstrap so tool entrypoints do not call `get_repo_root()` before importing it
- Repair the broken import block in `tools/run_reconciliation_quarantine.py`
- Add regression coverage that executes each operator CLI with `--help`

## Tests
- `PYTHONPATH=src:frontend/backend python -m pytest src/tests/test_operator_jobs.py -q`
- `python tools/capture_ops_summary.py --db-path data/sqlite/trades.db --output-dir /tmp/ai-trader-ops-summary-test`
- `python tools/run_incident_hygiene.py --db-path data/sqlite/trades.db --output-dir /tmp/ai-trader-incident-hygiene-test`
- `python tools/run_reconciliation.py --db-path /tmp/ai-trader-recon-verify.db --output-dir /tmp/ai-trader-reconciliation-test --broker-source mock --simulation true`
- `python tools/run_incident_resolution.py --db-path /tmp/ai-trader-cli-verify.db --summary-only`
- `python tools/run_reconciliation_quarantine.py --db-path /tmp/ai-trader-cli-verify.db --snapshot-path /tmp/ai-trader-reconciliation-test/latest.json`

## Risk
- Low: changes are limited to CLI bootstrap/import ordering and one regression test
- No core trading logic changed

## Related Issue
- Closes #367
