### PR TITLE
Handle wrapped SSL errors in EOD ingest fallback

### DIFF
--- a/src/openclaw/eod_ingest.py
+++ b/src/openclaw/eod_ingest.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
+from urllib.error import URLError
 from urllib.request import Request, urlopen
 from openclaw.path_utils import get_repo_root
 
@@ -95,6 +96,19 @@ def _fetch_text(url: str, timeout: int = 20, encoding: str = "utf-8") -> str:
         with urlopen(req, context=_make_ssl_ctx(verify=False), timeout=timeout) as resp:
             raw = resp.read()
             return raw.decode(encoding, errors="replace")
+    except URLError as exc:
+        reason = getattr(exc, "reason", None)
+        if isinstance(reason, ssl.SSLError):
+            _log.warning(
+                "[SECURITY] SSL verification failed for %s (%s); retrying with CERT_NONE. "
+                "This is a known TWSE/TPEx certificate issue (missing SKI, RFC 5280 §4.2.1.2).",
+                url,
+                reason,
+            )
+            with urlopen(req, context=_make_ssl_ctx(verify=False), timeout=timeout) as resp:
+                raw = resp.read()
+                return raw.decode(encoding, errors="replace")
+        raise
 
 
 def _to_float(value: Any) -> Optional[float]:

--- a/tests/test_ssl_fallback.py
+++ b/tests/test_ssl_fallback.py
@@ -123,6 +123,29 @@ class TestFetchTextSslFallback:
             with pytest.raises(urllib.error.URLError):
                 _fetch_text("https://openapi.twse.com.tw/v1/test")
 
+    def test_urlerror_wrapped_ssl_error_triggers_fallback(self):
+        """URLError(reason=SSLError) should use the insecure fallback path."""
+        from openclaw.eod_ingest import _fetch_text
+
+        wrapped_ssl_err = urllib.error.URLError(ssl.SSLError("CERTIFICATE_VERIFY_FAILED"))
+        mock_resp = _make_mock_response(b"twse data")
+
+        call_count = [0]
+
+        def side_effect(req, context, timeout):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise wrapped_ssl_err
+            return mock_resp
+
+        with patch("openclaw.eod_ingest.urlopen", side_effect=side_effect) as mock_urlopen:
+            result = _fetch_text("https://openapi.twse.com.tw/v1/test")
+
+        assert result == "twse data"
+        assert mock_urlopen.call_count == 2
+        ctx_fallback = mock_urlopen.call_args_list[1][1]["context"]
+        assert ctx_fallback.verify_mode == ssl.CERT_NONE
+
     def test_encoding_applied_on_fallback(self):
         """Encoding parameter is respected even on the fallback path."""
         from openclaw.eod_ingest import _fetch_text


### PR DESCRIPTION
## Summary
Handle Python 3.14-style `URLError(reason=SSLError)` wrappers in the TWSE/TPEx SSL fallback path so EOD ingest can still retry with `CERT_NONE` for known government cert issues.

## Tests
- `pytest -q tests/test_ssl_fallback.py`

## Risk
Low. This only broadens the existing insecure retry path to an equivalent wrapped exception shape; non-SSL `URLError` cases still propagate.

## Related
- Closes #369
- Related: cct08311github/openclaw#32
