### PR TITLE
Clean redundant local temp files from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,9 @@ firebase-debug.log
 config/daily_pm_state.json
 config/system_state.json
 config/market_monitor_state.json
+
+# Local editor / Codex artifacts
+.claude/settings.local.json
+.claude/*.local.md
+_tmp/
+test_crash.py


### PR DESCRIPTION
## Scope
- Remove redundant tracked runtime log `shioaji.log`
- Ignore local-only Codex/Claude artifacts and scratch files

## Tests
- `git check-ignore -v .claude/settings.local.json .claude/hookify.block-commit-on-main.local.md _tmp/demo.tmp test_crash.py`
- `git status --short --branch`

## Risk
- Low: no production code paths changed
- Cleanup is limited to repo hygiene and tracked-file removal

## Related Issue
- Closes #371
