### PR TITLE
fix(coder-agent): clear stale results when no approved issues

### DIFF
--- a/tests/test_check_approved_issues.py
+++ b/tests/test_check_approved_issues.py
@@ -267,6 +267,13 @@ class TestMainDryRun:
             rc = cai.main(["--dry-run", "--token", "fake"])
         assert rc == 0
 
+    def test_no_approved_issues_clears_state_in_non_dry_run(self):
+        with patch.object(cai, "fetch_approved_issues", return_value=[]), \
+             patch.object(cai, "save_results_state") as mock_save:
+            rc = cai.main(["--token", "fake"])
+        assert rc == 0
+        mock_save.assert_called_once_with([])
+
     def test_github_api_failure_returns_1(self):
         import urllib.error
         with patch.object(

--- a/tools/check_approved_issues.py
+++ b/tools/check_approved_issues.py
@@ -461,6 +461,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if not issues:
         print("No approved issues found.")
+        if not args.dry_run:
+            # Clear stale state so evening report does not show outdated backtest results.
+            save_results_state([])
         return 0
 
     print(f"Found {len(issues)} approved issue(s).")


### PR DESCRIPTION
## Scope
- Clear stale coder-agent results state when approved-issue scan finds no issues (non-dry-run)
- Add regression test for non-dry-run no-issue path

## Tests
- pytest -q tests/test_check_approved_issues.py

## Risk
- Low: changes only the no-approved-issue fast path in tools/check_approved_issues.py

## Related Issue
- Fixes #373
