### PR TITLE
fix: isolate ai-trader watcher Telegram identity

### DIFF
--- a/bin/run_watcher.sh
+++ b/bin/run_watcher.sh
@@ -30,6 +30,17 @@ fi
 export PYTHONPATH="${PYTHONPATH:-$REPO/src:$REPO/frontend/backend}"
 export DB_PATH="${DB_PATH:-$REPO/data/sqlite/trades.db}"
 
+# 4. 允許 watcher 使用專用 Telegram bot，避免和 OpenClaw 共用 token
+if [ -n "${WATCHER_TELEGRAM_BOT_TOKEN:-}" ]; then
+    export TELEGRAM_BOT_TOKEN="$WATCHER_TELEGRAM_BOT_TOKEN"
+fi
+
+if [ -n "${WATCHER_TELEGRAM_CHAT_ID:-}" ]; then
+    export TELEGRAM_CHAT_ID="$WATCHER_TELEGRAM_CHAT_ID"
+elif [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+    export TELEGRAM_CHAT_ID="1017252031"
+fi
+
 echo "[run_watcher] Starting ai-trader-watcher"
 echo "[run_watcher] SHIOAJI_API_KEY=${SHIOAJI_API_KEY:+SET} DB_PATH=$DB_PATH"
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -41,7 +41,9 @@ module.exports = {
       watch: false,
       kill_timeout: 30000,
       env: {
-        OPENCLAW_CURRENT_IP: "127.0.0.1"
+        OPENCLAW_CURRENT_IP: "127.0.0.1",
+        WATCHER_TELEGRAM_BOT_TOKEN: "8773751510:AAHFORPaipYCA_993wx8B5fGH_eOAq5jqP0",
+        WATCHER_TELEGRAM_CHAT_ID: "1017252031"
       }
     },
     {


### PR DESCRIPTION
## Summary
- add a watcher-specific Telegram bot token in PM2 config
- add a watcher-specific Telegram chat id in PM2 config
- make run_watcher.sh prefer watcher-specific Telegram env values and ignore empty inherited chat ids

## Testing
- 
- restarted  with usage: pm2 [options] <command>

pm2 -h, --help             all available commands and options
pm2 examples               display pm2 usage examples
pm2 <command> -h           help on a specific command

Access pm2 files in ~/.pm2 and verified runtime env/logs
- verified OpenClaw no longer logs Telegram 409 getUpdates conflicts after watcher restart

## Related
- Closes #375
- Closes #376