### PR TITLE
fix: guard negative sleep in ticker_watcher _interruptible_sleep (closes #378)

### DIFF
--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -48,7 +48,7 @@ def _interruptible_sleep(seconds: int) -> bool:
     while time.monotonic() < deadline:
         if _shutdown_requested:
             return True
-        time.sleep(min(1, deadline - time.monotonic()))
+        time.sleep(max(0, min(1, deadline - time.monotonic())))
     return False
 
 from openclaw.pnl_engine import on_sell_filled, sync_positions_table


### PR DESCRIPTION
## Summary

在 _interruptible_sleep 中加 max(0, ...) 保護，防止 deadline 已過時 time.sleep 收到負數拋 ValueError。

## 變更

-  — 1 行

## 驗證

- 手動測試 _interruptible_sleep(0) 行為正常
- 週末休市後重啟不再 crash