### PR TITLE
fix(risk): concentration guard — lower thresholds and fix dedup

### DIFF
--- a/src/openclaw/concentration_guard.py
+++ b/src/openclaw/concentration_guard.py
@@ -1,9 +1,11 @@
 """concentration_guard.py — 集中度守衛
 
 自動偵測單檔倉位過度集中，生成再平衡 proposal：
-  - 超過 60%：自動核准 → approved（proposal_executor 下輪掃盤自動執行）
-  - 超過 40%：待審 → pending（需人工核准）
-  - 低於 40%：無動作
+  - 超過 40%：自動核准 → approved（proposal_executor 下輪掃盤自動執行）
+  - 超過 25%：待審 → pending（需人工核准）
+  - 低於 25%：無動作
+
+#385: 閾值從 60%/40% 降至 40%/25%，修復 dedup 阻擋減倉的問題
 """
 import json
 import logging
@@ -14,9 +16,10 @@ from typing import TypedDict
 
 log = logging.getLogger(__name__)
 
-_AUTO_REDUCE_THRESHOLD: float = 0.60   # 超過 60%：自動核准減倉
-_WARN_THRESHOLD:        float = 0.40   # 超過 40%：生成待審 proposal
-_TARGET_WEIGHT:         float = 0.30   # 目標降至 30%
+_AUTO_REDUCE_THRESHOLD: float = 0.40   # 超過 40%：自動核准減倉
+_WARN_THRESHOLD:        float = 0.25   # 超過 25%：生成待審 proposal
+_TARGET_WEIGHT:         float = 0.20   # 目標降至 20%（與 risk_engine max_symbol_weight 對齊）
+_STALE_ORDER_SEC:       int   = 360    # 超過 6 分鐘的 submitted 賣單視為 stale
 
 
 class ConcentrationProposal(TypedDict):
@@ -49,17 +52,22 @@ def check_concentration(
     if total_value <= 0:
         return []
 
-    # Dedup: skip symbols that already have pending submitted sell orders
+    # Dedup: check pending sell orders per symbol, but only skip if
+    # the pending sell qty is sufficient to bring weight below target (#385)
+    stale_cutoff = time.strftime("%Y-%m-%dT%H:%M:%S",
+                                 time.gmtime(time.time() - _STALE_ORDER_SEC))
+    pending_sell_qty: dict[str, int] = {}
     try:
-        pending_symbols = {
-            r[0] for r in conn.execute(
-                "SELECT DISTINCT symbol FROM orders WHERE side='sell' AND status='submitted'"
-            ).fetchall()
-        }
+        for r in conn.execute(
+            """SELECT symbol, SUM(qty) FROM orders
+               WHERE side='sell' AND status='submitted' AND ts_submit > ?
+               GROUP BY symbol""",
+            (stale_cutoff,),
+        ).fetchall():
+            pending_sell_qty[r[0]] = int(r[1] or 0)
     except sqlite3.Error as e:
         log.error("Dedup query failed, proceeding WITHOUT dedup — "
                   "duplicate proposals may be generated: %s", e)
-        pending_symbols = set()
 
     proposals: list[ConcentrationProposal] = []
     for symbol, qty, price in rows:
@@ -67,10 +75,17 @@ def check_concentration(
         if weight < _WARN_THRESHOLD:
             continue
 
-        if symbol in pending_symbols:
-            log.info("Concentration %s: %.1f%% — skipped (pending sell orders exist)",
-                     symbol, weight * 100)
-            continue
+        # Check if pending sell is sufficient to bring weight below target
+        pending_qty = pending_sell_qty.get(symbol, 0)
+        if pending_qty > 0:
+            remaining_qty = qty - pending_qty
+            remaining_weight = (remaining_qty * (price or 0)) / total_value if total_value > 0 else 0
+            if remaining_weight <= _TARGET_WEIGHT:
+                log.info("Concentration %s: %.1f%% — skipped (pending sell %d will reduce to %.1f%%)",
+                         symbol, weight * 100, pending_qty, remaining_weight * 100)
+                continue
+            log.info("Concentration %s: %.1f%% — pending sell %d insufficient (would be %.1f%%), generating additional proposal",
+                     symbol, weight * 100, pending_qty, remaining_weight * 100)
 
         if locked_symbols and symbol in locked_symbols:
             log.warning("Concentration %s: %.1f%% — skipped (locked symbol, sell prohibited)",

--- a/src/tests/test_concentration_guard.py
+++ b/src/tests/test_concentration_guard.py
@@ -53,28 +53,31 @@ def test_auto_reduce_creates_approved_proposal_in_db(tmp_path):
     assert any(r[0] == "approved" for r in rows)
 
 
-def test_pending_proposal_when_40_to_60_pct(tmp_path):
-    """單檔 40-60% 生成 pending proposal（需人工核准）"""
+def test_pending_proposal_when_25_to_40_pct(tmp_path):
+    """單檔 25-40% 生成 pending proposal（需人工核准，#385 閾值降低）"""
     from openclaw.concentration_guard import check_concentration
     conn = _make_db(tmp_path)
+    # 3008: 100*2450 = 245000 (30%), 2330: 300*1900 = 570000 (70%)
     conn.execute("INSERT INTO positions VALUES ('3008',100,379.6,2450,0,2450)")
-    conn.execute("INSERT INTO positions VALUES ('2330',300,898.6,1000,0,1000)")
+    conn.execute("INSERT INTO positions VALUES ('2330',300,898.6,1900,0,1900)")
     conn.commit()
 
     proposals = check_concentration(conn)
-    if proposals:
-        p3008 = next((p for p in proposals if p["symbol"] == "3008"), None)
-        if p3008:
-            assert not p3008["auto_approve"]  # 需人工核准
+    p3008 = next((p for p in proposals if p["symbol"] == "3008"), None)
+    if p3008:
+        assert not p3008["auto_approve"]  # 30% is between 25-40% → pending
 
 
-def test_no_proposals_when_under_40pct(tmp_path):
-    """所有持倉均低於 40% 時不生成 proposal（各佔約 33%）"""
+def test_no_proposals_when_under_25pct(tmp_path):
+    """所有持倉均低於 25% 時不生成 proposal（#385 閾值降至 25%）"""
     from openclaw.concentration_guard import check_concentration
     conn = _make_db(tmp_path)
+    # 5 stocks at 20% each → all under 25%
     conn.execute("INSERT INTO positions VALUES ('2330',100,0,100,0,100)")
     conn.execute("INSERT INTO positions VALUES ('2317',100,0,100,0,100)")
     conn.execute("INSERT INTO positions VALUES ('2382',100,0,100,0,100)")
+    conn.execute("INSERT INTO positions VALUES ('2454',100,0,100,0,100)")
+    conn.execute("INSERT INTO positions VALUES ('3008',100,0,100,0,100)")
     conn.commit()
 
     proposals = check_concentration(conn)
@@ -89,16 +92,18 @@ def test_empty_positions_returns_no_proposals(tmp_path):
     assert proposals == []
 
 
-def test_dedup_skips_symbol_with_pending_sell_orders(tmp_path):
-    """已有 submitted sell orders 的標的不應再產生新 proposal"""
+def test_dedup_skips_symbol_with_sufficient_recent_sell(tmp_path):
+    """已有足夠的 recent submitted sell → 不再產生新 proposal (#385 dedup fix)"""
+    import time as _time
     from openclaw.concentration_guard import check_concentration
     conn = _make_db(tmp_path)
     conn.execute("INSERT INTO positions VALUES ('3008',591,379.6,2450,0,2450)")
     conn.execute("INSERT INTO positions VALUES ('2330',151,898.6,1935,0,1935)")
-    # 已有一筆 submitted sell order for 3008
-    conn.execute("""INSERT INTO orders VALUES (
-        'existing-order','d1','b1','2026-03-06T04:00:00+00:00',
-        '3008','sell',378,2350.0,'limit','ROD','submitted','v1')""")
+    # Recent sell order for 500 shares of 3008 → sufficient to bring below target
+    now_iso = _time.strftime("%Y-%m-%dT%H:%M:%S+00:00", _time.gmtime())
+    conn.execute(f"""INSERT INTO orders VALUES (
+        'existing-order','d1','b1','{now_iso}',
+        '3008','sell',500,2350.0,'limit','ROD','submitted','v1')""")
     conn.commit()
 
     proposals = check_concentration(conn)

--- a/tests/test_concentration_guard_dedup.py
+++ b/tests/test_concentration_guard_dedup.py
@@ -1,0 +1,174 @@
+"""Tests for concentration_guard dedup fix and threshold changes (#385).
+
+Covers:
+- New thresholds: 40% auto-approve, 25% warn
+- Dedup: pending sell orders skip only if sufficient to reach target
+- Stale orders (>6 min) are ignored in dedup
+- Insufficient pending sell generates additional proposal
+"""
+import sqlite3
+import time
+
+import pytest
+
+from openclaw.concentration_guard import (
+    _AUTO_REDUCE_THRESHOLD,
+    _STALE_ORDER_SEC,
+    _TARGET_WEIGHT,
+    _WARN_THRESHOLD,
+    check_concentration,
+)
+
+
+def _make_db(positions: list[tuple], orders: list[tuple] | None = None) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """CREATE TABLE positions (
+            symbol TEXT PRIMARY KEY,
+            quantity REAL,
+            current_price REAL,
+            state TEXT,
+            avg_price REAL,
+            unrealized_pnl REAL,
+            high_water_mark REAL,
+            entry_trading_day TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE orders (
+            order_id TEXT PRIMARY KEY,
+            symbol TEXT,
+            side TEXT,
+            qty INTEGER,
+            status TEXT,
+            ts_submit TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE strategy_proposals (
+            proposal_id TEXT PRIMARY KEY,
+            generated_by TEXT,
+            target_rule TEXT,
+            rule_category TEXT,
+            proposed_value TEXT,
+            supporting_evidence TEXT,
+            confidence REAL,
+            requires_human_approval INTEGER,
+            status TEXT,
+            proposal_json TEXT,
+            created_at INTEGER
+        )"""
+    )
+    conn.executemany(
+        "INSERT INTO positions (symbol, quantity, current_price) VALUES (?,?,?)",
+        positions,
+    )
+    if orders:
+        conn.executemany(
+            "INSERT INTO orders (order_id, symbol, side, qty, status, ts_submit) VALUES (?,?,?,?,?,?)",
+            orders,
+        )
+    conn.commit()
+    return conn
+
+
+class TestThresholdValues:
+    """Verify threshold constants match #385 spec."""
+
+    def test_auto_reduce_threshold(self):
+        assert _AUTO_REDUCE_THRESHOLD == 0.40
+
+    def test_warn_threshold(self):
+        assert _WARN_THRESHOLD == 0.25
+
+    def test_target_weight(self):
+        assert _TARGET_WEIGHT == 0.20
+
+
+class TestConcentrationDetection:
+    def test_above_40pct_auto_approved(self):
+        # SYM_A: 500 * 100 = 50,000 (50%)
+        # SYM_B: 500 * 100 = 50,000 (50%)
+        conn = _make_db([("SYM_A", 500, 100), ("SYM_B", 500, 100)])
+        proposals = check_concentration(conn)
+        # Both at 50% > 40% → both auto-approved
+        assert len(proposals) == 2
+        assert all(p["auto_approve"] for p in proposals)
+
+    def test_between_25_and_40_pending(self):
+        # SYM_A: 300 * 100 = 30,000 (30%)
+        # SYM_B: 700 * 100 = 70,000 (70%)
+        conn = _make_db([("SYM_A", 300, 100), ("SYM_B", 700, 100)])
+        proposals = check_concentration(conn)
+        sym_a = [p for p in proposals if p["symbol"] == "SYM_A"]
+        sym_b = [p for p in proposals if p["symbol"] == "SYM_B"]
+        # SYM_A: 30% > 25%, < 40% → pending
+        assert len(sym_a) == 1
+        assert sym_a[0]["auto_approve"] is False
+        # SYM_B: 70% > 40% → auto-approved
+        assert len(sym_b) == 1
+        assert sym_b[0]["auto_approve"] is True
+
+    def test_below_threshold_no_proposal(self):
+        # SYM_A: 200 * 100 = 20,000 (20%)
+        # SYM_B: 800 * 100 = 80,000 (80%)
+        conn = _make_db([("SYM_A", 200, 100), ("SYM_B", 800, 100)])
+        proposals = check_concentration(conn)
+        # SYM_A: 20% < 25% → no proposal
+        assert len(proposals) == 1
+        assert proposals[0]["symbol"] == "SYM_B"
+
+
+class TestDedupSufficientSell:
+    def test_skips_when_pending_sell_covers_target(self):
+        # SYM_A: 800 * 100 = 80,000 (80%)
+        # SYM_B: 200 * 100 = 20,000 (20%)
+        # Pending sell 600 for SYM_A → remaining = 200 (20%) <= target 20%
+        now_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
+        conn = _make_db(
+            [("SYM_A", 800, 100), ("SYM_B", 200, 100)],
+            [("ORD1", "SYM_A", "sell", 600, "submitted", now_iso)],
+        )
+        proposals = check_concentration(conn)
+        # SYM_A should be skipped — pending sell is sufficient
+        sym_a = [p for p in proposals if p["symbol"] == "SYM_A"]
+        assert len(sym_a) == 0
+
+    def test_generates_proposal_when_pending_sell_insufficient(self):
+        # SYM_A: 800 * 100 = 80,000 (80%)
+        # SYM_B: 200 * 100 = 20,000 (20%)
+        # Pending sell 100 for SYM_A → remaining = 700 (70%) > target 20%
+        now_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
+        conn = _make_db(
+            [("SYM_A", 800, 100), ("SYM_B", 200, 100)],
+            [("ORD1", "SYM_A", "sell", 100, "submitted", now_iso)],
+        )
+        proposals = check_concentration(conn)
+        sym_a = [p for p in proposals if p["symbol"] == "SYM_A"]
+        assert len(sym_a) == 1
+
+    def test_ignores_stale_orders(self):
+        # SYM_A: 800 * 100 = 80,000 (80%)
+        # SYM_B: 200 * 100 = 20,000 (20%)
+        # Old sell order (7 min ago) → stale, should be ignored
+        stale_iso = time.strftime(
+            "%Y-%m-%dT%H:%M:%S",
+            time.gmtime(time.time() - _STALE_ORDER_SEC - 60),
+        )
+        conn = _make_db(
+            [("SYM_A", 800, 100), ("SYM_B", 200, 100)],
+            [("ORD1", "SYM_A", "sell", 600, "submitted", stale_iso)],
+        )
+        proposals = check_concentration(conn)
+        # Stale sell order ignored → SYM_A gets a new proposal
+        sym_a = [p for p in proposals if p["symbol"] == "SYM_A"]
+        assert len(sym_a) == 1
+
+    def test_no_pending_sells_generates_proposal(self):
+        # SYM_A: 800 * 100 = 80,000 (80%)
+        # SYM_B: 200 * 100 = 20,000 (20%)
+        conn = _make_db([("SYM_A", 800, 100), ("SYM_B", 200, 100)])
+        proposals = check_concentration(conn)
+        sym_a = [p for p in proposals if p["symbol"] == "SYM_A"]
+        assert len(sym_a) == 1
+        assert sym_a[0]["auto_approve"] is True

--- a/tests/test_concentration_guard_locked.py
+++ b/tests/test_concentration_guard_locked.py
@@ -126,8 +126,9 @@ class TestBackwardCompatibility:
         assert "LOCKED_SYM" in symbols
 
 
-def test_dedup_skips_symbol_with_pending_sell(tmp_path):
-    """Symbol with pending sell order → skipped (no duplicate proposal)."""
+def test_dedup_skips_symbol_with_sufficient_pending_sell(tmp_path):
+    """Symbol with sufficient recent pending sell order → skipped (#385: dedup checks qty)."""
+    import time as _time
     db_path = tmp_path / "dedup.db"
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
@@ -136,14 +137,15 @@ def test_dedup_skips_symbol_with_pending_sell(tmp_path):
     conn.execute("CREATE TABLE strategy_proposals (proposal_id TEXT PRIMARY KEY, generated_by TEXT, target_rule TEXT, rule_category TEXT, proposed_value TEXT, supporting_evidence TEXT, confidence REAL, requires_human_approval INTEGER, status TEXT, proposal_json TEXT, created_at INTEGER)")
     conn.execute("INSERT INTO positions VALUES ('HIGH', 700, 100.0, 80.0, 'holding')")
     conn.execute("INSERT INTO positions VALUES ('LOW', 300, 100.0, 90.0, 'holding')")
-    # HIGH has a pending sell order → should be deduped
-    conn.execute("INSERT INTO orders VALUES ('o1','HIGH','sell','submitted',100,100.0,'2026-03-14',NULL,NULL,NULL,NULL,NULL)")
+    # HIGH has a recent pending sell for 600 qty → sufficient to bring to 10% (below 20% target)
+    now_iso = _time.strftime("%Y-%m-%dT%H:%M:%S", _time.gmtime())
+    conn.execute(f"INSERT INTO orders VALUES ('o1','HIGH','sell','submitted',600,100.0,'{now_iso}',NULL,NULL,NULL,NULL,NULL)")
     conn.commit()
 
     from openclaw.concentration_guard import check_concentration
     proposals = check_concentration(conn)
     high_proposals = [p for p in proposals if p["symbol"] == "HIGH"]
-    assert len(high_proposals) == 0  # deduped
+    assert len(high_proposals) == 0  # deduped — sell qty sufficient
 
 
 def test_dedup_does_not_skip_filled_sell(tmp_path):
@@ -183,4 +185,4 @@ def test_concentration_40_60_pending_proposal(tmp_path):
     proposals = check_concentration(conn)
     mid_proposals = [p for p in proposals if p["symbol"] == "MID"]
     assert len(mid_proposals) == 1
-    assert mid_proposals[0]["auto_approve"] is False  # 50% is between 40-60%
+    assert mid_proposals[0]["auto_approve"] is True  # 50% > 40% → auto-approve (#385 lowered thresholds)


### PR DESCRIPTION
## Summary
- 閾值降低：自動核准 60%→40%、警告 40%→25%、目標 30%→20%（與 risk_engine 對齊）
- Dedup 修復：改為檢查 pending sell 數量是否足以降到目標，而非只看是否有 submitted 訂單
- Stale order 處理：超過 6 分鐘的 submitted 賣單不計入 dedup
- 10 個新 pytest case + 2 個既有測試更新

## Test plan
- [x] 18/18 concentration guard tests pass
- [x] 811/811 existing tests pass
- [ ] 觀察 5 個交易日確認集中度不再超過 40%

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)