### PR TITLE
fix(risk): hard wash sale — block buy after same-day sell

### DIFF
--- a/src/openclaw/risk_engine.py
+++ b/src/openclaw/risk_engine.py
@@ -94,6 +94,7 @@ class PortfolioState:
     positions: Dict[str, Position] = field(default_factory=dict)
     consecutive_losses: int = 0
     same_day_fill_symbols: set = field(default_factory=set)
+    same_day_sell_symbols: set = field(default_factory=set)  # #386: sell-then-buy prevention
 
     def position_value(self, symbol: str) -> float:
         pos = self.positions.get(symbol)
@@ -244,6 +245,14 @@ def evaluate_and_build_order(
         and decision.symbol in portfolio.same_day_fill_symbols
     ):
         return EvaluationResult(False, "RISK_WASH_SALE", metrics=base_metrics)
+
+    # HARD WASH SALE — blocks buy on symbol sold today (#386).
+    # NO config bypass: sell-then-buy same day is never allowed.
+    if (
+        decision.signal_side == "buy"
+        and decision.symbol in portfolio.same_day_sell_symbols
+    ):
+        return EvaluationResult(False, "RISK_WASH_SALE_SELL_TODAY", metrics=base_metrics)
 
     # DAILY PM APPROVAL — blocks all trading if today's review not approved.
     # Bypass with limits["pm_review_required"] = 0 (e.g. simulation / backtest).

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -150,6 +150,25 @@ def _get_today_buy_filled_symbols(conn: sqlite3.Connection) -> set:
         return set()
 
 
+def _get_today_sell_filled_symbols(conn: sqlite3.Connection) -> set:
+    """返回今日（UTC+8）已有 fills 的 sell 訂單 symbol 集合。
+
+    用於 wash sale 防護 #386：同日賣出後禁止買回。
+    """
+    try:
+        rows = conn.execute(
+            """SELECT DISTINCT o.symbol
+               FROM orders o
+               JOIN fills f ON f.order_id = o.order_id
+               WHERE o.side = 'sell'
+                 AND date(o.ts_submit, '+8 hours') = date('now', '+8 hours')"""
+        ).fetchall()
+        return {r[0] for r in rows}
+    except sqlite3.Error as e:
+        log.warning("_get_today_sell_filled_symbols failed: %s", e)
+        return set()
+
+
 def _ensure_schema(conn: sqlite3.Connection) -> None:
     """執行 schema migration：為舊版 DB 新增缺少的欄位。
 
@@ -1178,6 +1197,7 @@ def run_watcher() -> None:
                     realized_pnl_today=_get_realized_pnl_today(conn), unrealized_pnl=0.0,
                     positions=all_pos_map,
                     same_day_fill_symbols=_get_today_buy_filled_symbols(conn),
+                    same_day_sell_symbols=_get_today_sell_filled_symbols(conn),  # #386
                 )
                 _exit_system = SystemState(
                     now_ms=scan_ms,
@@ -1322,6 +1342,7 @@ def run_watcher() -> None:
                     realized_pnl_today=_get_realized_pnl_today(conn), unrealized_pnl=0.0,
                     positions=all_pos_map,   # ← 包含全部持倉，gross_exposure 正確累計
                     same_day_fill_symbols=_get_today_buy_filled_symbols(conn),
+                    same_day_sell_symbols=_get_today_sell_filled_symbols(conn),  # #386
                 )
                 system = SystemState(
                     now_ms=scan_ms,

--- a/tests/test_wash_sale_hard_fix.py
+++ b/tests/test_wash_sale_hard_fix.py
@@ -1,0 +1,128 @@
+"""Tests for hard wash sale prevention (#386).
+
+Covers:
+- RISK_WASH_SALE_SELL_TODAY blocks buy after same-day sell
+- Cannot be bypassed by wash_sale_prevention_enabled=0
+- Does not block buy when no same-day sell exists
+- Does not block sell orders
+"""
+from __future__ import annotations
+
+import pytest
+
+from openclaw.risk_engine import (
+    Decision,
+    EvaluationResult,
+    MarketState,
+    PortfolioState,
+    SystemState,
+    evaluate_and_build_order,
+    default_limits,
+)
+
+
+def _make_decision(symbol: str = "2330", side: str = "buy") -> Decision:
+    return Decision(
+        decision_id="test-001",
+        ts_ms=1000,
+        symbol=symbol,
+        strategy_id="test",
+        signal_side=side,
+        signal_score=0.8,
+    )
+
+
+def _make_market() -> MarketState:
+    return MarketState(
+        best_bid=100.0,
+        best_ask=100.2,
+        volume_1m=100000,
+        feed_delay_ms=10,
+    )
+
+
+def _make_portfolio(
+    same_day_sell_symbols: set | None = None,
+    same_day_fill_symbols: set | None = None,
+) -> PortfolioState:
+    return PortfolioState(
+        nav=1_000_000,
+        cash=500_000,
+        realized_pnl_today=0.0,
+        unrealized_pnl=0.0,
+        same_day_fill_symbols=same_day_fill_symbols or set(),
+        same_day_sell_symbols=same_day_sell_symbols or set(),
+    )
+
+
+def _make_system() -> SystemState:
+    return SystemState(
+        now_ms=1000,
+        trading_locked=False,
+        broker_connected=True,
+        db_write_p99_ms=10,
+        orders_last_60s=0,
+    )
+
+
+class TestHardWashSale:
+    def test_buy_blocked_after_same_day_sell(self):
+        decision = _make_decision("2330", "buy")
+        portfolio = _make_portfolio(same_day_sell_symbols={"2330"})
+        limits = default_limits()
+        limits["pm_review_required"] = 0
+
+        result = evaluate_and_build_order(
+            decision, _make_market(), portfolio, limits, _make_system()
+        )
+        assert not result.approved
+        assert result.reject_code == "RISK_WASH_SALE_SELL_TODAY"
+
+    def test_cannot_bypass_with_config(self):
+        """Even with wash_sale_prevention_enabled=0, sell-today check still blocks."""
+        decision = _make_decision("2330", "buy")
+        portfolio = _make_portfolio(same_day_sell_symbols={"2330"})
+        limits = default_limits()
+        limits["pm_review_required"] = 0
+        limits["wash_sale_prevention_enabled"] = 0  # disable old check
+
+        result = evaluate_and_build_order(
+            decision, _make_market(), portfolio, limits, _make_system()
+        )
+        assert not result.approved
+        assert result.reject_code == "RISK_WASH_SALE_SELL_TODAY"
+
+    def test_buy_allowed_when_no_same_day_sell(self):
+        decision = _make_decision("2330", "buy")
+        portfolio = _make_portfolio(same_day_sell_symbols=set())
+        limits = default_limits()
+        limits["pm_review_required"] = 0
+
+        result = evaluate_and_build_order(
+            decision, _make_market(), portfolio, limits, _make_system()
+        )
+        # May still be rejected by other checks, but NOT by wash sale
+        assert result.reject_code != "RISK_WASH_SALE_SELL_TODAY"
+
+    def test_sell_not_blocked_by_same_day_sell(self):
+        """Sell orders should not be blocked by wash sale (allow closing positions)."""
+        decision = _make_decision("2330", "sell")
+        portfolio = _make_portfolio(same_day_sell_symbols={"2330"})
+        limits = default_limits()
+        limits["pm_review_required"] = 0
+
+        result = evaluate_and_build_order(
+            decision, _make_market(), portfolio, limits, _make_system()
+        )
+        assert result.reject_code != "RISK_WASH_SALE_SELL_TODAY"
+
+    def test_different_symbol_not_blocked(self):
+        decision = _make_decision("2317", "buy")
+        portfolio = _make_portfolio(same_day_sell_symbols={"2330"})
+        limits = default_limits()
+        limits["pm_review_required"] = 0
+
+        result = evaluate_and_build_order(
+            decision, _make_market(), portfolio, limits, _make_system()
+        )
+        assert result.reject_code != "RISK_WASH_SALE_SELL_TODAY"


### PR DESCRIPTION
## Summary
- 新增 `RISK_WASH_SALE_SELL_TODAY` 硬性檢查：同日賣出的標的禁止買回
- 無 config 可繞過（不同於原有的 `wash_sale_prevention_enabled`）
- 新增 `_get_today_sell_filled_symbols()` 追蹤當日賣出標的
- 5 個 pytest case 覆蓋阻擋、bypass、不同標的等場景

## Test plan
- [x] 5/5 新測試通過
- [x] 806/806 既有測試通過
- [ ] 觀察 5 個交易日確認無同日買賣

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)