### PR TITLE
feat(metrics): performance feedback loop — daily summary + staleness check

### DIFF
--- a/frontend/backend/app/api/system.py
+++ b/frontend/backend/app/api/system.py
@@ -345,6 +345,38 @@ def system_events():
     }
 
 
+@router.get("/performance-summary")
+def performance_summary():
+    """Daily performance summary (#387). Returns key metrics for monitoring."""
+    from datetime import timezone
+    tz_twn = timezone(timedelta(hours=8))
+    trade_date = datetime.now(tz_twn).strftime("%Y-%m-%d")
+
+    conn = db.get_conn()
+    try:
+        from openclaw.performance_summary import (
+            build_daily_summary,
+            check_nav_staleness,
+            format_summary_text,
+        )
+        from dataclasses import asdict
+
+        summary = build_daily_summary(conn, trade_date)
+        staleness = check_nav_staleness(conn)
+
+        return {
+            "status": "ok",
+            "summary": asdict(summary),
+            "formatted": format_summary_text(summary),
+            "nav_staleness_warning": staleness,
+        }
+    except Exception as e:
+        return JSONResponse(
+            status_code=500,
+            content={"status": "error", "detail": str(e)},
+        )
+
+
 # ─── /api/inventory ────────────────────────────────────────────────────────────
 
 @inventory_router.get("")

--- a/src/openclaw/performance_summary.py
+++ b/src/openclaw/performance_summary.py
@@ -1,0 +1,205 @@
+"""performance_summary.py — 績效閉環模組 (#387)
+
+整合 daily_snapshot、pnl_engine、signal_aggregator 的績效數據，
+輸出一份 summary dict 供 EOD Telegram 通知和 API 使用。
+
+呼叫方式：
+  from openclaw.performance_summary import build_daily_summary, check_nav_staleness
+  summary = build_daily_summary(conn, trade_date="2026-03-19")
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+_NAV_STALE_DAYS = 5  # daily_nav 連續 N 天無記錄 → 觸發 incident
+
+
+@dataclass(frozen=True)
+class DailyPerformanceSummary:
+    """每日績效摘要。"""
+    trade_date: str
+    nav: float
+    nav_change_pct: float          # vs 前一日
+    realized_pnl_today: float
+    realized_pnl_cumulative: float
+    unrealized_pnl: float
+    win_rate_28d: Optional[float]  # 28 日滾動勝率
+    profit_factor_28d: Optional[float]
+    total_trades_28d: int
+    signal_attribution: dict       # {source: {count, win_rate}} from decisions
+
+
+def _get_28d_stats(conn: sqlite3.Connection) -> tuple[Optional[float], Optional[float], int]:
+    """28 日滾動勝率、Profit Factor、交易數。"""
+    try:
+        rows = conn.execute(
+            """SELECT realized_pnl FROM daily_pnl_summary
+               WHERE trade_date >= date('now', '-28 days', '+8 hours')
+               ORDER BY trade_date"""
+        ).fetchall()
+        if not rows:
+            return None, None, 0
+
+        wins = sum(1 for r in rows if (r[0] or 0) > 0)
+        total = len(rows)
+        win_rate = wins / total if total > 0 else None
+
+        gross_profit = sum(r[0] for r in rows if (r[0] or 0) > 0)
+        gross_loss = abs(sum(r[0] for r in rows if (r[0] or 0) < 0))
+        profit_factor = gross_profit / gross_loss if gross_loss > 0 else None
+
+        return win_rate, profit_factor, total
+    except sqlite3.Error as e:
+        log.warning("28d stats query failed: %s", e)
+        return None, None, 0
+
+
+def _get_signal_attribution(conn: sqlite3.Connection, days: int = 28) -> dict:
+    """信號來源績效歸因（近 N 日）。"""
+    try:
+        rows = conn.execute(
+            """SELECT signal_source, COUNT(*) as cnt,
+                      AVG(CASE WHEN signal_score > 0.5 THEN 1.0 ELSE 0.0 END) as avg_win
+               FROM decisions
+               WHERE created_at > ?
+               GROUP BY signal_source""",
+            (int(time.time() * 1000) - days * 86400 * 1000,),
+        ).fetchall()
+        return {r[0]: {"count": r[1], "win_rate": round(r[2], 3) if r[2] else None} for r in rows}
+    except sqlite3.Error as e:
+        log.debug("signal attribution query failed: %s", e)
+        return {}
+
+
+def _get_today_realized_pnl(conn: sqlite3.Connection, trade_date: str) -> float:
+    """查詢指定日期的已實現損益。"""
+    try:
+        row = conn.execute(
+            "SELECT realized_pnl FROM daily_pnl_summary WHERE trade_date=?",
+            (trade_date,),
+        ).fetchone()
+        return float(row[0]) if row and row[0] else 0.0
+    except sqlite3.Error:
+        return 0.0
+
+
+def build_daily_summary(
+    conn: sqlite3.Connection,
+    trade_date: str,
+) -> DailyPerformanceSummary:
+    """建構每日績效摘要。
+
+    Args:
+        conn: SQLite 連線（readonly OK）
+        trade_date: "YYYY-MM-DD"
+
+    Returns:
+        DailyPerformanceSummary dataclass
+    """
+    # NAV data from daily_nav
+    nav = 0.0
+    nav_prev = 0.0
+    unrealized = 0.0
+    realized_cum = 0.0
+    try:
+        row = conn.execute(
+            "SELECT nav, unrealized_pnl, realized_pnl_cumulative FROM daily_nav WHERE trade_date=?",
+            (trade_date,),
+        ).fetchone()
+        if row:
+            nav = float(row[0] or 0)
+            unrealized = float(row[1] or 0)
+            realized_cum = float(row[2] or 0)
+
+        prev_row = conn.execute(
+            "SELECT nav FROM daily_nav WHERE trade_date < ? ORDER BY trade_date DESC LIMIT 1",
+            (trade_date,),
+        ).fetchone()
+        if prev_row:
+            nav_prev = float(prev_row[0] or 0)
+    except sqlite3.Error as e:
+        log.warning("NAV query failed: %s", e)
+
+    nav_change_pct = ((nav - nav_prev) / nav_prev * 100) if nav_prev > 0 else 0.0
+
+    # 28-day rolling stats
+    win_rate, profit_factor, total_trades = _get_28d_stats(conn)
+
+    # Signal attribution
+    attribution = _get_signal_attribution(conn)
+
+    # Today's realized PnL
+    realized_today = _get_today_realized_pnl(conn, trade_date)
+
+    return DailyPerformanceSummary(
+        trade_date=trade_date,
+        nav=round(nav, 2),
+        nav_change_pct=round(nav_change_pct, 2),
+        realized_pnl_today=round(realized_today, 2),
+        realized_pnl_cumulative=round(realized_cum, 2),
+        unrealized_pnl=round(unrealized, 2),
+        win_rate_28d=round(win_rate, 3) if win_rate is not None else None,
+        profit_factor_28d=round(profit_factor, 3) if profit_factor is not None else None,
+        total_trades_28d=total_trades,
+        signal_attribution=attribution,
+    )
+
+
+def format_summary_text(summary: DailyPerformanceSummary) -> str:
+    """Format summary for Telegram notification."""
+    lines = [
+        f"📊 績效摘要 {summary.trade_date}",
+        f"NAV: {summary.nav:,.0f} ({summary.nav_change_pct:+.2f}%)",
+        f"今日已實現: {summary.realized_pnl_today:+,.0f}",
+        f"累計已實現: {summary.realized_pnl_cumulative:+,.0f}",
+        f"浮動損益: {summary.unrealized_pnl:+,.0f}",
+    ]
+    if summary.win_rate_28d is not None:
+        lines.append(f"28日勝率: {summary.win_rate_28d:.1%}")
+    if summary.profit_factor_28d is not None:
+        lines.append(f"28日損益比: {summary.profit_factor_28d:.2f}")
+    lines.append(f"28日交易數: {summary.total_trades_28d}")
+
+    if summary.signal_attribution:
+        lines.append("── 信號歸因 ──")
+        for src, data in summary.signal_attribution.items():
+            wr = f"{data['win_rate']:.1%}" if data.get("win_rate") is not None else "N/A"
+            lines.append(f"  {src}: {data['count']}次, 勝率{wr}")
+
+    return "\n".join(lines)
+
+
+def check_nav_staleness(conn: sqlite3.Connection) -> Optional[str]:
+    """Check if daily_nav has been stale for > N days.
+
+    Returns:
+        Incident message string if stale, None if OK.
+    """
+    try:
+        row = conn.execute(
+            "SELECT MAX(trade_date) FROM daily_nav"
+        ).fetchone()
+        if not row or not row[0]:
+            return "daily_nav table is empty — no NAV snapshots recorded"
+
+        from datetime import datetime, timedelta, timezone
+        tz_twn = timezone(timedelta(hours=8))
+        last_date = datetime.strptime(row[0], "%Y-%m-%d").replace(tzinfo=tz_twn)
+        now = datetime.now(tz_twn)
+        gap_days = (now - last_date).days
+
+        if gap_days > _NAV_STALE_DAYS:
+            return (
+                f"daily_nav stale: last snapshot {row[0]} ({gap_days} days ago), "
+                f"threshold={_NAV_STALE_DAYS} days"
+            )
+    except (sqlite3.Error, ValueError) as e:
+        return f"daily_nav staleness check failed: {e}"
+
+    return None

--- a/tests/test_performance_summary.py
+++ b/tests/test_performance_summary.py
@@ -1,0 +1,164 @@
+"""Tests for performance_summary module (#387).
+
+Covers:
+- build_daily_summary returns valid DailyPerformanceSummary
+- format_summary_text produces readable output
+- check_nav_staleness detects stale data
+- Handles missing tables gracefully
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from openclaw.performance_summary import (
+    DailyPerformanceSummary,
+    build_daily_summary,
+    check_nav_staleness,
+    format_summary_text,
+)
+
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE daily_nav (
+            trade_date TEXT PRIMARY KEY,
+            nav REAL, cash REAL, unrealized_pnl REAL,
+            realized_pnl_cumulative REAL, recorded_at INTEGER
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE daily_pnl_summary (
+            trade_date TEXT PRIMARY KEY,
+            realized_pnl REAL,
+            rolling_win_rate REAL,
+            consecutive_losses INTEGER
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE decisions (
+            decision_id TEXT PRIMARY KEY,
+            symbol TEXT, signal TEXT, signal_score REAL,
+            signal_source TEXT, created_at INTEGER
+        )
+    """)
+    return conn
+
+
+def _populate_nav(conn: sqlite3.Connection, days: int = 10) -> None:
+    tz = timezone(timedelta(hours=8))
+    now = datetime.now(tz)
+    for i in range(days):
+        d = (now - timedelta(days=days - i - 1)).strftime("%Y-%m-%d")
+        nav = 1_000_000 + i * 5000
+        conn.execute(
+            "INSERT INTO daily_nav VALUES (?,?,?,?,?,?)",
+            (d, nav, 500000, i * 1000, i * 2000, int(time.time() * 1000)),
+        )
+    conn.commit()
+
+
+class TestBuildDailySummary:
+    def test_returns_summary_with_nav_data(self):
+        conn = _make_db()
+        _populate_nav(conn, 5)
+        tz = timezone(timedelta(hours=8))
+        today = datetime.now(tz).strftime("%Y-%m-%d")
+        summary = build_daily_summary(conn, today)
+        assert isinstance(summary, DailyPerformanceSummary)
+        assert summary.trade_date == today
+        assert summary.nav > 0
+
+    def test_returns_zero_nav_when_no_data(self):
+        conn = _make_db()
+        summary = build_daily_summary(conn, "2099-01-01")
+        assert summary.nav == 0.0
+        assert summary.nav_change_pct == 0.0
+
+    def test_calculates_nav_change_pct(self):
+        conn = _make_db()
+        conn.execute("INSERT INTO daily_nav VALUES ('2026-03-18', 1000000, 500000, 0, 0, 1)")
+        conn.execute("INSERT INTO daily_nav VALUES ('2026-03-19', 1050000, 500000, 50000, 0, 1)")
+        conn.commit()
+        summary = build_daily_summary(conn, "2026-03-19")
+        assert summary.nav_change_pct == 5.0  # +5%
+
+    def test_28d_stats_with_pnl_data(self):
+        conn = _make_db()
+        tz = timezone(timedelta(hours=8))
+        now = datetime.now(tz)
+        for i in range(10):
+            d = (now - timedelta(days=10 - i)).strftime("%Y-%m-%d")
+            pnl = 1000 if i % 3 != 0 else -500  # ~67% win rate
+            conn.execute("INSERT INTO daily_pnl_summary VALUES (?,?,?,?)", (d, pnl, 0.6, 0))
+        conn.commit()
+        summary = build_daily_summary(conn, now.strftime("%Y-%m-%d"))
+        assert summary.win_rate_28d is not None
+        assert summary.total_trades_28d == 10
+
+
+class TestFormatSummaryText:
+    def test_produces_readable_text(self):
+        summary = DailyPerformanceSummary(
+            trade_date="2026-03-19",
+            nav=1_050_000,
+            nav_change_pct=2.5,
+            realized_pnl_today=5000,
+            realized_pnl_cumulative=25000,
+            unrealized_pnl=-3000,
+            win_rate_28d=0.55,
+            profit_factor_28d=1.3,
+            total_trades_28d=20,
+            signal_attribution={"technical": {"count": 15, "win_rate": 0.6}},
+        )
+        text = format_summary_text(summary)
+        assert "2026-03-19" in text
+        assert "1,050,000" in text
+        assert "+2.50%" in text
+        assert "55.0%" in text
+        assert "technical" in text
+
+    def test_handles_none_values(self):
+        summary = DailyPerformanceSummary(
+            trade_date="2026-03-19",
+            nav=0,
+            nav_change_pct=0,
+            realized_pnl_today=0,
+            realized_pnl_cumulative=0,
+            unrealized_pnl=0,
+            win_rate_28d=None,
+            profit_factor_28d=None,
+            total_trades_28d=0,
+            signal_attribution={},
+        )
+        text = format_summary_text(summary)
+        assert "2026-03-19" in text
+        assert "28日勝率" not in text  # Should be skipped when None
+
+
+class TestCheckNavStaleness:
+    def test_returns_none_when_recent(self):
+        conn = _make_db()
+        _populate_nav(conn, 3)
+        result = check_nav_staleness(conn)
+        assert result is None  # Recent data → OK
+
+    def test_returns_warning_when_stale(self):
+        conn = _make_db()
+        # Insert data from 10 days ago
+        old_date = (datetime.now(timezone(timedelta(hours=8))) - timedelta(days=10)).strftime("%Y-%m-%d")
+        conn.execute("INSERT INTO daily_nav VALUES (?,?,?,?,?,?)", (old_date, 1000000, 500000, 0, 0, 1))
+        conn.commit()
+        result = check_nav_staleness(conn)
+        assert result is not None
+        assert "stale" in result
+
+    def test_returns_warning_when_empty(self):
+        conn = _make_db()
+        result = check_nav_staleness(conn)
+        assert result is not None
+        assert "empty" in result


### PR DESCRIPTION
## Summary
- 新增 `performance_summary.py` 整合 NAV、PnL、28 日勝率、損益比、信號歸因
- `format_summary_text()` 產出 Telegram 可讀格式
- `check_nav_staleness()` 偵測 daily_nav >5 天無更新
- 新增 `GET /api/system/performance-summary` API endpoint
- 9 個 pytest case 覆蓋摘要建構、格式化、過期偵測

## Test plan
- [x] 9/9 新測試通過
- [x] 810/810 既有測試通過
- [ ] 確認 EOD 後 /api/system/performance-summary 回傳正確數據

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)