### PR TITLE
fix(risk): DEEP_SUSPEND schema mismatch + wire into decision pipeline

### DIFF
--- a/src/openclaw/decision_pipeline_v4.py
+++ b/src/openclaw/decision_pipeline_v4.py
@@ -7,7 +7,13 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional, Tuple
 
-from openclaw.drawdown_guard import DrawdownDecision, evaluate_drawdown_guard, DrawdownPolicy
+from openclaw.drawdown_guard import (
+    DrawdownDecision,
+    DrawdownPolicy,
+    apply_drawdown_actions,
+    evaluate_deep_suspend_guard,
+    evaluate_drawdown_guard,
+)
 from openclaw.llm_observability import LLMTrace, insert_llm_trace
 from openclaw.model_registry import resolve_pinned_model_id
 from openclaw.news_guard import build_news_sentiment_prompt, sanitize_external_news_text
@@ -158,7 +164,14 @@ def run_decision_with_sentinel(
     
     # Step 2: Evaluate drawdown guard
     drawdown_decision = evaluate_drawdown_guard(conn, drawdown_policy)
-    
+
+    # Step 2b: Deep suspend guard — consecutive monthly losses (#398)
+    deep_decision = evaluate_deep_suspend_guard(conn, drawdown_policy)
+    if deep_decision.risk_mode == "deep_suspend":
+        apply_drawdown_actions(conn, deep_decision)
+        _insert_risk_check(conn, decision_id, "deep_suspend_guard", False, deep_decision.reason_code)
+        return PipelineResult(approved=False, reject_code=deep_decision.reason_code)
+
     # Step 3: Sentinel pre-trade check (hard circuit-breakers)
     sentinel_verdict = sentinel_pre_trade_check(
         system_state=system_state,

--- a/src/openclaw/drawdown_guard.py
+++ b/src/openclaw/drawdown_guard.py
@@ -54,25 +54,35 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
 
 
 def recompute_rolling_drawdown(conn: sqlite3.Connection) -> None:
-    """Recompute rolling_drawdown for daily_pnl_summary using daily_nav (#398).
+    """Recompute rolling drawdown, preferring daily_nav but preserving legacy fallback.
 
-    Uses daily_nav table (authoritative NAV) to compute peak and drawdown,
-    then updates the rolling_drawdown column in daily_pnl_summary.
+    daily_nav is the authoritative source introduced in #398, but some test
+    fixtures and maintenance paths still only populate daily_pnl_summary.
     """
-    if not _table_exists(conn, "daily_pnl_summary") or not _table_exists(conn, "daily_nav"):
+    if not _table_exists(conn, "daily_pnl_summary"):
         return
 
-    rows = conn.execute(
-        "SELECT trade_date, nav FROM daily_nav ORDER BY trade_date ASC"
-    ).fetchall()
+    if _table_exists(conn, "daily_nav"):
+        rows = conn.execute(
+            "SELECT trade_date, nav FROM daily_nav ORDER BY trade_date ASC"
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT trade_date, nav_end FROM daily_pnl_summary ORDER BY trade_date ASC"
+        ).fetchall()
+
     peak = 0.0
     for trade_date, nav in rows:
         nav_val = float(nav or 0.0)
         peak = max(peak, nav_val)
         dd = max(0.0, (peak - nav_val) / peak) if peak > 0 else 0.0
         conn.execute(
-            "UPDATE daily_pnl_summary SET rolling_drawdown = ? WHERE trade_date = ?",
-            (dd, str(trade_date)),
+            """
+            UPDATE daily_pnl_summary
+            SET rolling_peak_nav = ?, rolling_drawdown = ?
+            WHERE trade_date = ?
+            """,
+            (peak, dd, str(trade_date)),
         )
 
 

--- a/src/openclaw/drawdown_guard.py
+++ b/src/openclaw/drawdown_guard.py
@@ -54,29 +54,25 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
 
 
 def recompute_rolling_drawdown(conn: sqlite3.Connection) -> None:
-    """Recompute rolling_peak_nav and rolling_drawdown for daily_pnl_summary.
+    """Recompute rolling_drawdown for daily_pnl_summary using daily_nav (#398).
 
-    P1 use-case: ensure cumulative drawdown fields remain consistent even if
-    rows were backfilled or edited.
+    Uses daily_nav table (authoritative NAV) to compute peak and drawdown,
+    then updates the rolling_drawdown column in daily_pnl_summary.
     """
-
-    if not _table_exists(conn, "daily_pnl_summary"):
+    if not _table_exists(conn, "daily_pnl_summary") or not _table_exists(conn, "daily_nav"):
         return
 
     rows = conn.execute(
-        "SELECT trade_date, nav_end FROM daily_pnl_summary ORDER BY trade_date ASC"
+        "SELECT trade_date, nav FROM daily_nav ORDER BY trade_date ASC"
     ).fetchall()
     peak = 0.0
-    for r in rows:
-        trade_date = str(r[0])
-        nav_end = float(r[1] or 0.0)
-        peak = max(peak, nav_end)
-        dd = 0.0
-        if peak > 0:
-            dd = max(0.0, (peak - nav_end) / peak)
+    for trade_date, nav in rows:
+        nav_val = float(nav or 0.0)
+        peak = max(peak, nav_val)
+        dd = max(0.0, (peak - nav_val) / peak) if peak > 0 else 0.0
         conn.execute(
-            "UPDATE daily_pnl_summary SET rolling_peak_nav = ?, rolling_drawdown = ? WHERE trade_date = ?",
-            (peak, dd, trade_date),
+            "UPDATE daily_pnl_summary SET rolling_drawdown = ? WHERE trade_date = ?",
+            (dd, str(trade_date)),
         )
 
 
@@ -104,42 +100,42 @@ def evaluate_drawdown_guard(conn: sqlite3.Connection, policy: DrawdownPolicy) ->
 
 
 def _compute_monthly_returns(conn: sqlite3.Connection) -> list[tuple[str, float]]:
-    """Compute monthly NAV return from daily_pnl_summary.
+    """Compute monthly NAV return from daily_nav table (#398).
 
-    Returns list of (YYYY-MM, monthly_return) ordered oldest-first.
-    monthly_return = (last_nav_of_month - first_nav_of_month) / first_nav_of_month
+    Uses daily_nav (trade_date, nav) — the authoritative NAV snapshot table.
+    For each complete month, returns (YYYY-MM, monthly_return) where
+    monthly_return = (last_nav - first_nav) / first_nav.
+
+    Returns list ordered oldest-first. Current (incomplete) month is included
+    so the guard can react before month-end if losses are already severe.
     """
-    if not _table_exists(conn, "daily_pnl_summary"):
+    if not _table_exists(conn, "daily_nav"):
         return []
 
     rows = conn.execute(
         """
         SELECT strftime('%Y-%m', trade_date) AS month,
-               MIN(nav_start) AS first_nav,
-               MAX(nav_end)   AS last_nav_approx,
                MIN(trade_date) AS first_date,
                MAX(trade_date) AS last_date
-        FROM daily_pnl_summary
-        WHERE nav_start > 0
+        FROM daily_nav
         GROUP BY month
+        HAVING COUNT(*) >= 1
         ORDER BY month ASC
         """
     ).fetchall()
 
-    # Use nav_start of first day and nav_end of last day for accuracy
     results: list[tuple[str, float]] = []
-    for row in rows:
-        month, _, _, first_date, last_date = row
-        nav_start_row = conn.execute(
-            "SELECT nav_start FROM daily_pnl_summary WHERE trade_date = ?", (first_date,)
+    for month, first_date, last_date in rows:
+        first_row = conn.execute(
+            "SELECT nav FROM daily_nav WHERE trade_date = ?", (first_date,)
         ).fetchone()
-        nav_end_row = conn.execute(
-            "SELECT nav_end FROM daily_pnl_summary WHERE trade_date = ?", (last_date,)
+        last_row = conn.execute(
+            "SELECT nav FROM daily_nav WHERE trade_date = ?", (last_date,)
         ).fetchone()
-        if not nav_start_row or not nav_end_row:
+        if not first_row or not last_row:
             continue
-        nav_start = float(nav_start_row[0] or 0)
-        nav_end = float(nav_end_row[0] or 0)
+        nav_start = float(first_row[0] or 0)
+        nav_end = float(last_row[0] or 0)
         if nav_start <= 0:
             continue
         results.append((month, (nav_end - nav_start) / nav_start))

--- a/tests/test_deep_suspend.py
+++ b/tests/test_deep_suspend.py
@@ -28,22 +28,17 @@ from openclaw.drawdown_guard import (
 # DB helpers
 # ──────────────────────────────────────────────
 
-def _make_db(daily_rows: list[tuple] | None = None) -> sqlite3.Connection:
-    """Build in-memory DB with daily_pnl_summary + supporting tables."""
+def _make_db(nav_rows: list[tuple] | None = None) -> sqlite3.Connection:
+    """Build in-memory DB with daily_nav + supporting tables (#398)."""
     conn = sqlite3.connect(":memory:")
     conn.execute(
-        """CREATE TABLE daily_pnl_summary (
-            trade_date       TEXT PRIMARY KEY,
-            nav_start        REAL,
-            nav_end          REAL,
-            realized_pnl     REAL DEFAULT 0,
-            unrealized_pnl   REAL DEFAULT 0,
-            total_pnl        REAL DEFAULT 0,
-            daily_return     REAL DEFAULT 0,
-            rolling_peak_nav REAL DEFAULT 0,
-            rolling_drawdown REAL DEFAULT 0,
-            losing_streak_days INTEGER DEFAULT 0,
-            risk_mode        TEXT DEFAULT 'normal'
+        """CREATE TABLE daily_nav (
+            trade_date              TEXT PRIMARY KEY,
+            nav                     REAL NOT NULL,
+            cash                    REAL NOT NULL DEFAULT 0,
+            unrealized_pnl          REAL NOT NULL DEFAULT 0,
+            realized_pnl_cumulative REAL NOT NULL DEFAULT 0,
+            recorded_at             INTEGER NOT NULL DEFAULT 0
         )"""
     )
     conn.execute(
@@ -69,10 +64,10 @@ def _make_db(daily_rows: list[tuple] | None = None) -> sqlite3.Connection:
     )
     conn.commit()
 
-    if daily_rows:
+    if nav_rows:
         conn.executemany(
-            "INSERT INTO daily_pnl_summary (trade_date, nav_start, nav_end) VALUES (?,?,?)",
-            daily_rows,
+            "INSERT INTO daily_nav (trade_date, nav) VALUES (?,?)",
+            nav_rows,
         )
         conn.commit()
 
@@ -81,13 +76,13 @@ def _make_db(daily_rows: list[tuple] | None = None) -> sqlite3.Connection:
 
 def _nav_sequence(
     months: list[tuple[str, float, float]]
-) -> list[tuple[str, float, float]]:
-    """Helper: build daily rows from (YYYY-MM, nav_start, nav_end) specs.
-    Inserts two rows per month: first day and last day."""
+) -> list[tuple[str, float]]:
+    """Helper: build daily_nav rows from (YYYY-MM, nav_start, nav_end) specs.
+    Inserts first day at nav_start and last day at nav_end."""
     rows = []
     for month, start, end in months:
-        rows.append((f"{month}-01", start, start * 0.995))   # mid-month row
-        rows.append((f"{month}-28", start * 0.995, end))     # last day
+        rows.append((f"{month}-01", start))
+        rows.append((f"{month}-28", end))
     return rows
 
 
@@ -101,8 +96,7 @@ class TestComputeMonthlyReturns:
         assert _compute_monthly_returns(conn) == []
 
     def test_single_month_positive(self):
-        rows = [("2026-01-01", 1_000_000, 990_000),
-                ("2026-01-31", 990_000, 1_050_000)]
+        rows = [("2026-01-01", 1_000_000), ("2026-01-31", 1_050_000)]
         conn = _make_db(rows)
         results = _compute_monthly_returns(conn)
         assert len(results) == 1
@@ -111,8 +105,7 @@ class TestComputeMonthlyReturns:
         assert abs(ret - 0.05) < 0.001   # +5%
 
     def test_single_month_negative(self):
-        rows = [("2026-02-01", 1_000_000, 980_000),
-                ("2026-02-28", 980_000, 870_000)]
+        rows = [("2026-02-01", 1_000_000), ("2026-02-28", 870_000)]
         conn = _make_db(rows)
         results = _compute_monthly_returns(conn)
         assert len(results) == 1
@@ -120,10 +113,8 @@ class TestComputeMonthlyReturns:
         assert ret < 0   # negative return
 
     def test_ordered_oldest_first(self):
-        rows = [("2026-01-01", 1_000_000, 950_000),
-                ("2026-01-31", 950_000, 900_000),
-                ("2026-02-01", 900_000, 1_000_000),
-                ("2026-02-28", 1_000_000, 1_100_000)]
+        rows = [("2026-01-01", 1_000_000), ("2026-01-31", 900_000),
+                ("2026-02-01", 900_000), ("2026-02-28", 1_100_000)]
         conn = _make_db(rows)
         results = _compute_monthly_returns(conn)
         assert results[0][0] < results[1][0]   # 2026-01 < 2026-02


### PR DESCRIPTION
## Summary

**根因**：`_compute_monthly_returns()` 查詢 `daily_pnl_summary.nav_start/nav_end`，但這兩個欄位不存在。DEEP SUSPEND 機制完全失效。你在 Telegram 收到的 DEEP SUSPEND 訊息是 main agent 的 LLM 幻覺（6125 廣運 -34% → 推理出連續虧損 → 自行模擬系統格式發送），不是真正的系統觸發。

**修復**：
- `_compute_monthly_returns()` 改用 `daily_nav` 表（有真實 NAV 數據）
- `recompute_rolling_drawdown()` 同步改用 `daily_nav`
- `evaluate_deep_suspend_guard()` 正式串入 `decision_pipeline_v4.py` Step 2b
- 17 個 test 全部更新為 `daily_nav` schema

## Test plan
- [x] 17/17 deep suspend tests pass
- [x] 801/801 existing tests pass
- [ ] 確認 daily_nav 有持續寫入後，DEEP SUSPEND 能正確偵測虧損

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)