### PR TITLE
feat(backtest): add deterministic CI validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,33 @@ jobs:
         working-directory: frontend/backend
         run: pytest -q tests/
 
+  backtest-validation:
+    name: 📈 Backtest Validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: guardrails
+
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: frontend/backend/requirements.txt
+
+      - name: 📦 Install backend deps
+        run: pip install -r frontend/backend/requirements.txt
+
+      - name: 🧪 Run CI backtest validation
+        run: PYTHONPATH=src python tools/run_backtest_ci.py --report-file backtest_ci_report.json
+
+      - name: 📄 Print backtest report
+        if: always()
+        run: cat backtest_ci_report.json
+
   # ── Job 3：Frontend 測試 + Build（與 backend 並行）────────────────
   frontend:
     name: 🟢 Frontend Build & Test

--- a/config/backtest_baseline.json
+++ b/config/backtest_baseline.json
@@ -1,0 +1,37 @@
+{
+  "dataset": {
+    "days": 60,
+    "start_date": "2025-01-02",
+    "symbols": ["2330", "2317", "2454"]
+  },
+  "signal_params": {
+    "ma_short": 3,
+    "ma_long": 7,
+    "rsi_entry_max": 100.0,
+    "take_profit_pct": 0.04,
+    "stop_loss_pct": 0.04,
+    "trailing_pct": 0.08,
+    "trailing_pct_tight": 0.05,
+    "trailing_profit_threshold": 0.04
+  },
+  "thresholds": {
+    "min_win_rate_pct": 40.0,
+    "max_drawdown_pct": 15.0,
+    "min_total_trades": 5
+  },
+  "allowed_regression": {
+    "total_return_pct": -5.0,
+    "sharpe_ratio": -2.0,
+    "total_trades": -3
+  },
+  "metrics": {
+    "total_return_pct": 10.2736,
+    "annualized_return_pct": 50.7928,
+    "sharpe_ratio": 9.4361,
+    "max_drawdown_pct": 0.057,
+    "win_rate_pct": 100.0,
+    "profit_factor": 0.0,
+    "avg_holding_days": 2.0,
+    "total_trades": 9
+  }
+}

--- a/tests/test_run_backtest_ci.py
+++ b/tests/test_run_backtest_ci.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import run_backtest_ci as rbc
+
+
+def _baseline() -> dict:
+    return {
+        "dataset": {
+            "days": 60,
+            "start_date": "2025-01-02",
+            "symbols": ["2330", "2317", "2454"],
+        },
+        "signal_params": {
+            "ma_short": 3,
+            "ma_long": 7,
+            "rsi_entry_max": 100.0,
+            "take_profit_pct": 0.04,
+            "stop_loss_pct": 0.04,
+            "trailing_pct": 0.08,
+            "trailing_pct_tight": 0.05,
+            "trailing_profit_threshold": 0.04,
+        },
+        "thresholds": {
+            "min_win_rate_pct": 40.0,
+            "max_drawdown_pct": 15.0,
+            "min_total_trades": 5,
+        },
+        "allowed_regression": {
+            "total_return_pct": -5.0,
+            "sharpe_ratio": -2.0,
+            "total_trades": -3,
+        },
+        "metrics": {
+            "total_return_pct": 10.2736,
+            "annualized_return_pct": 50.7928,
+            "sharpe_ratio": 9.4361,
+            "max_drawdown_pct": 0.057,
+            "win_rate_pct": 100.0,
+            "profit_factor": 0.0,
+            "avg_holding_days": 2.0,
+            "total_trades": 9,
+        },
+    }
+
+
+def test_create_synthetic_backtest_db(tmp_path):
+    db_path = tmp_path / "fixture.db"
+    rbc.create_synthetic_backtest_db(db_path, days=10, start_date="2025-01-02")
+
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM eod_prices").fetchone()[0]
+    conn.close()
+    assert count == 30
+
+
+def test_run_ci_backtest_produces_trades():
+    metrics = rbc.run_ci_backtest(_baseline())
+    assert metrics["total_trades"] >= 5
+    assert metrics["win_rate_pct"] >= 40.0
+
+
+def test_compare_to_baseline_passes_for_current_config():
+    baseline = _baseline()
+    current = rbc.run_ci_backtest(baseline)
+    failures, diff = rbc.compare_to_baseline(current, baseline)
+    assert failures == []
+    assert "total_return_pct" in diff
+
+
+def test_compare_to_baseline_flags_regression():
+    baseline = _baseline()
+    current = dict(baseline["metrics"])
+    current["total_return_pct"] = 1.0
+    current["sharpe_ratio"] = 1.0
+    current["win_rate_pct"] = 20.0
+    current["max_drawdown_pct"] = 20.0
+    current["total_trades"] = 1
+
+    failures, _ = rbc.compare_to_baseline(current, baseline)
+    assert any("win_rate_pct" in failure for failure in failures)
+    assert any("max_drawdown_pct" in failure for failure in failures)
+    assert any("total_trades" in failure for failure in failures)
+
+
+def test_main_writes_report_file(tmp_path):
+    baseline_path = tmp_path / "baseline.json"
+    report_path = tmp_path / "report.json"
+    baseline_path.write_text(json.dumps(_baseline()))
+
+    rc = rbc.main(["--baseline", str(baseline_path), "--report-file", str(report_path)])
+
+    assert rc == 0
+    report = json.loads(report_path.read_text())
+    assert report["status"] == "passed"
+    assert report["current_metrics"]["total_trades"] >= 5

--- a/tools/run_backtest_ci.py
+++ b/tools/run_backtest_ci.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Deterministic CI backtest validation for signal changes."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sqlite3
+import sys
+import tempfile
+from dataclasses import asdict
+from datetime import date, timedelta
+from pathlib import Path
+
+from openclaw.backtest_engine import BacktestConfig, run_backtest
+from openclaw.cost_model import CostParams
+from openclaw.signal_logic import SignalParams
+
+_PROJECT = Path(__file__).resolve().parents[1]
+_DEFAULT_BASELINE = _PROJECT / "config" / "backtest_baseline.json"
+
+
+def load_baseline(path: str | Path = _DEFAULT_BASELINE) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def _business_days(start: date, days: int) -> list[date]:
+    out: list[date] = []
+    cursor = start
+    while len(out) < days:
+        if cursor.weekday() < 5:
+            out.append(cursor)
+        cursor += timedelta(days=1)
+    return out
+
+
+def _synthetic_rows(
+    symbol: str,
+    base: float,
+    amplitude: float,
+    trend: float,
+    phase: float,
+    start: date,
+    days: int,
+) -> list[tuple]:
+    rows = []
+    for idx, trading_day in enumerate(_business_days(start, days)):
+        close = round(base + amplitude * math.sin((idx / 3.0) + phase) + trend * idx, 2)
+        rows.append(
+            (
+                trading_day.isoformat(),
+                symbol,
+                round(close * 0.99, 2),
+                round(close * 1.01, 2),
+                round(close * 0.98, 2),
+                close,
+                10000 + idx * 50,
+            )
+        )
+    return rows
+
+
+def create_synthetic_backtest_db(path: str | Path, days: int, start_date: str) -> str:
+    db_path = str(path)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE eod_prices (
+            trade_date TEXT,
+            symbol TEXT,
+            open REAL,
+            high REAL,
+            low REAL,
+            close REAL,
+            volume INTEGER
+        )
+        """
+    )
+    start = date.fromisoformat(start_date)
+    rows = []
+    rows += _synthetic_rows("2330", 100.0, 8.0, 0.05, 0.0, start, days)
+    rows += _synthetic_rows("2317", 82.0, 6.0, 0.04, 0.7, start, days)
+    rows += _synthetic_rows("2454", 120.0, 10.0, 0.06, 1.4, start, days)
+    conn.executemany("INSERT INTO eod_prices VALUES (?,?,?,?,?,?,?)", rows)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def metrics_to_dict(result) -> dict:
+    data = asdict(result.metrics)
+    data["win_rate_pct"] = round(float(data.pop("win_rate", 0.0)) * 100, 4)
+    for key, value in list(data.items()):
+        if isinstance(value, float):
+            data[key] = round(value, 4)
+    return data
+
+
+def run_ci_backtest(baseline: dict) -> dict:
+    dataset = baseline["dataset"]
+    params = SignalParams(**baseline["signal_params"])
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+
+    create_synthetic_backtest_db(
+        db_path,
+        days=int(dataset["days"]),
+        start_date=dataset["start_date"],
+    )
+
+    config = BacktestConfig(
+        symbols=list(dataset["symbols"]),
+        start_date=dataset["start_date"],
+        end_date=_business_days(date.fromisoformat(dataset["start_date"]), int(dataset["days"]))[-1].isoformat(),
+        initial_capital=1_000_000.0,
+        signal_params=params,
+        max_positions=3,
+        max_single_pct=0.30,
+        cost_params=CostParams(),
+        slippage_bps=10,
+    )
+    result = run_backtest(config, db_path)
+    return metrics_to_dict(result)
+
+
+def compare_to_baseline(current: dict, baseline: dict) -> tuple[list[str], dict]:
+    failures: list[str] = []
+    diff: dict[str, float] = {}
+
+    baseline_metrics = baseline["metrics"]
+    thresholds = baseline["thresholds"]
+    allowed_regression = baseline.get("allowed_regression", {})
+
+    for key, baseline_value in baseline_metrics.items():
+        current_value = current.get(key)
+        if isinstance(baseline_value, (int, float)) and isinstance(current_value, (int, float)):
+            diff[key] = round(current_value - baseline_value, 4)
+
+    if current["win_rate_pct"] < thresholds["min_win_rate_pct"]:
+        failures.append(
+            f"win_rate_pct {current['win_rate_pct']:.2f} < {thresholds['min_win_rate_pct']:.2f}"
+        )
+    if current["max_drawdown_pct"] > thresholds["max_drawdown_pct"]:
+        failures.append(
+            f"max_drawdown_pct {current['max_drawdown_pct']:.2f} > {thresholds['max_drawdown_pct']:.2f}"
+        )
+    if current["total_trades"] < thresholds["min_total_trades"]:
+        failures.append(
+            f"total_trades {current['total_trades']} < {thresholds['min_total_trades']}"
+        )
+
+    for key, allowed_drop in allowed_regression.items():
+        if diff.get(key, 0.0) < allowed_drop:
+            failures.append(
+                f"{key} regression {diff[key]:.4f} < allowed {allowed_drop:.4f}"
+            )
+
+    return failures, diff
+
+
+def build_report(current: dict, baseline: dict, failures: list[str], diff: dict) -> dict:
+    return {
+        "status": "failed" if failures else "passed",
+        "baseline_path": str(_DEFAULT_BASELINE),
+        "dataset": baseline["dataset"],
+        "current_metrics": current,
+        "baseline_metrics": baseline["metrics"],
+        "diff_vs_baseline": diff,
+        "thresholds": baseline["thresholds"],
+        "failures": failures,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run deterministic CI backtest validation.")
+    parser.add_argument("--baseline", default=str(_DEFAULT_BASELINE))
+    parser.add_argument("--report-file", default="")
+    args = parser.parse_args(argv)
+
+    baseline = load_baseline(args.baseline)
+    current = run_ci_backtest(baseline)
+    failures, diff = compare_to_baseline(current, baseline)
+    report = build_report(current, baseline, failures, diff)
+    report_json = json.dumps(report, ensure_ascii=False, indent=2)
+    print(report_json)
+
+    if args.report_file:
+        Path(args.report_file).write_text(report_json + "\n")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add a deterministic synthetic backtest runner for CI
- add `config/backtest_baseline.json` with baseline metrics and gating thresholds
- add a dedicated CI backtest validation job and regression tests

## Related Issue

- Closes #389

## Testing

- [x] Tests run locally
- [ ] Not run (explain why)
- [x] Added or updated regression tests for the changed behavior

Commands:

```bash
PYTHONPATH=src python tools/run_backtest_ci.py
pytest -q tests/test_run_backtest_ci.py
pytest -q tests/test_check_approved_issues.py tests/test_run_backtest_ci.py
```

## Verification Evidence

- [x] Before/After data included
- [x] Verification time window included
- [x] Effect validation included

Before:

- CI had no backtest gate, so signal changes could merge without a reproducible performance check.
- No baseline file existed for comparing current strategy behavior against a known-good result.

After:

- CI runs a deterministic 60-day synthetic backtest and fails on threshold or regression breaches.
- `config/backtest_baseline.json` stores the reproducible baseline metrics and thresholds.

Verification window:

- Validated locally on 2026-03-23 using the new deterministic dataset and tool tests.

Regression coverage:

- `tests/test_run_backtest_ci.py`
- `tests/test_check_approved_issues.py tests/test_run_backtest_ci.py`

## Risk

- Medium-low: adds a new CI job, but uses a synthetic dataset to avoid dependency on live market data.

## Docs / Ops Impact

- [x] No doc changes needed
- [ ] `AGENTS.md` updated
- [ ] `progress.md` high-level status updated
- [ ] Runbook / operator notes updated

## Issue Linkback

- [ ] PR link added back to the related issue
