### PR TITLE
feat(system): add simulation graduation check endpoint

### DIFF
--- a/frontend/backend/app/api/system.py
+++ b/frontend/backend/app/api/system.py
@@ -377,6 +377,168 @@ def performance_summary():
         )
 
 
+def _metric_payload(value, threshold, passed: bool, detail: str | None = None) -> dict:
+    payload = {
+        "value": value,
+        "threshold": threshold,
+        "passed": bool(passed),
+    }
+    if detail:
+        payload["detail"] = detail
+    return payload
+
+
+@router.get("/graduation-check")
+def graduation_check():
+    """Simulation-to-live graduation checklist (#392)."""
+    now = datetime.now()
+    recent_ts_text = (now - timedelta(days=28)).isoformat()
+    recent_ms = int((now - timedelta(days=28)).timestamp() * 1000)
+
+    with READONLY_POOL.conn() as conn:
+        try:
+            incident_row = conn.execute(
+                """
+                SELECT COUNT(*)
+                  FROM incidents
+                 WHERE resolved = 0
+                   AND severity IN ('critical', 'warning')
+                   AND ts >= ?
+                """,
+                (recent_ts_text,),
+            ).fetchone()
+            incident_count = int(incident_row[0] or 0) if incident_row else 0
+        except sqlite3.Error:
+            incident_count = 999
+
+        try:
+            from openclaw.performance_summary import _get_28d_stats
+
+            win_rate, profit_factor, trade_days = _get_28d_stats(conn)
+            win_rate_pct = round((win_rate or 0.0) * 100, 2)
+            profit_factor_val = round(profit_factor or 0.0, 2)
+        except Exception:
+            win_rate_pct = 0.0
+            profit_factor_val = 0.0
+            trade_days = 0
+
+        try:
+            row = conn.execute(
+                """
+                SELECT MAX(COALESCE(rolling_drawdown, 0))
+                  FROM daily_pnl_summary
+                 WHERE trade_date >= date('now', '-28 days', '+8 hours')
+                """
+            ).fetchone()
+            max_drawdown_pct = round(float(row[0] or 0.0) * 100, 2) if row else 0.0
+        except sqlite3.Error:
+            max_drawdown_pct = 999.0
+
+        try:
+            rows = conn.execute(
+                """
+                SELECT quantity, avg_price, current_price
+                  FROM positions
+                 WHERE quantity > 0
+                """
+            ).fetchall()
+            exposures = [
+                float((row["current_price"] or row["avg_price"] or 0.0)) * float(row["quantity"] or 0.0)
+                for row in rows
+            ]
+            total_exposure = sum(exposures)
+            max_concentration_pct = round((max(exposures) / total_exposure) * 100, 2) if total_exposure > 0 else 0.0
+        except sqlite3.Error:
+            max_concentration_pct = 999.0
+
+        try:
+            row = conn.execute(
+                """
+                SELECT COUNT(*)
+                  FROM order_events
+                 WHERE ts >= ?
+                   AND COALESCE(reason_code, '') LIKE 'RISK_WASH_SALE%'
+                """,
+                (recent_ts_text,),
+            ).fetchone()
+            wash_sale_violations = int(row[0] or 0) if row else 0
+        except sqlite3.Error:
+            wash_sale_violations = 999
+
+        try:
+            proposals_row = conn.execute(
+                """
+                SELECT COUNT(*)
+                  FROM strategy_proposals
+                 WHERE created_at >= ?
+                """,
+                (recent_ms,),
+            ).fetchone()
+            executed_row = conn.execute(
+                """
+                SELECT COUNT(DISTINCT proposal_id)
+                  FROM proposal_execution_journal
+                 WHERE created_at >= ?
+                """,
+                (recent_ms,),
+            ).fetchone()
+            proposal_count = int(proposals_row[0] or 0) if proposals_row else 0
+            executed_count = int(executed_row[0] or 0) if executed_row else 0
+            proposal_alignment_pct = round((executed_count / proposal_count) * 100, 2) if proposal_count > 0 else 0.0
+        except sqlite3.Error:
+            proposal_count = 0
+            executed_count = 0
+            proposal_alignment_pct = 0.0
+
+    metrics = {
+        "incident_free_20d": _metric_payload(
+            incident_count,
+            "0 unresolved warning/critical incidents in recent window",
+            incident_count == 0,
+            "Uses recent unresolved incidents as a fail-safe proxy for P0/P1 incident-free days.",
+        ),
+        "win_rate_28d_pct": _metric_payload(
+            win_rate_pct,
+            ">= 45%",
+            win_rate_pct >= 45.0 and trade_days > 0,
+        ),
+        "max_drawdown_pct": _metric_payload(
+            max_drawdown_pct,
+            "<= 10%",
+            max_drawdown_pct <= 10.0,
+        ),
+        "profit_factor_28d": _metric_payload(
+            profit_factor_val,
+            ">= 1.2",
+            profit_factor_val >= 1.2,
+        ),
+        "max_concentration_pct": _metric_payload(
+            max_concentration_pct,
+            "<= 40%",
+            max_concentration_pct <= 40.0,
+        ),
+        "wash_sale_violations_28d": _metric_payload(
+            wash_sale_violations,
+            "== 0",
+            wash_sale_violations == 0,
+        ),
+        "proposal_execution_alignment_pct": _metric_payload(
+            proposal_alignment_pct,
+            ">= 80%",
+            proposal_alignment_pct >= 80.0 and proposal_count > 0,
+            f"{executed_count}/{proposal_count} proposals linked to execution journal entries in recent window.",
+        ),
+    }
+    blockers = [name for name, item in metrics.items() if not item["passed"]]
+
+    return {
+        "status": "ok",
+        "ready_for_live": len(blockers) == 0,
+        "blockers": blockers,
+        "metrics": metrics,
+    }
+
+
 # ─── /api/inventory ────────────────────────────────────────────────────────────
 
 @inventory_router.get("")

--- a/frontend/backend/tests/test_system_api.py
+++ b/frontend/backend/tests/test_system_api.py
@@ -99,6 +99,29 @@ def _init_system_db(path: Path) -> None:
         )
     """)
     conn.execute("""
+        CREATE TABLE IF NOT EXISTS daily_pnl_summary (
+            trade_date TEXT PRIMARY KEY,
+            nav_start REAL NOT NULL,
+            nav_end REAL NOT NULL,
+            realized_pnl REAL NOT NULL,
+            unrealized_pnl REAL NOT NULL,
+            total_pnl REAL NOT NULL,
+            daily_return REAL NOT NULL,
+            rolling_peak_nav REAL NOT NULL,
+            rolling_drawdown REAL NOT NULL,
+            losing_streak_days INTEGER NOT NULL DEFAULT 0,
+            risk_mode TEXT NOT NULL DEFAULT 'normal'
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS daily_nav (
+            trade_date TEXT PRIMARY KEY,
+            nav REAL,
+            unrealized_pnl REAL,
+            realized_pnl_cumulative REAL
+        )
+    """)
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS order_events (
             event_id TEXT PRIMARY KEY,
             ts TEXT NOT NULL,
@@ -765,3 +788,100 @@ class TestSystemRiskPnl:
                 sys.modules["openclaw.pnl_engine"] = pnl_engine
             except Exception:
                 pass
+
+
+class TestGraduationCheck:
+    def test_graduation_check_returns_fail_safe_when_no_data(self, sys_client):
+        c, _, _ = sys_client
+        r = c.get("/api/system/graduation-check", headers=_AUTH)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ready_for_live"] is False
+        assert "win_rate_28d_pct" in data["metrics"]
+
+    def test_graduation_check_passes_when_all_thresholds_met(self, sys_client):
+        c, _, db_path = sys_client
+        now_ms = int(__import__("time").time() * 1000)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO daily_pnl_summary VALUES ('2026-03-01', 1000000, 1010000, 5000, 0, 5000, 0.005, 1010000, 0.02, 0, 'normal')"
+        )
+        conn.execute(
+            "INSERT INTO daily_pnl_summary VALUES ('2026-03-02', 1010000, 1020000, 6000, 0, 6000, 0.006, 1020000, 0.03, 0, 'normal')"
+        )
+        conn.execute(
+            "INSERT INTO daily_pnl_summary VALUES ('2026-03-03', 1020000, 1015000, -1000, 0, -1000, -0.001, 1020000, 0.03, 0, 'normal')"
+        )
+        conn.execute(
+            "INSERT INTO positions VALUES ('2330', 100, 100.0, 100.0, NULL, NULL)"
+        )
+        conn.execute(
+            "INSERT INTO positions VALUES ('2317', 100, 100.0, 100.0, NULL, NULL)"
+        )
+        conn.execute(
+            "INSERT INTO positions VALUES ('2454', 100, 100.0, 100.0, NULL, NULL)"
+        )
+        conn.execute(
+            "INSERT INTO strategy_proposals VALUES ('p1', 'approved', ?)",
+            (now_ms,),
+        )
+        conn.execute(
+            "INSERT INTO strategy_proposals VALUES ('p2', 'approved', ?)",
+            (now_ms,),
+        )
+        conn.execute(
+            "INSERT INTO strategy_proposals VALUES ('p3', 'approved', ?)",
+            (now_ms,),
+        )
+        conn.execute(
+            "INSERT INTO strategy_proposals VALUES ('p4', 'approved', ?)",
+            (now_ms,),
+        )
+        for idx, pid in enumerate(("p1", "p2", "p3", "p4"), start=1):
+            conn.execute(
+                "INSERT INTO proposal_execution_journal VALUES (?, ?, 'RULE', '2330', 100, 500.0, 'executed', 1, ?, NULL, ?, ?)",
+                (f"ek{idx}", pid, f"o{idx}", now_ms, now_ms),
+            )
+        conn.commit()
+        conn.close()
+
+        r = c.get("/api/system/graduation-check", headers=_AUTH)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ready_for_live"] is True
+        assert data["blockers"] == []
+        assert data["metrics"]["proposal_execution_alignment_pct"]["value"] == 100.0
+
+    def test_graduation_check_flags_blockers(self, sys_client):
+        c, _, db_path = sys_client
+        now_ms = int(__import__("time").time() * 1000)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO daily_pnl_summary VALUES ('2026-03-01', 1000000, 900000, -10000, 0, -10000, -0.01, 1000000, 0.15, 0, 'normal')"
+        )
+        conn.execute(
+            "INSERT INTO incidents VALUES ('i1', datetime('now'), 'critical', 'risk', 'P0', '{}', 0)"
+        )
+        conn.execute(
+            "INSERT INTO positions VALUES ('2330', 100, 1000.0, 1000.0, NULL, NULL)"
+        )
+        conn.execute(
+            "INSERT INTO positions VALUES ('2317', 10, 100.0, 100.0, NULL, NULL)"
+        )
+        conn.execute(
+            "INSERT INTO strategy_proposals VALUES ('p1', 'approved', ?)",
+            (now_ms,),
+        )
+        conn.execute(
+            "INSERT INTO order_events VALUES ('e1', datetime('now'), 'o1', 'rejected', NULL, 'rejected', 'pre_trade_guard', 'RISK_WASH_SALE_SELL_TODAY', '{}')"
+        )
+        conn.commit()
+        conn.close()
+
+        r = c.get("/api/system/graduation-check", headers=_AUTH)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ready_for_live"] is False
+        assert "incident_free_20d" in data["blockers"]
+        assert "max_concentration_pct" in data["blockers"]
+        assert "wash_sale_violations_28d" in data["blockers"]


### PR DESCRIPTION
## Summary

- add `/api/system/graduation-check` with fail-safe live-readiness metrics
- evaluate incident-free status, 28d win rate, max drawdown, profit factor, concentration, wash-sale violations, and proposal execution alignment
- cover passing and failing scenarios in backend API tests

## Related Issue

- Closes #392

## Testing

- [x] Tests run locally
- [ ] Not run (explain why)
- [x] Added or updated regression tests for the changed behavior

Commands:

```bash
./.venv/bin/python -m pytest -q frontend/backend/tests/test_system_api.py -k graduation
```

## Verification Evidence

- [x] Before/After data included
- [x] Verification time window included
- [x] Effect validation included

Before:

- There was no single API endpoint exposing a simulation-to-live graduation gate.
- Operators had to infer readiness from multiple tables and logs manually.

After:

- `/api/system/graduation-check` returns a structured readiness decision plus blocking metrics.
- Missing or failing data keeps `ready_for_live=false` by default.

Verification window:

- Validated locally on 2026-03-23 with targeted backend API tests.

Regression coverage:

- `frontend/backend/tests/test_system_api.py -k graduation`

## Risk

- Low: read-only endpoint using existing tables, with fail-safe defaults on missing data.

## Docs / Ops Impact

- [x] No doc changes needed
- [ ] `AGENTS.md` updated
- [ ] `progress.md` high-level status updated
- [ ] Runbook / operator notes updated

## Issue Linkback

- [ ] PR link added back to the related issue
