### PR TITLE
feat(regime): benchmark MA override + foreign investor streak

### DIFF
--- a/src/openclaw/market_regime.py
+++ b/src/openclaw/market_regime.py
@@ -223,6 +223,48 @@ def compute_regime_features(
         "atr": float(atr),
     }
 
+def _benchmark_ma_direction(benchmark_prices: Sequence[float], window: int = 20) -> str:
+    """Determine benchmark (0050) MA direction as a hard regime indicator (#390).
+
+    Returns 'up', 'down', or 'flat' based on 20-day MA slope.
+    """
+    ps = _to_floats(benchmark_prices)
+    if len(ps) < window + 1:
+        return "flat"
+    ma_now = mean(ps[-window:])
+    ma_prev = mean(ps[-(window + 1):-1])
+    if ma_prev <= 0:
+        return "flat"
+    change_pct = (ma_now - ma_prev) / ma_prev
+    if change_pct > 0.001:   # MA rising > 0.1%
+        return "up"
+    elif change_pct < -0.001:
+        return "down"
+    return "flat"
+
+
+def _foreign_investor_streak(net_buy_days: Sequence[float]) -> int:
+    """Count consecutive net-buy (positive) or net-sell (negative) days (#390).
+
+    Args:
+        net_buy_days: sequence of daily net buy amounts (positive = net buy),
+                      ordered oldest to newest.
+    Returns:
+        Positive int for consecutive buy days, negative for sell days, 0 if mixed/empty.
+    """
+    vals = _to_floats(net_buy_days)
+    if not vals:
+        return 0
+    streak = 0
+    direction = 1 if vals[-1] > 0 else -1 if vals[-1] < 0 else 0
+    for v in reversed(vals):
+        if (direction > 0 and v > 0) or (direction < 0 and v < 0):
+            streak += 1
+        else:
+            break
+    return streak * direction
+
+
 def classify_market_regime(
     prices: Sequence[float],
     volumes: Sequence[float] | None = None,
@@ -231,8 +273,15 @@ def classify_market_regime(
     long_window: int = 60,
     trend_threshold: float = 0.01,
     slope_threshold: float = 0.0005,
+    benchmark_prices: Sequence[float] | None = None,
+    foreign_net_buy_days: Sequence[float] | None = None,
 ) -> MarketRegimeResult:
-    """Classify bull/bear/range based on trend + volume + volatility."""
+    """Classify bull/bear/range based on trend + volume + volatility.
+
+    #390 enhancements:
+    - benchmark_prices: 0050 price series for MA direction override
+    - foreign_net_buy_days: institutional net buy amounts for confirmation
+    """
 
     feats = compute_regime_features(prices, volumes, short_window=short_window, long_window=long_window)
     trend = feats["trend_strength"]
@@ -248,6 +297,33 @@ def classify_market_regime(
         regime = MarketRegime.BEAR
     else:
         regime = MarketRegime.RANGE
+
+    # ── Benchmark MA override (#390) ──────────────────────────────
+    # 0050 MA direction is a hard indicator: if benchmark disagrees
+    # with individual stock regime, downgrade to RANGE.
+    if benchmark_prices is not None:
+        bench_dir = _benchmark_ma_direction(benchmark_prices)
+        feats["benchmark_ma_direction"] = {"up": 1.0, "down": -1.0, "flat": 0.0}[bench_dir]
+        if regime == MarketRegime.BULL and bench_dir == "down":
+            regime = MarketRegime.RANGE
+            feats["regime_override"] = 1.0  # flag the override
+        elif regime == MarketRegime.BEAR and bench_dir == "up":
+            regime = MarketRegime.RANGE
+            feats["regime_override"] = 1.0
+
+    # ── Foreign investor streak (#390) ────────────────────────────
+    # Strong institutional flow confirms or weakens the regime.
+    if foreign_net_buy_days is not None:
+        fi_streak = _foreign_investor_streak(foreign_net_buy_days)
+        feats["foreign_investor_streak"] = float(fi_streak)
+        # 5+ consecutive buy days in bear → upgrade to range
+        if regime == MarketRegime.BEAR and fi_streak >= 5:
+            regime = MarketRegime.RANGE
+            feats["regime_fi_upgrade"] = 1.0
+        # 5+ consecutive sell days in bull → downgrade to range
+        elif regime == MarketRegime.BULL and fi_streak <= -5:
+            regime = MarketRegime.RANGE
+            feats["regime_fi_downgrade"] = 1.0
 
     # Confidence: mostly trend strength + slope, penalize extreme volatility.
     trend_score = min(1.0, abs(trend) / max(trend_threshold * 3.0, 1e-9))

--- a/src/openclaw/signal_aggregator.py
+++ b/src/openclaw/signal_aggregator.py
@@ -49,13 +49,42 @@ class AggregatedSignal:
 def _get_regime(conn: sqlite3.Connection, symbol: str) -> tuple[str, float]:
     """從 eod_prices 取收盤價序列，判斷 market regime。
     回傳 (regime_str, volatility_multiplier)。
+
+    #390: 加入 0050 benchmark MA direction 和外資連續買賣天數。
     """
     candles = fetch_candles(conn, symbol, days=60)
     if len(candles) < 20:
         return "range", 1.0
     prices  = [c["close"]  for c in candles]
     volumes = [c["volume"] for c in candles]
-    result = classify_market_regime(prices, volumes)
+
+    # Fetch benchmark (0050) prices for regime override
+    bench_prices = None
+    try:
+        bench_candles = fetch_candles(conn, "0050", days=60)
+        if len(bench_candles) >= 21:
+            bench_prices = [c["close"] for c in bench_candles]
+    except Exception:
+        pass
+
+    # Fetch foreign investor net buy streak
+    fi_net_buy = None
+    try:
+        fi_rows = conn.execute(
+            """SELECT net_buy FROM eod_institution_flows
+               WHERE symbol = ? ORDER BY trade_date DESC LIMIT 10""",
+            (symbol,),
+        ).fetchall()
+        if fi_rows:
+            fi_net_buy = [float(r[0] or 0) for r in reversed(fi_rows)]
+    except Exception:
+        pass
+
+    result = classify_market_regime(
+        prices, volumes,
+        benchmark_prices=bench_prices,
+        foreign_net_buy_days=fi_net_buy,
+    )
     return result.regime.value, result.volatility_multiplier
 
 

--- a/tests/test_regime_enhancement.py
+++ b/tests/test_regime_enhancement.py
@@ -1,0 +1,149 @@
+"""Tests for regime detection enhancement (#390).
+
+Covers:
+- _benchmark_ma_direction detects up/down/flat
+- _foreign_investor_streak counts consecutive days
+- classify_market_regime benchmark override
+- classify_market_regime foreign investor confirmation
+"""
+from __future__ import annotations
+
+import pytest
+
+from openclaw.market_regime import (
+    MarketRegime,
+    _benchmark_ma_direction,
+    _foreign_investor_streak,
+    classify_market_regime,
+)
+
+
+def _trending_up(n: int = 60, start: float = 100.0, step: float = 0.5) -> list[float]:
+    return [start + i * step for i in range(n)]
+
+
+def _trending_down(n: int = 60, start: float = 130.0, step: float = 0.5) -> list[float]:
+    return [start - i * step for i in range(n)]
+
+
+def _flat(n: int = 60, val: float = 100.0) -> list[float]:
+    return [val] * n
+
+
+class TestBenchmarkMaDirection:
+    def test_up(self):
+        prices = _trending_up(25, 100, 1.0)
+        assert _benchmark_ma_direction(prices) == "up"
+
+    def test_down(self):
+        prices = _trending_down(25, 130, 1.0)
+        assert _benchmark_ma_direction(prices) == "down"
+
+    def test_flat(self):
+        prices = _flat(25, 100.0)
+        assert _benchmark_ma_direction(prices) == "flat"
+
+    def test_insufficient_data(self):
+        assert _benchmark_ma_direction([100.0] * 5) == "flat"
+
+
+class TestForeignInvestorStreak:
+    def test_consecutive_buy(self):
+        assert _foreign_investor_streak([100, 200, 50, 300, 150]) == 5
+
+    def test_consecutive_sell(self):
+        assert _foreign_investor_streak([-100, -200, -50]) == -3
+
+    def test_mixed_ending_buy(self):
+        assert _foreign_investor_streak([-100, -200, 50, 100]) == 2
+
+    def test_mixed_ending_sell(self):
+        assert _foreign_investor_streak([100, 200, -50, -100]) == -2
+
+    def test_empty(self):
+        assert _foreign_investor_streak([]) == 0
+
+    def test_single_day(self):
+        assert _foreign_investor_streak([100]) == 1
+        assert _foreign_investor_streak([-100]) == -1
+
+
+class TestRegimeBenchmarkOverride:
+    def test_bull_downgraded_when_benchmark_falling(self):
+        """Stock trending up but benchmark (0050) falling → RANGE."""
+        stock_prices = _trending_up(60, 100, 1.0)
+        volumes = _flat(60, 10000)
+        benchmark = _trending_down(60, 130, 0.5)
+
+        result = classify_market_regime(
+            stock_prices, volumes, benchmark_prices=benchmark
+        )
+        # Should be downgraded from BULL to RANGE
+        assert result.regime in (MarketRegime.RANGE, MarketRegime.BEAR)
+
+    def test_bear_upgraded_when_benchmark_rising(self):
+        """Stock trending down but benchmark rising → RANGE."""
+        stock_prices = _trending_down(60, 130, 1.0)
+        volumes = _flat(60, 10000)
+        benchmark = _trending_up(60, 100, 0.5)
+
+        result = classify_market_regime(
+            stock_prices, volumes, benchmark_prices=benchmark
+        )
+        assert result.regime in (MarketRegime.RANGE, MarketRegime.BULL)
+
+    def test_no_override_when_aligned(self):
+        """Stock and benchmark both trending up → stays BULL."""
+        stock_prices = _trending_up(60, 100, 1.0)
+        volumes = _flat(60, 10000)
+        benchmark = _trending_up(60, 100, 0.3)
+
+        result = classify_market_regime(
+            stock_prices, volumes, benchmark_prices=benchmark
+        )
+        assert result.regime == MarketRegime.BULL
+
+    def test_no_override_without_benchmark(self):
+        """Without benchmark, original logic applies."""
+        stock_prices = _trending_up(60, 100, 1.0)
+        volumes = _flat(60, 10000)
+
+        result = classify_market_regime(stock_prices, volumes)
+        assert result.regime == MarketRegime.BULL
+
+
+class TestRegimeForeignInvestor:
+    def test_bear_upgraded_with_strong_buying(self):
+        """Bear regime + 5 consecutive foreign buy days → RANGE."""
+        stock_prices = _trending_down(60, 130, 1.0)
+        volumes = _flat(60, 10000)
+        fi_days = [100, 200, 300, 400, 500]  # 5 consecutive buy days
+
+        result = classify_market_regime(
+            stock_prices, volumes, foreign_net_buy_days=fi_days
+        )
+        assert result.regime == MarketRegime.RANGE
+        assert result.features.get("regime_fi_upgrade") == 1.0
+
+    def test_bull_downgraded_with_strong_selling(self):
+        """Bull regime + 5 consecutive foreign sell days → RANGE."""
+        stock_prices = _trending_up(60, 100, 1.0)
+        volumes = _flat(60, 10000)
+        fi_days = [-100, -200, -300, -400, -500]
+
+        result = classify_market_regime(
+            stock_prices, volumes, foreign_net_buy_days=fi_days
+        )
+        assert result.regime == MarketRegime.RANGE
+        assert result.features.get("regime_fi_downgrade") == 1.0
+
+    def test_no_change_with_weak_streak(self):
+        """3 consecutive sell days (< 5) → no override."""
+        stock_prices = _trending_up(60, 100, 1.0)
+        volumes = _flat(60, 10000)
+        fi_days = [100, -100, -200, -300]  # only 3 sell days
+
+        result = classify_market_regime(
+            stock_prices, volumes, foreign_net_buy_days=fi_days
+        )
+        assert result.regime == MarketRegime.BULL  # Not downgraded


### PR DESCRIPTION
## Summary
- 0050 20 日均線方向作為 regime 硬指標：Bull + 大盤下跌 → RANGE
- 外資連續買賣天數確認：Bear + 外資連續 5 天買超 → RANGE
- signal_aggregator 自動查詢 0050 和 eod_institution_flows
- 17 個新 pytest case

## Test plan
- [x] 17/17 regime tests pass
- [x] 881/881 existing tests pass

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)