### PR TITLE
feat(llm): LLM stability — lower temperature + latency warning

### DIFF
--- a/src/openclaw/llm_minimax.py
+++ b/src/openclaw/llm_minimax.py
@@ -47,13 +47,16 @@ def _extract_json(text: str) -> Dict[str, Any]:
     raise ValueError(f"Cannot parse JSON from MiniMax response: {text[:300]}")
 
 
-def minimax_call(model: str, prompt: str, temperature: float = 0.2) -> Dict[str, Any]:
-    """呼叫 MiniMax M2.5，回傳解析後的 JSON dict。
+_LATENCY_WARN_MS = int(os.environ.get("LLM_LATENCY_WARN_MS", "30000"))  # 30s default
+
+
+def minimax_call(model: str, prompt: str, temperature: float = 0.1) -> Dict[str, Any]:
+    """呼叫 MiniMax，回傳解析後的 JSON dict。
 
     Args:
         model: MiniMax 模型 ID，e.g. "MiniMax-M2.7"。
         prompt: 完整 prompt 字串。
-        temperature: 生成溫度，預設 0.2（低隨機性，審查決策更穩定）。
+        temperature: 生成溫度，預設 0.1（#391: 降低決策隨機性）。
 
     Returns:
         解析後的 dict，包含 '_raw_response', '_prompt', '_latency_ms', '_model'。
@@ -75,6 +78,7 @@ def minimax_call(model: str, prompt: str, temperature: float = 0.2) -> Dict[str,
         "model": model,
         "messages": [{"role": "user", "content": prompt}],
         "response_format": {"type": "json_object"},
+        "temperature": temperature,
         "max_tokens": 16384,
     }
 
@@ -106,8 +110,17 @@ def minimax_call(model: str, prompt: str, temperature: float = 0.2) -> Dict[str,
     result["_raw_response"] = raw_text
     result["_latency_ms"] = latency_ms
     result["_model"] = model
+    result["_temperature"] = temperature
     result["_input_tokens"] = usage.get("prompt_tokens", 0)
     result["_output_tokens"] = usage.get("completion_tokens", 0)
+
+    # Latency warning (#391)
+    if latency_ms > _LATENCY_WARN_MS:
+        log.warning(
+            "LLM call slow: model=%s latency=%dms (threshold=%dms) tokens_in=%d tokens_out=%d",
+            model, latency_ms, _LATENCY_WARN_MS,
+            result["_input_tokens"], result["_output_tokens"],
+        )
 
     return result
 

--- a/tests/test_llm_stability.py
+++ b/tests/test_llm_stability.py
@@ -67,18 +67,24 @@ class TestMinimaxCallConfig:
         payload = call_args.kwargs.get("json") or call_args[1].get("json")
         assert payload["temperature"] == 0.05
 
-    @patch("openclaw.llm_minimax.time.time")
     @patch("openclaw.llm_minimax.requests.post")
     @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
-    def test_latency_warning_logged(self, mock_post, mock_time, caplog):
+    def test_latency_warning_logged(self, mock_post, caplog, monkeypatch):
         from openclaw.llm_minimax import minimax_call
         import openclaw.llm_minimax as mod
 
         old_warn = mod._LATENCY_WARN_MS
         mod._LATENCY_WARN_MS = 1000  # 1 second threshold
 
-        # Simulate 5-second latency
-        mock_time.side_effect = [100.0, 105.0]
+        # Simulate 5-second latency via time.time returning increasing values
+        _call_count = 0
+        _times = [100.0, 105.0]  # 5s apart
+        def _fake_time():
+            nonlocal _call_count
+            idx = min(_call_count, len(_times) - 1)
+            _call_count += 1
+            return _times[idx]
+        monkeypatch.setattr(mod.time, "time", _fake_time)
 
         mock_resp = MagicMock()
         mock_resp.json.return_value = {

--- a/tests/test_llm_stability.py
+++ b/tests/test_llm_stability.py
@@ -1,0 +1,112 @@
+"""Tests for LLM stability improvements (#391).
+
+Covers:
+- Default temperature is 0.1
+- Temperature is passed to API payload
+- Latency warning logged when exceeding threshold
+- _extract_json handles various formats
+"""
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openclaw.llm_minimax import _extract_json
+
+
+class TestExtractJson:
+    def test_plain_json(self):
+        assert _extract_json('{"key": "value"}') == {"key": "value"}
+
+    def test_markdown_fenced(self):
+        text = '```json\n{"key": "value"}\n```'
+        assert _extract_json(text) == {"key": "value"}
+
+    def test_embedded_in_text(self):
+        text = 'Here is the result: {"key": "value"} done.'
+        assert _extract_json(text) == {"key": "value"}
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Cannot parse"):
+            _extract_json("not json at all")
+
+    def test_array_response(self):
+        text = '[{"a": 1}, {"a": 2}]'
+        # Arrays are valid JSON but _extract_json expects dict
+        # It should still work via the regex fallback
+        result = _extract_json(text)
+        assert isinstance(result, list)
+
+
+class TestMinimaxCallConfig:
+    def test_default_temperature_is_01(self):
+        import inspect
+        from openclaw.llm_minimax import minimax_call
+        sig = inspect.signature(minimax_call)
+        assert sig.parameters["temperature"].default == 0.1
+
+    @patch("openclaw.llm_minimax.requests.post")
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+    def test_temperature_passed_to_payload(self, mock_post):
+        from openclaw.llm_minimax import minimax_call
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        minimax_call("test-model", "test prompt", temperature=0.05)
+
+        call_args = mock_post.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert payload["temperature"] == 0.05
+
+    @patch("openclaw.llm_minimax.time.time")
+    @patch("openclaw.llm_minimax.requests.post")
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+    def test_latency_warning_logged(self, mock_post, mock_time, caplog):
+        from openclaw.llm_minimax import minimax_call
+        import openclaw.llm_minimax as mod
+
+        old_warn = mod._LATENCY_WARN_MS
+        mod._LATENCY_WARN_MS = 1000  # 1 second threshold
+
+        # Simulate 5-second latency
+        mock_time.side_effect = [100.0, 105.0]
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        try:
+            with caplog.at_level(logging.WARNING, logger="openclaw.llm_minimax"):
+                minimax_call("test-model", "test prompt")
+            assert any("LLM call slow" in r.message for r in caplog.records)
+        finally:
+            mod._LATENCY_WARN_MS = old_warn
+
+    @patch("openclaw.llm_minimax.requests.post")
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+    def test_result_includes_temperature(self, mock_post):
+        from openclaw.llm_minimax import minimax_call
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {},
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        result = minimax_call("test-model", "test", temperature=0.1)
+        assert result["_temperature"] == 0.1


### PR DESCRIPTION
## Summary
- Temperature 預設值 0.2 → 0.1（降低決策隨機性）
- Temperature 現在實際傳入 API payload（之前遺漏！）
- 新增 latency 警告 log（超過 30s 閾值時）
- 9 個新 pytest case

## Test plan
- [x] 9/9 新測試通過
- [x] 890/890 既有測試通過

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)