### PR TITLE
fix: migrate all Gemini model references to MiniMax-M2.7

### DIFF
--- a/src/openclaw/bootstrap_and_dry_run.py
+++ b/src/openclaw/bootstrap_and_dry_run.py
@@ -71,14 +71,14 @@ def _mock_llm_call(model: str, prompt: str) -> dict:
 def run_pipeline_demo(conn: sqlite3.Connection) -> None:
     news_result = run_news_sentiment_with_guard(
         conn,
-        model="gemini-3.0-flash",
+        model="MiniMax-M2.7",
         raw_news_text="台積電法說會優於預期，市場看法偏多",
         llm_call=_mock_llm_call,
         decision_id="demo-decision-001",
     )
     debate_result = run_pm_debate(
         conn,
-        model="gemini-3.1-pro",
+        model="MiniMax-M2.7",
         context={"symbol": "2330", "news": news_result},
         llm_call=_mock_llm_call,
         decision_id="demo-decision-001",

--- a/src/openclaw/proposal_reviewer.py
+++ b/src/openclaw/proposal_reviewer.py
@@ -1,7 +1,7 @@
 """proposal_reviewer.py — LLM 自動審查 pending 策略提案（MiniMax M2.5）
 
 掃描 strategy_proposals 中 status='pending' 的提案，
-呼叫 Gemini 做快速審查，輸出 approve / reject + 理由，
+呼叫 MiniMax LLM 做快速審查，輸出 approve / reject + 理由，
 更新 DB 並透過 Telegram 通知。
 
 整合點（ticker_watcher 每輪掃盤後呼叫）：

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -1590,13 +1590,13 @@ def run_watcher() -> None:
             except Exception as ce:  # noqa: BLE001 — dynamic import; can't predict exceptions
                 log.error("[concentration] guard error: %s", ce, exc_info=True)
 
-            # ── Gemini 自動審查 pending proposals → 核准/拒絕 + Telegram 通知 ──
+            # ── LLM 自動審查 pending proposals → 核准/拒絕 + Telegram 通知 ──
             try:
                 from openclaw.proposal_reviewer import auto_review_pending_proposals
                 n_reviewed = auto_review_pending_proposals(conn)
                 if n_reviewed > 0:
                     log.info("[reviewer] Auto-reviewed %d pending proposals", n_reviewed)
-            except Exception as rv:  # noqa: BLE001 — dynamic import + Gemini API
+            except Exception as rv:  # noqa: BLE001 — dynamic import + LLM API
                 log.error("[reviewer] proposal reviewer error: %s", rv, exc_info=True)
 
             # ── Telegram 提案通知 + 老闆 inline 核准 ──────────────────────────


### PR DESCRIPTION
## Summary
- Migrate all hardcoded Gemini model strings to MiniMax-M2.7
- Update comments and docstrings referencing Gemini
- .env changes (AGENT_LLM_MODEL, AGENT_COMMITTEE_MODEL) applied directly on server (gitignored)

## Files Changed
- `bootstrap_and_dry_run.py` — model strings
- `proposal_reviewer.py` — docstring
- `ticker_watcher.py` — comments

## Note
`.env` is gitignored, so AGENT_LLM_MODEL and AGENT_COMMITTEE_MODEL were changed directly on the server.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)