### PR TITLE
refactor: deep Repository migration — PnL, Proposal, Order

### DIFF
--- a/src/openclaw/pnl_engine.py
+++ b/src/openclaw/pnl_engine.py
@@ -11,13 +11,16 @@ Schema dependencies:
   fills   (order_id, qty, price, fee, tax)
   daily_pnl_summary  (trade_date PK, realized_pnl, total_trades, ...)
   positions          (symbol PK, quantity, avg_price, ...)
+
+All SQL is delegated to PnLRepository.
 """
 from __future__ import annotations
 
-import datetime
 import logging
 import sqlite3
 from typing import Tuple
+
+from openclaw.repositories.pnl_repository import PnLRepository
 
 log = logging.getLogger(__name__)
 
@@ -37,25 +40,7 @@ def get_avg_cost(conn: sqlite3.Connection, symbol: str) -> Tuple[float, int]:
     Uses all historical buy fills minus sold qty to reflect current holding.
     Returns (0.0, 0) if no position.
     """
-    row = conn.execute(
-        """
-        SELECT
-          SUM(CASE WHEN o.side='buy'  THEN f.qty ELSE 0 END)
-        - SUM(CASE WHEN o.side='sell' THEN f.qty ELSE 0 END) AS net_qty,
-          ROUND(
-            SUM(CASE WHEN o.side='buy' THEN f.qty * f.price ELSE 0 END)
-            / MAX(SUM(CASE WHEN o.side='buy' THEN f.qty ELSE 0 END), 1),
-          4) AS avg_price
-        FROM orders o
-        JOIN fills f ON f.order_id = o.order_id
-        WHERE UPPER(o.symbol) = UPPER(?)
-          AND o.status IN ('filled', 'partially_filled')
-        """,
-        (symbol,)
-    ).fetchone()
-    if row and row["net_qty"] and row["net_qty"] > 0:
-        return float(row["avg_price"]), int(row["net_qty"])
-    return 0.0, 0
+    return PnLRepository(conn).get_avg_cost(symbol)
 
 
 # ── Sell fill handler ────────────────────────────────────────────────────────
@@ -77,9 +62,10 @@ def on_sell_filled(
 
     Returns the realized_pnl value.
     """
-    avg_cost, _ = get_avg_cost(conn, symbol)
+    repo = PnLRepository(conn)
+    avg_cost, _ = repo.get_avg_cost(symbol)
     realized_pnl = (sell_price - avg_cost) * sell_qty - sell_fee - sell_tax
-    _upsert_daily_pnl(conn, trade_date, delta_realized=realized_pnl, delta_trades=1)
+    repo.upsert_daily_pnl(trade_date, delta_realized=realized_pnl, delta_trades=1)
     return realized_pnl
 
 
@@ -90,36 +76,7 @@ def _upsert_daily_pnl(
     delta_trades: int,
 ) -> None:
     """Add delta to daily_pnl_summary for trade_date (upsert)."""
-    existing = conn.execute(
-        "SELECT realized_pnl, total_trades FROM daily_pnl_summary WHERE trade_date=?",
-        (trade_date,)
-    ).fetchone()
-
-    if existing:
-        new_pnl   = (existing["realized_pnl"] or 0.0) + delta_realized
-        new_total = (existing["total_trades"] or 0) + delta_trades
-        win_rate  = _compute_rolling_win_rate(conn, trade_date, new_pnl)
-        conn.execute(
-            """UPDATE daily_pnl_summary
-               SET realized_pnl=?, total_pnl=?, total_trades=?,
-                   rolling_win_rate=?
-               WHERE trade_date=?""",
-            (round(new_pnl, 2), round(new_pnl, 2), new_total, win_rate, trade_date)
-        )
-    else:
-        win_rate = 1.0 if delta_realized > 0 else 0.0
-        conn.execute(
-            """INSERT INTO daily_pnl_summary
-               (trade_date, realized_pnl, unrealized_pnl, total_pnl,
-                total_trades, rolling_drawdown, consecutive_losses,
-                losing_streak_days, rolling_win_rate)
-               VALUES (?,?,0.0,?,?,0.0,?,0,?)""",
-            (trade_date, round(delta_realized, 2), round(delta_realized, 2),
-             delta_trades,
-             1 if delta_realized < 0 else 0,
-             win_rate)
-        )
-    conn.commit()
+    PnLRepository(conn).upsert_daily_pnl(trade_date, delta_realized, delta_trades)
 
 
 def _compute_rolling_win_rate(
@@ -128,17 +85,7 @@ def _compute_rolling_win_rate(
     today_pnl: float,
 ) -> float:
     """Rolling win rate: % of trading days with realized_pnl > 0 (last 20 days)."""
-    rows = conn.execute(
-        """SELECT realized_pnl FROM daily_pnl_summary
-           WHERE trade_date < ?
-           ORDER BY trade_date DESC LIMIT 19""",
-        (up_to_date,)
-    ).fetchall()
-    all_pnls = [r["realized_pnl"] for r in rows] + [today_pnl]
-    if not all_pnls:  # pragma: no cover
-        return 0.0
-    wins = sum(1 for p in all_pnls if p > 0)
-    return round(wins / len(all_pnls), 4)
+    return PnLRepository(conn).compute_rolling_win_rate(up_to_date, today_pnl)
 
 
 # ── Positions table sync ─────────────────────────────────────────────────────
@@ -149,121 +96,31 @@ def sync_positions_table(conn: sqlite3.Connection) -> None:
     Removes closed positions (net_qty <= 0).
     Does NOT update current_price or unrealized_pnl (requires live feed).
     """
-    conn.execute("DELETE FROM positions")
-    # #485: include entry_trading_day = earliest buy order date for current position
-    if _table_exists(conn, "position_quarantine"):
-        conn.execute(
-            """
-            INSERT INTO positions (symbol, quantity, avg_price, entry_trading_day)
-            SELECT
-              o.symbol,
-              SUM(CASE WHEN o.side='buy'  THEN f.qty ELSE 0 END)
-            - SUM(CASE WHEN o.side='sell' THEN f.qty ELSE 0 END) AS net_qty,
-              ROUND(
-                SUM(CASE WHEN o.side='buy' THEN f.qty * f.price ELSE 0 END)
-                / MAX(SUM(CASE WHEN o.side='buy' THEN f.qty ELSE 0 END), 1),
-              4) AS avg_price,
-              MIN(CASE WHEN o.side='buy' THEN date(o.ts_submit) END) AS entry_trading_day
-            FROM orders o
-            JOIN fills f ON f.order_id = o.order_id
-            LEFT JOIN position_quarantine q
-              ON UPPER(q.symbol) = UPPER(o.symbol)
-             AND q.active = 1
-            WHERE o.status IN ('filled', 'partially_filled')
-              AND q.symbol IS NULL
-            GROUP BY o.symbol
-            HAVING net_qty > 0
-            """
-        )
-    else:
-        conn.execute(
-            """
-            INSERT INTO positions (symbol, quantity, avg_price, entry_trading_day)
-            SELECT
-              o.symbol,
-              SUM(CASE WHEN o.side='buy'  THEN f.qty ELSE 0 END)
-            - SUM(CASE WHEN o.side='sell' THEN f.qty ELSE 0 END) AS net_qty,
-              ROUND(
-                SUM(CASE WHEN o.side='buy' THEN f.qty * f.price ELSE 0 END)
-                / MAX(SUM(CASE WHEN o.side='buy' THEN f.qty ELSE 0 END), 1),
-              4) AS avg_price,
-              MIN(CASE WHEN o.side='buy' THEN date(o.ts_submit) END) AS entry_trading_day
-            FROM orders o
-            JOIN fills f ON f.order_id = o.order_id
-            WHERE o.status IN ('filled', 'partially_filled')
-            GROUP BY o.symbol
-            HAVING net_qty > 0
-            """
-        )
-    conn.commit()
-
-    # #485: backfill high_water_mark from eod_prices for positions that have it NULL
-    _backfill_high_water_mark(conn)
+    PnLRepository(conn).sync_positions()
 
 
 def _backfill_high_water_mark(conn: sqlite3.Connection) -> None:
     """Set high_water_mark from eod_prices max(close) since entry for positions missing it."""
-    try:
-        conn.execute(
-            """UPDATE positions SET high_water_mark = (
-                 SELECT MAX(e.close) FROM eod_prices e
-                 WHERE e.symbol = positions.symbol
-                   AND e.trade_date >= COALESCE(positions.entry_trading_day, '2000-01-01')
-               )
-               WHERE high_water_mark IS NULL AND quantity > 0"""
-        )
-        conn.commit()
-    except sqlite3.Error as e:
-        log.warning("_backfill_high_water_mark failed: %s", e)
+    PnLRepository(conn).backfill_high_water_mark()
 
 
 # ── API helpers ──────────────────────────────────────────────────────────────
 
 def get_today_pnl(conn: sqlite3.Connection, trade_date: str) -> float:
     """Return today's realized_pnl from daily_pnl_summary."""
-    row = conn.execute(
-        "SELECT realized_pnl FROM daily_pnl_summary WHERE trade_date=?",
-        (trade_date,)
-    ).fetchone()
-    return float(row["realized_pnl"]) if row and row["realized_pnl"] is not None else 0.0
+    return PnLRepository(conn).get_today_pnl(trade_date)
 
 
 def get_monthly_pnl(conn: sqlite3.Connection, month_prefix: str) -> float:
     """Return sum of realized_pnl for month_prefix e.g. '2026-03'."""
-    row = conn.execute(
-        "SELECT SUM(realized_pnl) AS total FROM daily_pnl_summary WHERE trade_date LIKE ?",
-        (f"{month_prefix}%",)
-    ).fetchone()
-    return float(row["total"]) if row and row["total"] is not None else 0.0
+    return PnLRepository(conn).get_monthly_pnl(month_prefix)
 
 
 def get_overall_win_rate(conn: sqlite3.Connection) -> float:
     """Win rate = days with realized_pnl > 0 / total days with trades."""
-    row = conn.execute(
-        """SELECT
-             SUM(CASE WHEN realized_pnl > 0 THEN 1 ELSE 0 END) AS wins,
-             COUNT(1) AS total
-           FROM daily_pnl_summary
-           WHERE total_trades > 0"""
-    ).fetchone()
-    if row and row["total"] and row["total"] > 0:
-        return round(float(row["wins"] or 0) / float(row["total"]), 4)
-    return 0.0
+    return PnLRepository(conn).get_overall_win_rate()
 
 
 def get_equity_curve(conn: sqlite3.Connection, days: int, start_equity: float) -> list:
     """Build equity curve from daily_pnl_summary (realized_pnl cumsum)."""
-    cutoff = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=days)).strftime("%Y-%m-%d")
-    rows = conn.execute(
-        """SELECT trade_date, realized_pnl
-           FROM daily_pnl_summary
-           WHERE trade_date >= ?
-           ORDER BY trade_date ASC""",
-        (cutoff,)
-    ).fetchall()
-    series = []
-    equity = start_equity
-    for r in rows:
-        equity += float(r["realized_pnl"] or 0)
-        series.append({"date": r["trade_date"], "equity": round(equity, 2)})
-    return series
+    return PnLRepository(conn).get_equity_curve(days, start_equity)

--- a/src/openclaw/repositories/__init__.py
+++ b/src/openclaw/repositories/__init__.py
@@ -8,6 +8,8 @@ from openclaw.repositories.position_repository import PositionRepository
 from openclaw.repositories.trace_repository import TraceRepository
 from openclaw.repositories.decision_repository import DecisionRepository
 from openclaw.repositories.signal_repository import SignalRepository
+from openclaw.repositories.pnl_repository import PnLRepository
+from openclaw.repositories.proposal_repository import ProposalRepository
 
 __all__ = [
     "OrderRepository",
@@ -15,4 +17,6 @@ __all__ = [
     "TraceRepository",
     "DecisionRepository",
     "SignalRepository",
+    "PnLRepository",
+    "ProposalRepository",
 ]

--- a/src/openclaw/repositories/order_repository.py
+++ b/src/openclaw/repositories/order_repository.py
@@ -141,3 +141,26 @@ class OrderRepository:
             (order_id,),
         ).fetchone()
         return (float(row[0]), float(row[1])) if row else (0.0, 0.0)
+
+    def get_realized_pnl_today(self) -> float:
+        """Return today's realized PnL from sell fills (UTC+8)."""
+        row = self._conn.execute(
+            """SELECT COALESCE(SUM(f.price * f.qty - f.fee - f.tax), 0.0)
+               FROM fills f
+               JOIN orders o ON f.order_id = o.order_id
+               WHERE date(o.ts_submit, '+8 hours') = date('now', '+8 hours')
+                 AND o.side = 'sell'"""
+        ).fetchone()
+        return float(row[0]) if row else 0.0
+
+    def get_today_filled_symbols(self, side: str) -> set[str]:
+        """Return set of symbols with fills today (UTC+8) for given side."""
+        rows = self._conn.execute(
+            """SELECT DISTINCT o.symbol
+               FROM orders o
+               JOIN fills f ON f.order_id = o.order_id
+               WHERE o.side = ?
+                 AND date(o.ts_submit, '+8 hours') = date('now', '+8 hours')""",
+            (side,),
+        ).fetchall()
+        return {r[0] for r in rows}

--- a/src/openclaw/repositories/pnl_repository.py
+++ b/src/openclaw/repositories/pnl_repository.py
@@ -1,0 +1,227 @@
+"""pnl_repository.py — Data access for P&L computation tables.
+
+Encapsulates all SQL operations on ``daily_pnl_summary``, ``positions``
+(sync/backfill), and the cost-basis query across ``orders+fills``.
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+import sqlite3
+from typing import List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+class PnLRepository:
+    """Encapsulates daily_pnl_summary + cost-basis + positions sync."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    # ── Cost basis ──────────────────────────────────────────────────────
+
+    def get_avg_cost(self, symbol: str) -> Tuple[float, int]:
+        """Return (avg_buy_price, net_qty) for a symbol from orders+fills."""
+        row = self._conn.execute(
+            """
+            SELECT
+              SUM(CASE WHEN o.side='buy'  THEN f.qty ELSE 0 END)
+            - SUM(CASE WHEN o.side='sell' THEN f.qty ELSE 0 END) AS net_qty,
+              ROUND(
+                SUM(CASE WHEN o.side='buy' THEN f.qty * f.price ELSE 0 END)
+                / MAX(SUM(CASE WHEN o.side='buy' THEN f.qty ELSE 0 END), 1),
+              4) AS avg_price
+            FROM orders o
+            JOIN fills f ON f.order_id = o.order_id
+            WHERE UPPER(o.symbol) = UPPER(?)
+              AND o.status IN ('filled', 'partially_filled')
+            """,
+            (symbol,),
+        ).fetchone()
+        if row and row["net_qty"] and row["net_qty"] > 0:
+            return float(row["avg_price"]), int(row["net_qty"])
+        return 0.0, 0
+
+    # ── Daily PnL summary ──────────────────────────────────────────────
+
+    def upsert_daily_pnl(
+        self,
+        trade_date: str,
+        delta_realized: float,
+        delta_trades: int,
+    ) -> None:
+        """Add delta to daily_pnl_summary for trade_date (upsert)."""
+        existing = self._conn.execute(
+            "SELECT realized_pnl, total_trades FROM daily_pnl_summary WHERE trade_date=?",
+            (trade_date,),
+        ).fetchone()
+
+        if existing:
+            new_pnl = (existing["realized_pnl"] or 0.0) + delta_realized
+            new_total = (existing["total_trades"] or 0) + delta_trades
+            win_rate = self.compute_rolling_win_rate(trade_date, new_pnl)
+            self._conn.execute(
+                """UPDATE daily_pnl_summary
+                   SET realized_pnl=?, total_pnl=?, total_trades=?,
+                       rolling_win_rate=?
+                   WHERE trade_date=?""",
+                (round(new_pnl, 2), round(new_pnl, 2), new_total, win_rate, trade_date),
+            )
+        else:
+            win_rate = 1.0 if delta_realized > 0 else 0.0
+            self._conn.execute(
+                """INSERT INTO daily_pnl_summary
+                   (trade_date, realized_pnl, unrealized_pnl, total_pnl,
+                    total_trades, rolling_drawdown, consecutive_losses,
+                    losing_streak_days, rolling_win_rate)
+                   VALUES (?,?,0.0,?,?,0.0,?,0,?)""",
+                (
+                    trade_date,
+                    round(delta_realized, 2),
+                    round(delta_realized, 2),
+                    delta_trades,
+                    1 if delta_realized < 0 else 0,
+                    win_rate,
+                ),
+            )
+        self._conn.commit()
+
+    def compute_rolling_win_rate(
+        self,
+        up_to_date: str,
+        today_pnl: float,
+    ) -> float:
+        """Rolling win rate: % of trading days with realized_pnl > 0 (last 20 days)."""
+        rows = self._conn.execute(
+            """SELECT realized_pnl FROM daily_pnl_summary
+               WHERE trade_date < ?
+               ORDER BY trade_date DESC LIMIT 19""",
+            (up_to_date,),
+        ).fetchall()
+        all_pnls = [r["realized_pnl"] for r in rows] + [today_pnl]
+        if not all_pnls:
+            return 0.0
+        wins = sum(1 for p in all_pnls if p > 0)
+        return round(wins / len(all_pnls), 4)
+
+    # ── Positions sync ─────────────────────────────────────────────────
+
+    def sync_positions(self) -> None:
+        """Recompute positions table from orders+fills (net qty, avg_cost)."""
+        self._conn.execute("DELETE FROM positions")
+        if _table_exists(self._conn, "position_quarantine"):
+            self._conn.execute(
+                """
+                INSERT INTO positions (symbol, quantity, avg_price, entry_trading_day)
+                SELECT
+                  o.symbol,
+                  SUM(CASE WHEN o.side='buy'  THEN f.qty ELSE 0 END)
+                - SUM(CASE WHEN o.side='sell' THEN f.qty ELSE 0 END) AS net_qty,
+                  ROUND(
+                    SUM(CASE WHEN o.side='buy' THEN f.qty * f.price ELSE 0 END)
+                    / MAX(SUM(CASE WHEN o.side='buy' THEN f.qty ELSE 0 END), 1),
+                  4) AS avg_price,
+                  MIN(CASE WHEN o.side='buy' THEN date(o.ts_submit) END) AS entry_trading_day
+                FROM orders o
+                JOIN fills f ON f.order_id = o.order_id
+                LEFT JOIN position_quarantine q
+                  ON UPPER(q.symbol) = UPPER(o.symbol)
+                 AND q.active = 1
+                WHERE o.status IN ('filled', 'partially_filled')
+                  AND q.symbol IS NULL
+                GROUP BY o.symbol
+                HAVING net_qty > 0
+                """
+            )
+        else:
+            self._conn.execute(
+                """
+                INSERT INTO positions (symbol, quantity, avg_price, entry_trading_day)
+                SELECT
+                  o.symbol,
+                  SUM(CASE WHEN o.side='buy'  THEN f.qty ELSE 0 END)
+                - SUM(CASE WHEN o.side='sell' THEN f.qty ELSE 0 END) AS net_qty,
+                  ROUND(
+                    SUM(CASE WHEN o.side='buy' THEN f.qty * f.price ELSE 0 END)
+                    / MAX(SUM(CASE WHEN o.side='buy' THEN f.qty ELSE 0 END), 1),
+                  4) AS avg_price,
+                  MIN(CASE WHEN o.side='buy' THEN date(o.ts_submit) END) AS entry_trading_day
+                FROM orders o
+                JOIN fills f ON f.order_id = o.order_id
+                WHERE o.status IN ('filled', 'partially_filled')
+                GROUP BY o.symbol
+                HAVING net_qty > 0
+                """
+            )
+        self._conn.commit()
+        self.backfill_high_water_mark()
+
+    def backfill_high_water_mark(self) -> None:
+        """Set high_water_mark from eod_prices max(close) since entry."""
+        try:
+            self._conn.execute(
+                """UPDATE positions SET high_water_mark = (
+                     SELECT MAX(e.close) FROM eod_prices e
+                     WHERE e.symbol = positions.symbol
+                       AND e.trade_date >= COALESCE(positions.entry_trading_day, '2000-01-01')
+                   )
+                   WHERE high_water_mark IS NULL AND quantity > 0"""
+            )
+            self._conn.commit()
+        except sqlite3.Error as e:
+            log.warning("backfill_high_water_mark failed: %s", e)
+
+    # ── API helpers ─────────────────────────────────────────────────────
+
+    def get_today_pnl(self, trade_date: str) -> float:
+        row = self._conn.execute(
+            "SELECT realized_pnl FROM daily_pnl_summary WHERE trade_date=?",
+            (trade_date,),
+        ).fetchone()
+        return float(row["realized_pnl"]) if row and row["realized_pnl"] is not None else 0.0
+
+    def get_monthly_pnl(self, month_prefix: str) -> float:
+        row = self._conn.execute(
+            "SELECT SUM(realized_pnl) AS total FROM daily_pnl_summary WHERE trade_date LIKE ?",
+            (f"{month_prefix}%",),
+        ).fetchone()
+        return float(row["total"]) if row and row["total"] is not None else 0.0
+
+    def get_overall_win_rate(self) -> float:
+        row = self._conn.execute(
+            """SELECT
+                 SUM(CASE WHEN realized_pnl > 0 THEN 1 ELSE 0 END) AS wins,
+                 COUNT(1) AS total
+               FROM daily_pnl_summary
+               WHERE total_trades > 0"""
+        ).fetchone()
+        if row and row["total"] and row["total"] > 0:
+            return round(float(row["wins"] or 0) / float(row["total"]), 4)
+        return 0.0
+
+    def get_equity_curve(self, days: int, start_equity: float) -> List[dict]:
+        cutoff = (
+            datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=days)
+        ).strftime("%Y-%m-%d")
+        rows = self._conn.execute(
+            """SELECT trade_date, realized_pnl
+               FROM daily_pnl_summary
+               WHERE trade_date >= ?
+               ORDER BY trade_date ASC""",
+            (cutoff,),
+        ).fetchall()
+        series = []
+        equity = start_equity
+        for r in rows:
+            equity += float(r["realized_pnl"] or 0)
+            series.append({"date": r["trade_date"], "equity": round(equity, 2)})
+        return series

--- a/src/openclaw/repositories/proposal_repository.py
+++ b/src/openclaw/repositories/proposal_repository.py
@@ -1,0 +1,217 @@
+"""proposal_repository.py — Data access for strategy_proposals and execution journal.
+
+Encapsulates SQL operations on ``strategy_proposals`` and
+``proposal_execution_journal`` tables, used by proposal_executor.py,
+proposal_engine.py, and concentration_guard.py.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from typing import Any, Dict, List, Optional
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+class ProposalRepository:
+    """Encapsulates strategy_proposals + proposal_execution_journal access."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    # ── strategy_proposals reads ────────────────────────────────────────
+
+    def get_actionable_proposals(
+        self,
+        statuses: tuple[str, ...] = ("approved", "queued", "executing"),
+    ) -> List[sqlite3.Row]:
+        """Return proposals with given statuses that haven't expired."""
+        placeholders = ",".join("?" * len(statuses))
+        return self._conn.execute(
+            f"""SELECT proposal_id, target_rule, proposal_json, status
+               FROM strategy_proposals
+               WHERE status IN ({placeholders})
+                 AND (expires_at IS NULL OR expires_at > ?)""",
+            (*statuses, int(time.time())),
+        ).fetchall()
+
+    def get_pending_by_rule(
+        self,
+        target_rule: str,
+        statuses: tuple[str, ...] = ("pending",),
+    ) -> List[sqlite3.Row]:
+        placeholders = ",".join("?" * len(statuses))
+        return self._conn.execute(
+            f"""SELECT * FROM strategy_proposals
+               WHERE target_rule = ? AND status IN ({placeholders})
+               ORDER BY created_at DESC""",
+            (target_rule, *statuses),
+        ).fetchall()
+
+    def get_recent_by_rule(
+        self,
+        target_rule: str,
+        since_ms: int,
+    ) -> List[sqlite3.Row]:
+        return self._conn.execute(
+            """SELECT * FROM strategy_proposals
+               WHERE target_rule = ? AND created_at > ?
+               ORDER BY created_at DESC""",
+            (target_rule, since_ms),
+        ).fetchall()
+
+    # ── strategy_proposals writes ───────────────────────────────────────
+
+    def update_status(
+        self,
+        proposal_id: str,
+        status: str,
+        decided_at: Optional[int] = None,
+    ) -> None:
+        ts = decided_at or _now_ms()
+        self._conn.execute(
+            "UPDATE strategy_proposals SET status=?, decided_at=? WHERE proposal_id=?",
+            (status, ts, proposal_id),
+        )
+
+    def insert_proposal(
+        self,
+        *,
+        proposal_id: str,
+        generated_by: str,
+        target_rule: str,
+        rule_category: str = "",
+        proposed_value: str = "",
+        supporting_evidence: str = "",
+        confidence: float = 0.0,
+        requires_human_approval: bool = False,
+        status: str = "pending",
+        proposal_json: Optional[str] = None,
+        expires_at: Optional[int] = None,
+    ) -> None:
+        now = _now_ms()
+        self._conn.execute(
+            """INSERT INTO strategy_proposals
+               (proposal_id, generated_by, target_rule, rule_category,
+                proposed_value, supporting_evidence, confidence,
+                requires_human_approval, status, proposal_json,
+                created_at, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                proposal_id,
+                generated_by,
+                target_rule,
+                rule_category,
+                proposed_value,
+                supporting_evidence,
+                confidence,
+                int(requires_human_approval),
+                status,
+                proposal_json or "{}",
+                now,
+                expires_at,
+            ),
+        )
+
+    def expire_stale_noted(self, max_age_ms: int = 48 * 60 * 60 * 1000) -> int:
+        """Expire 'noted' proposals older than max_age_ms. Returns count."""
+        cutoff = _now_ms() - max_age_ms
+        cursor = self._conn.execute(
+            """UPDATE strategy_proposals
+               SET status = 'expired', decided_at = ?
+               WHERE status = 'noted' AND created_at < ?""",
+            (_now_ms(), cutoff),
+        )
+        n = cursor.rowcount
+        if n > 0:
+            self._conn.commit()
+        return n
+
+    def has_active_sell_order(self, symbol: str) -> bool:
+        """Check if there's an active submitted sell order for symbol."""
+        row = self._conn.execute(
+            """SELECT 1 FROM orders
+               WHERE symbol = ? AND side = 'sell' AND status = 'submitted'
+               LIMIT 1""",
+            (symbol,),
+        ).fetchone()
+        return row is not None
+
+    def count_daily_sell_proposals(self, symbol: str, trade_date: str) -> int:
+        """Count concentration sell proposals for symbol today."""
+        row = self._conn.execute(
+            """SELECT COUNT(*) FROM strategy_proposals
+               WHERE target_rule = 'POSITION_REBALANCE'
+                 AND proposal_json LIKE ?
+                 AND created_at >= ?""",
+            (f'%"{symbol}"%', int(time.mktime(time.strptime(trade_date, "%Y-%m-%d")) * 1000)),
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    # ── execution journal reads ─────────────────────────────────────────
+
+    def load_journal(self, execution_key: str) -> Optional[sqlite3.Row]:
+        return self._conn.execute(
+            "SELECT * FROM proposal_execution_journal WHERE execution_key=?",
+            (execution_key,),
+        ).fetchone()
+
+    # ── execution journal writes ────────────────────────────────────────
+
+    def upsert_journal(
+        self,
+        *,
+        execution_key: str,
+        proposal_id: str,
+        target_rule: str,
+        symbol: str,
+        qty: int,
+        price: float,
+        state: str = "prepared",
+    ) -> None:
+        now = _now_ms()
+        existing = self.load_journal(execution_key)
+        if existing is None:
+            self._conn.execute(
+                """INSERT INTO proposal_execution_journal
+                   (execution_key, proposal_id, target_rule, symbol, qty, price,
+                    state, attempt_count, last_order_id, last_error, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, ?, ?)""",
+                (execution_key, proposal_id, target_rule, symbol, qty, price, state, now, now),
+            )
+            self._conn.commit()
+
+    def update_journal_state(
+        self,
+        execution_key: str,
+        state: str,
+        *,
+        increment_attempt: bool = False,
+        last_order_id: Optional[str] = None,
+        last_error: Optional[str] = None,
+    ) -> None:
+        now = _now_ms()
+        if increment_attempt:
+            self._conn.execute(
+                """UPDATE proposal_execution_journal
+                   SET state=?, attempt_count=attempt_count+1, updated_at=?
+                   WHERE execution_key=?""",
+                (state, now, execution_key),
+            )
+        else:
+            parts = ["state=?", "updated_at=?"]
+            params: list = [state, now]
+            if last_order_id is not None:
+                parts.append("last_order_id=?")
+                params.append(last_order_id)
+            if last_error is not None:
+                parts.append("last_error=?")
+                params.append(last_error)
+            params.append(execution_key)
+            self._conn.execute(
+                f"UPDATE proposal_execution_journal SET {', '.join(parts)} WHERE execution_key=?",
+                params,
+            )

--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -131,14 +131,7 @@ def _load_sim_nav() -> float:
 def _get_realized_pnl_today(conn: sqlite3.Connection) -> float:
     """查詢今日（UTC+8）已實現損益。"""
     try:
-        row = conn.execute(
-            """SELECT COALESCE(SUM(f.price * f.qty - f.fee - f.tax), 0.0)
-               FROM fills f
-               JOIN orders o ON f.order_id = o.order_id
-               WHERE date(o.ts_submit, '+8 hours') = date('now', '+8 hours')
-                 AND o.side = 'sell'"""
-        ).fetchone()
-        return float(row[0]) if row else 0.0
+        return OrderRepository(conn).get_realized_pnl_today()
     except sqlite3.Error as e:
         log.warning("_get_realized_pnl_today failed: %s", e)
         return 0.0
@@ -158,10 +151,7 @@ def _check_broker_connected(sj_instance) -> bool:
 def _get_orders_last_60s(conn: sqlite3.Connection) -> int:
     """計算最近 60 秒內的訂單數。"""
     try:
-        row = conn.execute(
-            "SELECT COUNT(*) FROM orders WHERE ts_submit >= datetime('now', '-1 minute')"
-        ).fetchone()
-        return int(row[0]) if row else 0
+        return OrderRepository(conn).count_orders_last_minute()
     except sqlite3.Error as e:
         log.warning("_get_orders_last_60s failed: %s", e)
         return 0
@@ -170,14 +160,7 @@ def _get_orders_last_60s(conn: sqlite3.Connection) -> int:
 def _get_today_buy_filled_symbols(conn: sqlite3.Connection) -> set:
     """返回今日（UTC+8）已有 fills 的 buy 訂單 symbol 集合，用於 wash sale 防護。"""
     try:
-        rows = conn.execute(
-            """SELECT DISTINCT o.symbol
-               FROM orders o
-               JOIN fills f ON f.order_id = o.order_id
-               WHERE o.side = 'buy'
-                 AND date(o.ts_submit, '+8 hours') = date('now', '+8 hours')"""
-        ).fetchall()
-        return {r[0] for r in rows}
+        return OrderRepository(conn).get_today_filled_symbols("buy")
     except sqlite3.Error as e:
         log.warning("_get_today_buy_filled_symbols failed: %s", e)
         return set()
@@ -189,14 +172,7 @@ def _get_today_sell_filled_symbols(conn: sqlite3.Connection) -> set:
     用於 wash sale 防護 #386：同日賣出後禁止買回。
     """
     try:
-        rows = conn.execute(
-            """SELECT DISTINCT o.symbol
-               FROM orders o
-               JOIN fills f ON f.order_id = o.order_id
-               WHERE o.side = 'sell'
-                 AND date(o.ts_submit, '+8 hours') = date('now', '+8 hours')"""
-        ).fetchall()
-        return {r[0] for r in rows}
+        return OrderRepository(conn).get_today_filled_symbols("sell")
     except sqlite3.Error as e:
         log.warning("_get_today_sell_filled_symbols failed: %s", e)
         return set()

--- a/tests/test_repositories/test_pnl_repository.py
+++ b/tests/test_repositories/test_pnl_repository.py
@@ -1,0 +1,151 @@
+"""Tests for PnLRepository."""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from openclaw.repositories.pnl_repository import PnLRepository
+
+
+@pytest.fixture()
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.executescript("""
+        CREATE TABLE orders (
+            order_id TEXT PRIMARY KEY, symbol TEXT, side TEXT,
+            status TEXT, ts_submit TEXT
+        );
+        CREATE TABLE fills (
+            fill_id TEXT, order_id TEXT, qty INTEGER, price REAL,
+            fee REAL DEFAULT 0, tax REAL DEFAULT 0
+        );
+        CREATE TABLE positions (
+            symbol TEXT PRIMARY KEY, quantity INTEGER, avg_price REAL,
+            current_price REAL DEFAULT 0, unrealized_pnl REAL DEFAULT 0,
+            state TEXT DEFAULT 'ACTIVE', high_water_mark REAL,
+            entry_trading_day TEXT
+        );
+        CREATE TABLE daily_pnl_summary (
+            trade_date TEXT PRIMARY KEY, realized_pnl REAL,
+            unrealized_pnl REAL DEFAULT 0, total_pnl REAL DEFAULT 0,
+            total_trades INTEGER DEFAULT 0, rolling_drawdown REAL DEFAULT 0,
+            consecutive_losses INTEGER DEFAULT 0,
+            losing_streak_days INTEGER DEFAULT 0,
+            rolling_win_rate REAL DEFAULT 0
+        );
+        CREATE TABLE eod_prices (
+            trade_date TEXT, symbol TEXT, open REAL, high REAL,
+            low REAL, close REAL, volume INTEGER
+        );
+    """)
+    return c
+
+
+@pytest.fixture()
+def repo(conn):
+    return PnLRepository(conn)
+
+
+class TestGetAvgCost:
+    def test_returns_zero_when_no_orders(self, repo):
+        avg, qty = repo.get_avg_cost("2330")
+        assert avg == 0.0
+        assert qty == 0
+
+    def test_computes_avg_cost(self, conn, repo):
+        conn.execute("INSERT INTO orders VALUES ('o1','2330','buy','filled','2026-03-28')")
+        conn.execute("INSERT INTO fills VALUES ('f1','o1',1000,500.0,0,0)")
+        avg, qty = repo.get_avg_cost("2330")
+        assert qty == 1000
+        assert avg == 500.0
+
+
+class TestUpsertDailyPnl:
+    def test_inserts_new_record(self, conn, repo):
+        repo.upsert_daily_pnl("2026-03-28", 1000.0, 1)
+        row = conn.execute("SELECT * FROM daily_pnl_summary WHERE trade_date='2026-03-28'").fetchone()
+        assert row["realized_pnl"] == 1000.0
+        assert row["total_trades"] == 1
+
+    def test_updates_existing_record(self, conn, repo):
+        repo.upsert_daily_pnl("2026-03-28", 1000.0, 1)
+        repo.upsert_daily_pnl("2026-03-28", 500.0, 1)
+        row = conn.execute("SELECT * FROM daily_pnl_summary WHERE trade_date='2026-03-28'").fetchone()
+        assert row["realized_pnl"] == 1500.0
+        assert row["total_trades"] == 2
+
+
+class TestSyncPositions:
+    def test_syncs_from_orders_fills(self, conn, repo):
+        conn.execute("INSERT INTO orders VALUES ('o1','2330','buy','filled','2026-03-28')")
+        conn.execute("INSERT INTO fills VALUES ('f1','o1',1000,500.0,0,0)")
+        repo.sync_positions()
+        row = conn.execute("SELECT * FROM positions WHERE symbol='2330'").fetchone()
+        assert row["quantity"] == 1000
+        assert row["avg_price"] == 500.0
+
+    def test_excludes_sold_positions(self, conn, repo):
+        conn.execute("INSERT INTO orders VALUES ('o1','2330','buy','filled','2026-03-28')")
+        conn.execute("INSERT INTO fills VALUES ('f1','o1',1000,500.0,0,0)")
+        conn.execute("INSERT INTO orders VALUES ('o2','2330','sell','filled','2026-03-28')")
+        conn.execute("INSERT INTO fills VALUES ('f2','o2',1000,510.0,0,0)")
+        repo.sync_positions()
+        row = conn.execute("SELECT * FROM positions WHERE symbol='2330'").fetchone()
+        assert row is None  # net_qty = 0, excluded
+
+
+class TestGetTodayPnl:
+    def test_returns_zero_when_no_data(self, repo):
+        assert repo.get_today_pnl("2026-03-28") == 0.0
+
+    def test_returns_pnl(self, conn, repo):
+        conn.execute(
+            "INSERT INTO daily_pnl_summary (trade_date, realized_pnl, total_trades) VALUES (?, ?, ?)",
+            ("2026-03-28", 1500.0, 3),
+        )
+        assert repo.get_today_pnl("2026-03-28") == 1500.0
+
+
+class TestGetMonthlyPnl:
+    def test_returns_sum(self, conn, repo):
+        conn.execute(
+            "INSERT INTO daily_pnl_summary (trade_date, realized_pnl, total_trades) VALUES (?, ?, ?)",
+            ("2026-03-27", 1000.0, 1),
+        )
+        conn.execute(
+            "INSERT INTO daily_pnl_summary (trade_date, realized_pnl, total_trades) VALUES (?, ?, ?)",
+            ("2026-03-28", 500.0, 1),
+        )
+        assert repo.get_monthly_pnl("2026-03") == 1500.0
+
+
+class TestGetOverallWinRate:
+    def test_returns_zero_when_no_data(self, repo):
+        assert repo.get_overall_win_rate() == 0.0
+
+    def test_computes_win_rate(self, conn, repo):
+        for i, pnl in enumerate([100, -50, 200]):
+            conn.execute(
+                "INSERT INTO daily_pnl_summary (trade_date, realized_pnl, total_trades) VALUES (?, ?, 1)",
+                (f"2026-03-{26+i}", pnl),
+            )
+        assert repo.get_overall_win_rate() == round(2 / 3, 4)
+
+
+class TestBackfillHighWaterMark:
+    def test_backfills_from_eod(self, conn, repo):
+        conn.execute(
+            "INSERT INTO positions (symbol, quantity, avg_price, entry_trading_day) VALUES (?, ?, ?, ?)",
+            ("2330", 1000, 500.0, "2026-03-01"),
+        )
+        conn.execute(
+            "INSERT INTO eod_prices VALUES ('2026-03-15', '2330', 500, 550, 490, 540, 10000)"
+        )
+        conn.execute(
+            "INSERT INTO eod_prices VALUES ('2026-03-20', '2330', 540, 560, 530, 555, 12000)"
+        )
+        repo.backfill_high_water_mark()
+        row = conn.execute("SELECT high_water_mark FROM positions WHERE symbol='2330'").fetchone()
+        assert row["high_water_mark"] == 555.0  # max(close) from eod_prices

--- a/tests/test_repositories/test_proposal_repository.py
+++ b/tests/test_repositories/test_proposal_repository.py
@@ -1,0 +1,147 @@
+"""Tests for ProposalRepository."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from openclaw.repositories.proposal_repository import ProposalRepository
+
+
+@pytest.fixture()
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.executescript("""
+        CREATE TABLE strategy_proposals (
+            proposal_id TEXT PRIMARY KEY,
+            generated_by TEXT,
+            target_rule TEXT,
+            rule_category TEXT,
+            proposed_value TEXT,
+            supporting_evidence TEXT,
+            confidence REAL,
+            requires_human_approval INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'pending',
+            proposal_json TEXT,
+            created_at INTEGER,
+            decided_at INTEGER,
+            expires_at INTEGER
+        );
+        CREATE TABLE proposal_execution_journal (
+            execution_key TEXT PRIMARY KEY,
+            proposal_id TEXT NOT NULL,
+            target_rule TEXT NOT NULL,
+            symbol TEXT,
+            qty INTEGER,
+            price REAL,
+            state TEXT NOT NULL,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            last_order_id TEXT,
+            last_error TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE orders (
+            order_id TEXT PRIMARY KEY, symbol TEXT, side TEXT,
+            status TEXT, ts_submit TEXT
+        );
+    """)
+    return c
+
+
+@pytest.fixture()
+def repo(conn):
+    return ProposalRepository(conn)
+
+
+class TestInsertProposal:
+    def test_inserts_proposal(self, conn, repo):
+        repo.insert_proposal(
+            proposal_id="p1",
+            generated_by="concentration_guard",
+            target_rule="POSITION_REBALANCE",
+            confidence=0.8,
+        )
+        row = conn.execute("SELECT * FROM strategy_proposals WHERE proposal_id='p1'").fetchone()
+        assert row["target_rule"] == "POSITION_REBALANCE"
+        assert row["confidence"] == 0.8
+
+
+class TestUpdateStatus:
+    def test_updates_status(self, conn, repo):
+        repo.insert_proposal(
+            proposal_id="p1", generated_by="test", target_rule="X",
+        )
+        repo.update_status("p1", "approved")
+        row = conn.execute("SELECT status FROM strategy_proposals WHERE proposal_id='p1'").fetchone()
+        assert row["status"] == "approved"
+
+
+class TestGetActionableProposals:
+    def test_returns_matching_proposals(self, conn, repo):
+        repo.insert_proposal(
+            proposal_id="p1", generated_by="test", target_rule="X", status="approved",
+        )
+        repo.insert_proposal(
+            proposal_id="p2", generated_by="test", target_rule="Y", status="pending",
+        )
+        rows = repo.get_actionable_proposals()
+        assert len(rows) == 1
+        assert rows[0]["proposal_id"] == "p1"
+
+
+class TestExpireStaleNoted:
+    def test_expires_old_noted(self, conn, repo):
+        # Insert a noted proposal with old created_at
+        old_ts = int(time.time() * 1000) - 72 * 60 * 60 * 1000  # 72h ago
+        conn.execute(
+            """INSERT INTO strategy_proposals
+               (proposal_id, generated_by, target_rule, status, created_at, proposal_json)
+               VALUES (?, ?, ?, 'noted', ?, '{}')""",
+            ("p1", "test", "X", old_ts),
+        )
+        conn.commit()
+        n = repo.expire_stale_noted()
+        assert n == 1
+        row = conn.execute("SELECT status FROM strategy_proposals WHERE proposal_id='p1'").fetchone()
+        assert row["status"] == "expired"
+
+
+class TestHasActiveSellOrder:
+    def test_false_when_no_orders(self, repo):
+        assert repo.has_active_sell_order("2330") is False
+
+    def test_true_when_submitted_sell(self, conn, repo):
+        conn.execute(
+            "INSERT INTO orders VALUES ('o1', '2330', 'sell', 'submitted', '2026-03-28')"
+        )
+        assert repo.has_active_sell_order("2330") is True
+
+
+class TestJournal:
+    def test_upsert_and_load(self, conn, repo):
+        repo.upsert_journal(
+            execution_key="ek1", proposal_id="p1",
+            target_rule="POSITION_REBALANCE",
+            symbol="2330", qty=100, price=500.0,
+        )
+        row = repo.load_journal("ek1")
+        assert row is not None
+        assert row["proposal_id"] == "p1"
+        assert row["state"] == "prepared"
+
+    def test_update_journal_state(self, conn, repo):
+        repo.upsert_journal(
+            execution_key="ek1", proposal_id="p1",
+            target_rule="X", symbol="2330", qty=100, price=500.0,
+        )
+        repo.update_journal_state("ek1", "executing", increment_attempt=True)
+        row = repo.load_journal("ek1")
+        assert row["state"] == "executing"
+        assert row["attempt_count"] == 1
+
+    def test_load_nonexistent_returns_none(self, repo):
+        assert repo.load_journal("nonexistent") is None


### PR DESCRIPTION
## Summary

- **PnLRepository** (新建): 封裝 pnl_engine.py 全部 14 個 SQL 操作（成本計算、損益摘要、持倉同步、HWM 回填、權益曲線）
- **ProposalRepository** (新建): 封裝 strategy_proposals + proposal_execution_journal 完整 CRUD，供 proposal_executor/engine/concentration_guard 使用
- **OrderRepository 擴充**: get_realized_pnl_today、get_today_filled_symbols（wash sale 防護）
- **ticker_watcher.py 遷移**: 4 個 helper 函數改為委託 Repository

## Test plan

- [x] `python -m pytest` — 2503 passed, 0 failed
- [x] 21 new repository unit tests
- [x] 所有原有函數簽名保持向後相容

https://claude.ai/code/session_011LhoTJuk5FAaZMaHVzWC41