### PR TITLE
refactor: final batch — proposal_engine migration (closing refactoring series)

### DIFF
--- a/src/openclaw/proposal_engine.py
+++ b/src/openclaw/proposal_engine.py
@@ -211,30 +211,24 @@ def approve_proposal(
     decision_reason: Optional[str] = None
 ) -> Dict[str, Any]:
     """Approve a proposal."""
+    from openclaw.repositories.proposal_repository import ProposalRepository
+    repo = ProposalRepository(conn)
+
     proposal = _get_proposal(conn, proposal_id)
     if proposal is None:
         return {"success": False, "reason": "PROPOSAL_NOT_FOUND"}
-    
+
     if proposal["status"] != "pending":
         return {"success": False, "reason": f"INVALID_STATUS_{proposal['status']}"}
-    
+
     # Check expiration
     if proposal["expires_at"] and proposal["expires_at"] < int(datetime.now(timezone.utc).timestamp() * 1000):
         _expire_proposal(conn, proposal_id)
         return {"success": False, "reason": "PROPOSAL_EXPIRED"}
-    
-    # Update status
-    now = int(datetime.now(timezone.utc).timestamp() * 1000)
-    conn.execute(
-        """
-        UPDATE strategy_proposals 
-        SET status = 'approved', decided_at = ?, decided_by = ?, decision_reason = ?
-        WHERE proposal_id = ?
-        """,
-        (now, decided_by, decision_reason or "Approved", proposal_id)
-    )
+
+    repo.update_decision(proposal_id, "approved", decided_by, decision_reason or "Approved")
     conn.commit()
-    
+
     return {"success": True, "proposal_id": proposal_id, "status": "approved"}
 
 
@@ -251,48 +245,26 @@ def reject_proposal(
     
     if proposal["status"] != "pending":
         return {"success": False, "reason": f"INVALID_STATUS_{proposal['status']}"}
-    
-    now = int(datetime.now(timezone.utc).timestamp() * 1000)
-    conn.execute(
-        """
-        UPDATE strategy_proposals 
-        SET status = 'rejected', decided_at = ?, decided_by = ?, decision_reason = ?
-        WHERE proposal_id = ?
-        """,
-        (now, decided_by, decision_reason, proposal_id)
-    )
+
+    from openclaw.repositories.proposal_repository import ProposalRepository
+    ProposalRepository(conn).update_decision(proposal_id, "rejected", decided_by, decision_reason)
     conn.commit()
-    
+
     return {"success": True, "proposal_id": proposal_id, "status": "rejected"}
 
 
 def _expire_proposal(conn: sqlite3.Connection, proposal_id: str) -> None:
     """Expire a proposal (internal)."""
-    now = int(datetime.now(timezone.utc).timestamp() * 1000)
-    conn.execute(
-        """
-        UPDATE strategy_proposals 
-        SET status = 'expired', decided_at = ?, decision_reason = 'Auto-expired'
-        WHERE proposal_id = ?
-        """,
-        (now, proposal_id)
-    )
+    from openclaw.repositories.proposal_repository import ProposalRepository
+    ProposalRepository(conn).update_decision(proposal_id, "expired", "system", "Auto-expired")
     conn.commit()
 
 
 def expire_old_proposals(conn: sqlite3.Connection) -> int:
     """Expire all pending proposals past their expiration time."""
+    from openclaw.repositories.proposal_repository import ProposalRepository
     now = int(datetime.now(timezone.utc).timestamp() * 1000)
-    cursor = conn.execute(
-        """
-        UPDATE strategy_proposals 
-        SET status = 'expired', decided_at = ?, decision_reason = 'Auto-expired'
-        WHERE status = 'pending' AND expires_at IS NOT NULL AND expires_at < ?
-        """,
-        (now, now)
-    )
-    conn.commit()
-    return cursor.rowcount
+    return ProposalRepository(conn).expire_pending_proposals(now)
 
 
 def _get_proposal(conn: sqlite3.Connection, proposal_id: str) -> Optional[Dict[str, Any]]:
@@ -438,12 +410,12 @@ def apply_authority_decision(conn: sqlite3.Connection, proposal_id: str) -> Dict
     """
     Legacy function for ref_package test compatibility.
     """
+    from openclaw.repositories.proposal_repository import ProposalRepository
+    repo = ProposalRepository(conn)
+
     row = conn.execute(
-        """
-        SELECT rule_category, auto_approve_eligible, expires_at, status
-        FROM strategy_proposals
-        WHERE proposal_id = ?
-        """,
+        """SELECT rule_category, auto_approve_eligible, expires_at, status
+           FROM strategy_proposals WHERE proposal_id = ?""",
         (proposal_id,),
     ).fetchone()
     if row is None:
@@ -455,12 +427,12 @@ def apply_authority_decision(conn: sqlite3.Connection, proposal_id: str) -> Dict
     if category in LEVEL3_FORBIDDEN_CATEGORIES:
         return {"allowed": False, "reason_code": "AUTH_LEVEL3_FORBIDDEN"}
     if expires_at < datetime.now(timezone.utc).strftime("%Y-%m-%d"):
-        conn.execute("UPDATE strategy_proposals SET status='expired' WHERE proposal_id = ?", (proposal_id,))
+        repo.update_status(proposal_id, "expired")
         return {"allowed": False, "reason_code": "AUTH_PROPOSAL_EXPIRED"}
 
     level = get_authority_level(conn)
     if level < 2 or int(eligible) != 1:
         return {"allowed": False, "reason_code": "AUTH_MANUAL_REQUIRED"}
 
-    conn.execute("UPDATE strategy_proposals SET status='auto_approved' WHERE proposal_id = ?", (proposal_id,))
+    repo.update_status(proposal_id, "auto_approved")
     return {"allowed": True, "reason_code": "AUTH_AUTO_APPROVED"}

--- a/src/openclaw/repositories/proposal_repository.py
+++ b/src/openclaw/repositories/proposal_repository.py
@@ -92,10 +92,18 @@ class ProposalRepository:
         decided_at: Optional[int] = None,
     ) -> None:
         ts = decided_at or _now_ms()
-        self._conn.execute(
-            "UPDATE strategy_proposals SET status=?, decided_at=? WHERE proposal_id=?",
-            (status, ts, proposal_id),
-        )
+        # Schema-safe: only set decided_at if the column exists
+        cols = {r[1] for r in self._conn.execute("PRAGMA table_info(strategy_proposals)").fetchall()}
+        if "decided_at" in cols:
+            self._conn.execute(
+                "UPDATE strategy_proposals SET status=?, decided_at=? WHERE proposal_id=?",
+                (status, ts, proposal_id),
+            )
+        else:
+            self._conn.execute(
+                "UPDATE strategy_proposals SET status=? WHERE proposal_id=?",
+                (status, proposal_id),
+            )
 
     def insert_proposal(
         self,


### PR DESCRIPTION
## Summary

- **proposal_engine.py**: 6 SQL ops → ProposalRepository 委託（approve/reject/expire/authority decision）
- **ProposalRepository.update_status** 增強：schema-safe decided_at 處理（PRAGMA introspection）
- ticker_watcher 主迴圈拆分評估後決定延後（高風險、低 ROI）

## 重構系列完工總結

| PR | 內容 |
|-----|------|
| #487 | 5-phase 架構重構（ConfigManager, Repository, MarketDataService, GuardChain, Logging） |
| #488 | Deep Repository migration（PnL, Proposal, Order） |
| #489 | Guard Chain 接線 decision_pipeline |
| #490 | proposal_executor + concentration_guard 遷移 |
| **#this** | proposal_engine 遷移（收工） |

**累計成果**：
- 27 個新增檔案（repositories, guards, services, tests）
- 3 個消費端模組完整遷移至 Repository
- 決策管線從 150+ 行 if/else → 7 個可插拔 Guard
- 測試從 2429 → 2503（+74 新測試）
- 0 regressions

## Test plan

- [x] `python -m pytest` — 2503 passed, 0 failed

https://claude.ai/code/session_011LhoTJuk5FAaZMaHVzWC41