### PR TITLE
feat: 策略提案批量審核 (#493)

### DIFF
--- a/frontend/backend/app/api/strategy.py
+++ b/frontend/backend/app/api/strategy.py
@@ -6,7 +6,8 @@ import time
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
 import app.db as db
@@ -39,6 +40,14 @@ def conn_dep():
 class DecideRequest(BaseModel):
     actor: str = "user"
     reason: str = ""
+
+
+class BatchDecideRequest(BaseModel):
+    proposal_ids: list[str]
+    actor: str = "user"
+    reason: str = ""
+
+_BATCH_MAX = 50
 
 
 def _now_iso() -> str:
@@ -212,6 +221,123 @@ def reject_strategy_proposal(
         raise HTTPException(status_code=500, detail=f"Failed to reject proposal: {e}")
 
 
+@router.post("/proposals/batch/{action}")
+def batch_decide(action: str, req: BatchDecideRequest):
+    """批量核准或拒絕多筆 pending 提案。
+
+    action: "approve" | "reject"
+    最多 50 筆/次。每筆獨立寫 version_audit_log。
+    已非 pending 的提案放入 failed（不中斷流程）。
+    """
+    action = action.strip().lower()
+    if action not in ("approve", "reject"):
+        raise HTTPException(status_code=400, detail="action must be 'approve' or 'reject'")
+    if not req.proposal_ids:
+        raise HTTPException(status_code=422, detail="proposal_ids must not be empty")
+    if len(req.proposal_ids) > _BATCH_MAX:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Too many proposals: {len(req.proposal_ids)} (max {_BATCH_MAX})",
+        )
+
+    succeeded: list[dict] = []
+    failed: list[dict] = []
+
+    try:
+        with db.get_conn_rw() as conn:
+            _ensure_tables(conn)
+            for pid in req.proposal_ids:
+                row = conn.execute(
+                    "SELECT proposal_id, status FROM strategy_proposals WHERE proposal_id = ?",
+                    (pid,),
+                ).fetchone()
+                if not row:
+                    failed.append({"proposal_id": pid, "reason": "not_found"})
+                    continue
+                if str(row["status"] or "").lower() != "pending":
+                    failed.append({"proposal_id": pid, "reason": f"already_{row['status']}"})
+                    continue
+                try:
+                    updated = _update_proposal_status(
+                        conn,
+                        proposal_id=pid,
+                        new_status=action + ("d" if action == "approve" else "ed"),
+                        actor=req.actor,
+                        reason=req.reason or f"batch_{action}",
+                    )
+                    succeeded.append({"proposal_id": pid, "status": updated.get("status", action)})
+                except Exception as exc:
+                    failed.append({"proposal_id": pid, "reason": str(exc)})
+            conn.commit()
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Batch {action} failed: {e}")
+
+    return {
+        "status": "ok",
+        "action": action,
+        "total": len(req.proposal_ids),
+        "succeeded": succeeded,
+        "failed": failed,
+    }
+
+
+@router.get("/proposals/batch-approve-all", response_class=HTMLResponse)
+def batch_approve_all_url(token: str = Query(...)):
+    """一鍵核准所有 pending 提案（Telegram URL button 用）。"""
+    import os
+    if token != os.environ.get("AUTH_TOKEN", ""):
+        return HTMLResponse("<h2>❌ 無效 token</h2>", status_code=403)
+
+    approved_ids: list[str] = []
+    with db.get_conn_rw() as conn:
+        _ensure_tables(conn)
+        rows = conn.execute(
+            "SELECT proposal_id, target_rule FROM strategy_proposals WHERE status = 'pending'"
+        ).fetchall()
+        now_ts = int(time.time())
+        for row in rows:
+            pid = row["proposal_id"]
+            conn.execute(
+                "UPDATE strategy_proposals SET status='approved', decided_at=? WHERE proposal_id=?",
+                (now_ts, pid),
+            )
+            conn.execute(
+                """INSERT INTO version_audit_log(version_id, action, performed_by, details, performed_at)
+                   VALUES(?, ?, ?, ?, ?)""",
+                (
+                    pid,
+                    "strategy_proposal_approved",
+                    "telegram_batch",
+                    json.dumps({"proposal_id": pid, "from": "pending", "to": "approved",
+                                "reason": "batch_approve_all"}, ensure_ascii=False),
+                    _now_iso(),
+                ),
+            )
+            approved_ids.append(pid[:8])
+        conn.commit()
+
+    n = len(approved_ids)
+    if n == 0:
+        return HTMLResponse("<h2>⚠️ 目前無待審提案</h2><p>可關閉此頁面。</p>")
+
+    try:
+        from openclaw.tg_notify import send_message
+        send_message(
+            f"✅ <b>批量核准完成</b> — 共 {n} 筆提案已核准\n"
+            f"IDs: {', '.join(approved_ids)}…",
+            chat_id=os.environ.get("TELEGRAM_CHAT_ID", "-1003772422881"),
+        )
+    except Exception:
+        pass
+
+    ids_html = "".join(f"<li>{pid}…</li>" for pid in approved_ids)
+    return HTMLResponse(
+        f"<h2>✅ 批量核准完成 — {n} 筆</h2><ul>{ids_html}</ul><p>可關閉此頁面。</p>"
+    )
+
+
 @router.get("/market-rating")
 def get_market_rating(conn: sqlite3.Connection = Depends(conn_dep)):
     """Return latest market rating from episodic_memory or working_memory."""
@@ -350,9 +476,6 @@ def get_debates(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-
-from fastapi import Query
-from fastapi.responses import HTMLResponse
 
 @router.get("/proposals/{proposal_id}/approve", response_class=HTMLResponse)
 def approve_proposal_url(proposal_id: str, token: str = Query(...)):

--- a/frontend/backend/tests/test_batch_decide.py
+++ b/frontend/backend/tests/test_batch_decide.py
@@ -1,0 +1,261 @@
+"""Tests for batch approve/reject API endpoints.
+
+Closes #493
+"""
+import json
+import sqlite3
+import time
+import os
+import importlib
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("AUTH_TOKEN", "test-bearer-token")
+
+
+@pytest.fixture
+def conn(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    c = sqlite3.connect(db_path)
+    c.row_factory = sqlite3.Row
+    c.execute("""
+        CREATE TABLE strategy_proposals (
+            proposal_id TEXT PRIMARY KEY,
+            generated_by TEXT,
+            target_rule TEXT,
+            rule_category TEXT,
+            current_value TEXT,
+            proposed_value TEXT,
+            supporting_evidence TEXT,
+            confidence REAL,
+            requires_human_approval INTEGER DEFAULT 1,
+            status TEXT DEFAULT 'pending',
+            expires_at INTEGER,
+            proposal_json TEXT DEFAULT '{}',
+            created_at INTEGER,
+            decided_at INTEGER,
+            decided_by TEXT,
+            decision_reason TEXT,
+            backtest_sharpe_before REAL,
+            backtest_sharpe_after REAL,
+            auto_approve_eligible INTEGER DEFAULT 0
+        )
+    """)
+    c.execute("""
+        CREATE TABLE version_audit_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            version_id TEXT,
+            action TEXT,
+            performed_by TEXT,
+            details TEXT,
+            performed_at TEXT
+        )
+    """)
+    c.commit()
+    yield c, db_path
+    c.close()
+
+
+def _insert_proposal(c, proposal_id, status="pending"):
+    c.execute(
+        """INSERT INTO strategy_proposals
+           (proposal_id, generated_by, target_rule, rule_category,
+            status, proposal_json, created_at)
+           VALUES (?, 'agent', 'POSITION_REBALANCE', 'test', ?, '{}', ?)""",
+        (proposal_id, status, int(time.time() * 1000)),
+    )
+    c.commit()
+
+
+@pytest.fixture
+def client(conn, monkeypatch):
+    c, db_path = conn
+    # Patch db module to use our test DB
+    import app.db as db_mod
+    monkeypatch.setenv("DB_PATH", db_path)
+    importlib.reload(db_mod)
+
+    from app.main import app
+    from fastapi.testclient import TestClient
+    return TestClient(app), c
+
+
+# ---------------------------------------------------------------------------
+# POST /api/strategy/proposals/batch/{action}
+# ---------------------------------------------------------------------------
+
+class TestBatchDecide:
+    def test_batch_approve_happy_path(self, client):
+        tc, c = client
+        for pid in ("p1", "p2", "p3"):
+            _insert_proposal(c, pid)
+
+        resp = tc.post(
+            "/api/strategy/proposals/batch/approve",
+            json={"proposal_ids": ["p1", "p2", "p3"]},
+            headers={"Authorization": "Bearer test-bearer-token"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "approve"
+        assert data["total"] == 3
+        assert len(data["succeeded"]) == 3
+        assert len(data["failed"]) == 0
+
+        # Verify DB state
+        for pid in ("p1", "p2", "p3"):
+            row = c.execute(
+                "SELECT status FROM strategy_proposals WHERE proposal_id=?", (pid,)
+            ).fetchone()
+            assert row["status"] == "approved"
+
+    def test_batch_reject_happy_path(self, client):
+        tc, c = client
+        _insert_proposal(c, "p1")
+        _insert_proposal(c, "p2")
+
+        resp = tc.post(
+            "/api/strategy/proposals/batch/reject",
+            json={"proposal_ids": ["p1", "p2"]},
+            headers={"Authorization": "Bearer test-bearer-token"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["succeeded"]) == 2
+        for pid in ("p1", "p2"):
+            row = c.execute(
+                "SELECT status FROM strategy_proposals WHERE proposal_id=?", (pid,)
+            ).fetchone()
+            assert row["status"] == "rejected"
+
+    def test_invalid_action_returns_400(self, client):
+        tc, _ = client
+        resp = tc.post(
+            "/api/strategy/proposals/batch/cancel",
+            json={"proposal_ids": ["p1"]},
+            headers={"Authorization": "Bearer test-bearer-token"},
+        )
+        assert resp.status_code == 400
+
+    def test_empty_list_returns_422(self, client):
+        tc, _ = client
+        resp = tc.post(
+            "/api/strategy/proposals/batch/approve",
+            json={"proposal_ids": []},
+            headers={"Authorization": "Bearer test-bearer-token"},
+        )
+        assert resp.status_code == 422
+
+    def test_exceeds_max_returns_422(self, client):
+        tc, _ = client
+        ids = [f"p{i}" for i in range(51)]
+        resp = tc.post(
+            "/api/strategy/proposals/batch/approve",
+            json={"proposal_ids": ids},
+            headers={"Authorization": "Bearer test-bearer-token"},
+        )
+        assert resp.status_code == 422
+        assert "max" in resp.json()["detail"].lower()
+
+    def test_skip_already_decided(self, client):
+        tc, c = client
+        _insert_proposal(c, "p-pending")
+        _insert_proposal(c, "p-approved", status="approved")
+
+        resp = tc.post(
+            "/api/strategy/proposals/batch/approve",
+            json={"proposal_ids": ["p-pending", "p-approved"]},
+            headers={"Authorization": "Bearer test-bearer-token"},
+        )
+        data = resp.json()
+        assert len(data["succeeded"]) == 1
+        assert data["succeeded"][0]["proposal_id"] == "p-pending"
+        assert len(data["failed"]) == 1
+        assert data["failed"][0]["proposal_id"] == "p-approved"
+        assert "already" in data["failed"][0]["reason"]
+
+    def test_not_found_in_failed(self, client):
+        tc, _ = client
+        resp = tc.post(
+            "/api/strategy/proposals/batch/approve",
+            json={"proposal_ids": ["nonexistent"]},
+            headers={"Authorization": "Bearer test-bearer-token"},
+        )
+        data = resp.json()
+        assert len(data["failed"]) == 1
+        assert data["failed"][0]["reason"] == "not_found"
+
+    def test_audit_log_per_proposal(self, client):
+        tc, c = client
+        for pid in ("p1", "p2"):
+            _insert_proposal(c, pid)
+
+        tc.post(
+            "/api/strategy/proposals/batch/approve",
+            json={"proposal_ids": ["p1", "p2"], "reason": "batch test"},
+            headers={"Authorization": "Bearer test-bearer-token"},
+        )
+
+        logs = c.execute("SELECT * FROM version_audit_log ORDER BY id").fetchall()
+        assert len(logs) >= 2
+        pids_logged = {json.loads(r["details"])["proposal_id"] for r in logs}
+        assert "p1" in pids_logged
+        assert "p2" in pids_logged
+
+    def test_batch_with_reason(self, client):
+        tc, c = client
+        _insert_proposal(c, "p1")
+        resp = tc.post(
+            "/api/strategy/proposals/batch/reject",
+            json={"proposal_ids": ["p1"], "reason": "市場異常"},
+            headers={"Authorization": "Bearer test-bearer-token"},
+        )
+        assert resp.status_code == 200
+        log = c.execute(
+            "SELECT details FROM version_audit_log WHERE version_id='p1'"
+        ).fetchone()
+        assert "市場異常" in log["details"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/strategy/proposals/batch-approve-all?token=...
+# ---------------------------------------------------------------------------
+
+class TestBatchApproveAllUrl:
+    def test_approves_all_pending(self, client):
+        tc, c = client
+        for pid in ("p1", "p2", "p3"):
+            _insert_proposal(c, pid)
+
+        resp = tc.get(
+            "/api/strategy/proposals/batch-approve-all?token=test-bearer-token"
+        )
+        assert resp.status_code == 200
+        assert "3 筆" in resp.text
+
+        for pid in ("p1", "p2", "p3"):
+            row = c.execute(
+                "SELECT status FROM strategy_proposals WHERE proposal_id=?", (pid,)
+            ).fetchone()
+            assert row["status"] == "approved"
+
+    def test_no_pending_returns_warning(self, client):
+        tc, _ = client
+        resp = tc.get(
+            "/api/strategy/proposals/batch-approve-all?token=test-bearer-token"
+        )
+        assert resp.status_code == 200
+        assert "無待審" in resp.text
+
+    def test_invalid_token_returns_error(self, client):
+        tc, _ = client
+        resp = tc.get(
+            "/api/strategy/proposals/batch-approve-all?token=wrong"
+        )
+        # Auth middleware may return 401 before handler checks token
+        assert resp.status_code in (401, 403)

--- a/frontend/web/src/lib/strategyApi.js
+++ b/frontend/web/src/lib/strategyApi.js
@@ -89,6 +89,13 @@ export function createStrategyClient(API_BASE) {
         { retries: 0, timeoutMs: 8000 }
       )
     },
+    async batchDecide(action, proposalIds, { actor = 'user', reason = '' } = {}) {
+      return await callApiWithRetry(
+        `${API_BASE}/proposals/batch/${action}`,
+        { method: 'POST', body: JSON.stringify({ proposal_ids: proposalIds, actor, reason }) },
+        { retries: 0, timeoutMs: 15000 }
+      )
+    },
     async marketRating({ timeoutMs = 5000 } = {}) {
       return await callApiWithRetry(
         `${API_BASE}/market-rating`,
@@ -239,6 +246,24 @@ export function useStrategyData({ pollMs = 8000 } = {}) {
     },
     [client, refreshProposals]
   )
+
+  const batchAct = useCallback(
+    async (action, proposalIds, { actor = 'user', reason = '' } = {}) => {
+      setLoading(p => ({ ...p, act: true }))
+      try {
+        const result = await client.batchDecide(action, proposalIds, { actor, reason })
+        await refreshProposals()
+        return result
+      } catch (err) {
+        setError(`批量操作失敗: ${err.message}`)
+        return null
+      } finally {
+        setLoading(p => ({ ...p, act: false }))
+      }
+    },
+    [client, refreshProposals]
+  )
+
   return {
     API_BASE,
     proposals,
@@ -253,6 +278,7 @@ export function useStrategyData({ pollMs = 8000 } = {}) {
     refreshMarketRating,
     refreshSemanticMemory,
     refreshDebates,
-    act
+    act,
+    batchAct
   }
 }

--- a/frontend/web/src/pages/Strategy.jsx
+++ b/frontend/web/src/pages/Strategy.jsx
@@ -595,7 +595,7 @@ function SemanticMemoryTable({ data }) {
 }
 
 export default function StrategyPage() {
-  const { proposals, logs, marketRating, semanticMemory, debates, error, loading, act, refreshProposals, refreshLogs, refreshSemanticMemory } = useStrategyData({ pollMs: 10000 })
+  const { proposals, logs, marketRating, semanticMemory, debates, error, loading, act, batchAct, refreshProposals, refreshLogs, refreshSemanticMemory } = useStrategyData({ pollMs: 10000 })
   const STREAM_BASE = useStreamApiBase()
   const symbolNames = useSymbolNames()
 
@@ -604,6 +604,8 @@ export default function StrategyPage() {
   const [modalOpen, setModalOpen] = useState(false)
   const [pendingAct, setPendingAct] = useState(null)  // { type: 'approve'|'reject', proposal }
   const [copiedId, setCopiedId] = useState(null)
+  const [selectedIds, setSelectedIds] = useState(new Set())
+  const [batchPending, setBatchPending] = useState(null) // { type: 'approve'|'reject' }
 
   const [memOrder, setMemOrder] = useState('desc')
 
@@ -685,6 +687,53 @@ export default function StrategyPage() {
     }
   }
 
+  // ── 批量選取邏輯 ──────────────────────────────────────────────────
+  const pendingRows = useMemo(() => rows.filter(r => String(r?.status || '').toLowerCase() === 'pending'), [rows])
+  const allPendingSelected = pendingRows.length > 0 && pendingRows.every(r => selectedIds.has(r.proposal_id))
+
+  const toggleSelect = (pid) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      next.has(pid) ? next.delete(pid) : next.add(pid)
+      return next
+    })
+  }
+  const toggleSelectAll = () => {
+    if (allPendingSelected) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(pendingRows.map(r => r.proposal_id)))
+    }
+  }
+  const confirmBatch = async () => {
+    if (!batchPending) return
+    const ids = [...selectedIds]
+    const action = batchPending.type
+    setBatchPending(null)
+    try {
+      const result = await batchAct(action, ids, { actor: 'operator', reason: `batch ${action} via UI` })
+      if (result) {
+        toast.success(`批量${action === 'approve' ? '核准' : '拒絕'} ${result.succeeded?.length || 0} 筆完成`)
+        if (result.failed?.length) {
+          toast.warning(`${result.failed.length} 筆跳過（已處理或不存在）`)
+        }
+      }
+    } catch (e) {
+      toast.error(`批量操作失敗：${e?.message || e}`)
+    }
+    setSelectedIds(new Set())
+  }
+
+  // Clear selection when proposals refresh
+  useEffect(() => {
+    setSelectedIds(prev => {
+      if (prev.size === 0) return prev
+      const validIds = new Set((proposals || []).filter(p => p.status === 'pending').map(p => p.proposal_id))
+      const next = new Set([...prev].filter(id => validIds.has(id)))
+      return next.size === prev.size ? prev : next
+    })
+  }, [proposals])
+
   function copyId(id) {
     navigator.clipboard.writeText(id).then(() => {
       setCopiedId(id)
@@ -706,10 +755,47 @@ export default function StrategyPage() {
 
         {error && <div className="mt-4 rounded-lg border border-rose-800 bg-rose-900/20 p-3 text-xs text-rose-300">{error}</div>}
 
+        {/* ── 批量操作列 ───────────────────────────────────────── */}
+        {selectedIds.size > 0 && (
+          <div className="mt-4 flex items-center gap-3 rounded-xl border border-slate-700 bg-slate-800/60 px-4 py-2.5">
+            <span className="text-xs text-slate-300">已選 <span className="font-semibold text-white">{selectedIds.size}</span> 筆</span>
+            <button
+              disabled={loading.act}
+              onClick={() => setBatchPending({ type: 'approve' })}
+              className="rounded-lg bg-emerald-700 px-3 py-1.5 text-[11px] font-semibold text-white disabled:opacity-40 hover:bg-emerald-600"
+            >
+              批量核准
+            </button>
+            <button
+              disabled={loading.act}
+              onClick={() => setBatchPending({ type: 'reject' })}
+              className="rounded-lg bg-rose-700 px-3 py-1.5 text-[11px] font-semibold text-white disabled:opacity-40 hover:bg-rose-600"
+            >
+              批量拒絕
+            </button>
+            <button
+              onClick={() => setSelectedIds(new Set())}
+              className="ml-auto text-[11px] text-slate-400 hover:text-slate-200"
+            >
+              取消選取
+            </button>
+          </div>
+        )}
+
         <div className="mt-5 overflow-auto rounded-xl border border-slate-800">
           <table className="min-w-full sm:min-w-[980px] w-full text-left text-xs">
             <thead className="bg-slate-950/40 text-slate-400">
               <tr>
+                <th className="px-3 py-3 w-8">
+                  <input
+                    type="checkbox"
+                    checked={allPendingSelected && pendingRows.length > 0}
+                    onChange={toggleSelectAll}
+                    disabled={pendingRows.length === 0}
+                    className="accent-emerald-500 h-3.5 w-3.5"
+                    title="全選 / 取消全選 pending 提案"
+                  />
+                </th>
                 <th className="px-4 py-3">時間</th>
                 <th className="px-4 py-3">Proposal ID</th>
                 <th className="px-4 py-3">標的</th>
@@ -722,7 +808,7 @@ export default function StrategyPage() {
             <tbody className="divide-y divide-slate-800">
               {rows.length === 0 ? (
                 <tr>
-                  <td className="px-4 py-5 text-slate-500" colSpan={7}>
+                  <td className="px-4 py-5 text-slate-500" colSpan={8}>
                     {loading.proposals ? '讀取中...' : '目前無提案記錄'}
                   </td>
                 </tr>
@@ -732,6 +818,16 @@ export default function StrategyPage() {
                   const canAct = status === 'pending'
                   return (
                     <tr key={p.proposal_id} className="hover:bg-slate-950/30">
+                      <td className="px-3 py-3">
+                        {canAct && (
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(p.proposal_id)}
+                            onChange={() => toggleSelect(p.proposal_id)}
+                            className="accent-emerald-500 h-3.5 w-3.5"
+                          />
+                        )}
+                      </td>
                       <td className="px-4 py-3 text-slate-300 whitespace-nowrap">{p._ts}</td>
                       <td className="px-4 py-3">
                         <div className="flex items-center gap-1.5">
@@ -828,6 +924,43 @@ export default function StrategyPage() {
 
       {/* ── PM LLM Trace ─────────────────────────────────────────────── */}
       <PmTracePanel />
+
+      {/* ── 批量確認 Dialog ───────────────────────────────────────────── */}
+      {batchPending && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4"
+          onMouseDown={() => setBatchPending(null)}
+        >
+          <div
+            className="w-full max-w-xs rounded-2xl border border-slate-700 bg-slate-900 p-5 shadow-2xl"
+            onMouseDown={e => e.stopPropagation()}
+          >
+            <div className={`text-sm font-semibold mb-2 ${batchPending.type === 'approve' ? 'text-emerald-300' : 'text-rose-300'}`}>
+              批量{batchPending.type === 'approve' ? '核准' : '拒絕'} {selectedIds.size} 筆提案
+            </div>
+            <div className="text-xs text-slate-400 mb-4">
+              此操作無法撤銷，請確認已選取正確的提案。
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setBatchPending(null)}
+                className="flex-1 rounded-xl border border-slate-700 py-2 text-sm font-medium text-slate-300 hover:bg-slate-800 transition-colors"
+              >
+                取消
+              </button>
+              <button
+                autoFocus
+                onClick={confirmBatch}
+                className={`flex-1 rounded-xl py-2 text-sm font-semibold text-white transition-colors ${
+                  batchPending.type === 'approve' ? 'bg-emerald-600 hover:bg-emerald-500' : 'bg-rose-600 hover:bg-rose-500'
+                }`}
+              >
+                確認{batchPending.type === 'approve' ? '核准' : '拒絕'} ({selectedIds.size})
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* ── Approve / Reject 確認 Dialog ──────────────────────────────── */}
       {pendingAct && (

--- a/src/openclaw/tg_approver.py
+++ b/src/openclaw/tg_approver.py
@@ -246,6 +246,20 @@ def notify_pending_proposals(conn: sqlite3.Connection) -> int:
     if sent > 0:
         _wm_set(conn, "notified_ids", list(notified))
 
+        # ── 批量摘要：2 筆以上附「一鍵全部核准」按鈕 ──────────────────
+        if sent >= 2:
+            base = os.environ.get("AI_TRADER_API_URL", "https://mac-mini.tailde842d.ts.net:8080")
+            auth = os.environ.get("AUTH_TOKEN", "")
+            try:
+                send_message_with_buttons(
+                    f"📋 本批次共 <b>{sent}</b> 筆待審提案",
+                    [[{"text": f"✅ 一鍵全部核准 ({sent})",
+                       "url": f"{base}/api/strategy/proposals/batch-approve-all?token={auth}"}]],
+                    chat_id=_chat_id(),
+                )
+            except Exception as _e:
+                log.warning("[tg_approver] batch summary notification failed: %s", _e)
+
     return sent
 
 


### PR DESCRIPTION
## Summary

- **API**: `POST /api/strategy/proposals/batch/{action}` — 批量核准/拒絕，最多 50 筆/次，逐筆寫 audit log，partial failure handling
- **API**: `GET /api/strategy/proposals/batch-approve-all?token=` — Telegram URL 按鈕一鍵核准所有 pending
- **Frontend**: Strategy 頁新增 checkbox 多選 + 批量操作列（核准/拒絕/取消）+ 確認 dialog
- **Telegram**: 通知 ≥2 筆時附「一鍵全部核准 (N)」URL 按鈕

## Test plan

- [x] 12 backend tests (`test_batch_decide.py`): happy path, validation, partial failure, audit log, URL endpoint
- [x] Frontend build passes (`npm run build`)
- [ ] Manual: curl batch-decide → verify succeeded/failed response
- [ ] Manual: Strategy 頁勾選 → 批量核准 → 確認 dialog → status 更新

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)