### PR TITLE
fix: tg_approver test call count for batch summary (#493)

### DIFF
--- a/src/tests/test_tg_approver.py
+++ b/src/tests/test_tg_approver.py
@@ -157,7 +157,8 @@ def test_notify_sends_for_new_proposals(conn_with_data, monkeypatch):
         n = notify_pending_proposals(c)
 
     assert n == 2
-    assert mock_send.call_count == 2
+    # 2 individual proposals + 1 batch summary (≥2 triggers summary)
+    assert mock_send.call_count == 3
 
 
 def test_notify_skips_already_notified(conn_with_data, monkeypatch):


### PR DESCRIPTION
## Summary

- Batch summary notification adds 1 extra `send_message_with_buttons` call when ≥2 proposals notified
- Updated `test_notify_sends_for_new_proposals` assertion: 2→3 (2 individual + 1 summary)

## Test plan

- [x] `pytest src/tests/test_tg_approver.py` — 17/17 passed

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)