### PR TITLE
fix: preserve TPEx market in Yahoo OHLCV fallback (#481)

### DIFF
--- a/src/openclaw/market_data_fetcher.py
+++ b/src/openclaw/market_data_fetcher.py
@@ -252,21 +252,34 @@ def save_margin_data(
 
 # ── Yahoo Finance fallback ────────────────────────────────────────────────────
 
-_YAHOO_CHART_URL = (
+_YAHOO_CHART_URL_TWSE = (
     "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}.TW"
+    "?interval=1d&range=5d"
+)
+_YAHOO_CHART_URL_TPEX = (
+    "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}.TWO"
     "?interval=1d&range=5d"
 )
 
 
-def fetch_ohlcv_yahoo(symbols: List[str], sleep_sec: float = 1.0) -> Dict[str, List[Dict]]:
+def fetch_ohlcv_yahoo(
+    symbols: List[str],
+    sleep_sec: float = 1.0,
+    market_map: Optional[Dict[str, str]] = None,
+) -> Dict[str, List[Dict]]:
     """
     Fetch recent OHLCV from Yahoo Finance as fallback when TWSE API is unavailable.
+
+    *market_map* maps symbol → 'TWSE' or 'TPEx'. TPEx symbols use `.TWO` suffix;
+    all others use `.TW`. If market_map is None, defaults to `.TW`.
 
     Returns {symbol: [{trade_date, open, high, low, close, volume}, ...]}
     """
     result: Dict[str, List[Dict]] = {}
     for sym in symbols:
-        url = _YAHOO_CHART_URL.format(symbol=sym)
+        is_tpex = (market_map or {}).get(sym, "TWSE") == "TPEx"
+        tmpl = _YAHOO_CHART_URL_TPEX if is_tpex else _YAHOO_CHART_URL_TWSE
+        url = tmpl.format(symbol=sym)
         req = urllib.request.Request(url, headers={
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
         })
@@ -449,8 +462,20 @@ def run_daily_fetch(
         twse_failed_symbols: List[str] = []
         today = datetime.date.today()
 
-        # Try TWSE STOCK_DAY first (current month only)
-        for sym in ohlcv_symbols:
+        # Build symbol → market lookup from existing eod_prices data
+        market_rows = conn.execute(
+            """SELECT DISTINCT symbol, market FROM eod_prices
+               WHERE symbol IN ({})""".format(",".join("?" for _ in ohlcv_symbols)),
+            [s.upper() for s in ohlcv_symbols],
+        ).fetchall()
+        market_map: Dict[str, str] = {r[0]: r[1] for r in market_rows}
+
+        # Separate TWSE vs TPEx symbols — STOCK_DAY API only works for TWSE
+        twse_symbols = [s for s in ohlcv_symbols if market_map.get(s.upper(), "TWSE") == "TWSE"]
+        tpex_symbols = [s for s in ohlcv_symbols if market_map.get(s.upper()) == "TPEx"]
+
+        # Try TWSE STOCK_DAY first (current month only, TWSE symbols only)
+        for sym in twse_symbols:
             try:
                 rows = fetch_ohlcv_month(sym, today.year, today.month)
                 if rows:
@@ -473,14 +498,16 @@ def run_daily_fetch(
                 twse_failed_symbols.append(sym)
             time.sleep(3)  # Conservative delay — one request per 3 seconds
 
-        # Fallback to Yahoo Finance for symbols that TWSE failed
-        if twse_failed_symbols:
+        # Fallback to Yahoo Finance for failed TWSE + all TPEx symbols
+        yahoo_symbols = twse_failed_symbols + tpex_symbols
+        if yahoo_symbols:
             log.info(
-                "[market_data_fetcher] TWSE failed for %d symbols, trying Yahoo Finance",
-                len(twse_failed_symbols),
+                "[market_data_fetcher] Yahoo fallback for %d symbols (%d TWSE failed + %d TPEx)",
+                len(yahoo_symbols), len(twse_failed_symbols), len(tpex_symbols),
             )
-            yahoo_data = fetch_ohlcv_yahoo(twse_failed_symbols)
+            yahoo_data = fetch_ohlcv_yahoo(yahoo_symbols, market_map=market_map)
             for sym, rows in yahoo_data.items():
+                mkt = market_map.get(sym.upper(), "TWSE")
                 if rows:
                     conn.executemany(
                         """
@@ -488,10 +515,10 @@ def run_daily_fetch(
                             (trade_date, market, symbol, name, open, high, low, close, volume,
                              source_url, ingested_at)
                         VALUES
-                            (:trade_date, 'TWSE', :symbol, NULL, :open, :high, :low, :close, :volume,
+                            (:trade_date, :market, :symbol, NULL, :open, :high, :low, :close, :volume,
                              'Yahoo Finance', datetime('now'))
                         """,
-                        [{"symbol": sym.upper(), **r} for r in rows],
+                        [{"symbol": sym.upper(), "market": mkt, **r} for r in rows],
                     )
                     conn.commit()
                     ohlcv_count += len(rows)

--- a/src/tests/test_market_data_fetcher.py
+++ b/src/tests/test_market_data_fetcher.py
@@ -20,6 +20,7 @@ from openclaw.market_data_fetcher import (
     ensure_schema,
     fetch_institution_flows,
     fetch_margin_data,
+    fetch_ohlcv_yahoo,
     run_daily_fetch,
     save_institution_flows,
     save_margin_data,
@@ -542,3 +543,136 @@ class TestRunDailyFetch:
 
         assert result["institution_flows"] == 0
         assert result["margin_data"] == 0
+
+
+# ── Regression: TPEx market preservation in Yahoo fallback (#481) ──────────
+
+
+class TestTPExYahooFallback:
+    """TPEx symbols must use .TWO suffix and preserve market='TPEx' on insert."""
+
+    @pytest.fixture
+    def conn_with_tpex(self):
+        c = sqlite3.connect(":memory:")
+        c.row_factory = sqlite3.Row
+        ensure_schema(c)
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS eod_prices (
+                trade_date TEXT NOT NULL,
+                market TEXT NOT NULL DEFAULT 'TWSE',
+                symbol TEXT NOT NULL,
+                name TEXT,
+                open REAL, high REAL, low REAL, close REAL,
+                volume INTEGER DEFAULT 0,
+                source_url TEXT,
+                ingested_at TEXT,
+                PRIMARY KEY (trade_date, symbol)
+            )
+        """)
+        c.execute(
+            """INSERT INTO eod_prices
+               (trade_date, market, symbol, open, high, low, close, volume)
+               VALUES ('2026-03-27', 'TPEx', '6515', 100, 110, 95, 105, 1000)"""
+        )
+        c.commit()
+        return c
+
+    def test_yahoo_url_uses_two_suffix_for_tpex(self):
+        """fetch_ohlcv_yahoo must call .TWO URL for TPEx symbols."""
+        yahoo_resp = {
+            "chart": {
+                "result": [{
+                    "timestamp": [1711500000],
+                    "indicators": {"quote": [{"open": [100], "high": [110], "low": [95], "close": [105], "volume": [1000]}]},
+                }]
+            }
+        }
+        urls_called = []
+
+        def fake_urlopen(req, **kwargs):
+            urls_called.append(req.full_url)
+            return _fake_response(yahoo_resp)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             patch("time.sleep"):
+            fetch_ohlcv_yahoo(["6515"], market_map={"6515": "TPEx"})
+
+        assert len(urls_called) == 1
+        assert ".TWO" in urls_called[0], f"Expected .TWO in URL but got: {urls_called[0]}"
+
+    def test_yahoo_url_uses_tw_suffix_for_twse(self):
+        """fetch_ohlcv_yahoo must call .TW URL for TWSE symbols."""
+        yahoo_resp = {
+            "chart": {
+                "result": [{
+                    "timestamp": [1711500000],
+                    "indicators": {"quote": [{"open": [500], "high": [510], "low": [490], "close": [505], "volume": [5000]}]},
+                }]
+            }
+        }
+        urls_called = []
+
+        def fake_urlopen(req, **kwargs):
+            urls_called.append(req.full_url)
+            return _fake_response(yahoo_resp)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             patch("time.sleep"):
+            fetch_ohlcv_yahoo(["2330"], market_map={"2330": "TWSE"})
+
+        assert len(urls_called) == 1
+        assert ".TW?" in urls_called[0], f"Expected .TW in URL but got: {urls_called[0]}"
+
+    def test_run_daily_fetch_preserves_tpex_market(self, conn_with_tpex):
+        """Yahoo fallback for TPEx symbol must write market='TPEx', not 'TWSE'."""
+        yahoo_resp = {
+            "chart": {
+                "result": [{
+                    "timestamp": [1711500000],
+                    "indicators": {"quote": [{"open": [100], "high": [110], "low": [95], "close": [108], "volume": [2000]}]},
+                }]
+            }
+        }
+        twse_err = urllib.error.HTTPError(
+            "http://twse", 404, "Not Found", {}, BytesIO(b"")
+        )
+
+        def fake_urlopen(req, **kwargs):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            if "twse" in url.lower() or "tse.com" in url.lower():
+                raise twse_err
+            return _fake_response(yahoo_resp)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             patch("time.sleep"):
+            result = run_daily_fetch("2026-03-28", conn_with_tpex, ohlcv_symbols=["6515"])
+
+        assert result["ohlcv"] >= 1
+        row = conn_with_tpex.execute(
+            "SELECT market FROM eod_prices WHERE symbol='6515' ORDER BY trade_date DESC LIMIT 1"
+        ).fetchone()
+        assert row["market"] == "TPEx", f"Expected TPEx but got {row['market']}"
+
+    def test_tpex_symbols_skip_twse_stock_day(self, conn_with_tpex):
+        """TPEx symbols should NOT attempt TWSE STOCK_DAY — go directly to Yahoo."""
+        yahoo_resp = {
+            "chart": {
+                "result": [{
+                    "timestamp": [1711500000],
+                    "indicators": {"quote": [{"open": [100], "high": [110], "low": [95], "close": [108], "volume": [2000]}]},
+                }]
+            }
+        }
+        stock_day_called = []
+
+        def fake_urlopen(req, **kwargs):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            if "STOCK_DAY" in url:
+                stock_day_called.append(url)
+            return _fake_response(yahoo_resp)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             patch("time.sleep"):
+            run_daily_fetch("2026-03-28", conn_with_tpex, ohlcv_symbols=["6515"])
+
+        assert stock_day_called == [], f"STOCK_DAY should not be called for TPEx, but was: {stock_day_called}"


### PR DESCRIPTION
## Summary

- `fetch_ohlcv_yahoo()`: TPEx symbols now use `.TWO` suffix (was `.TW` for all)
- `run_daily_fetch()`: builds symbol→market lookup, TPEx symbols skip TWSE STOCK_DAY and go directly to Yahoo
- Yahoo INSERT uses parameterized `:market` preserving original market (was hardcoded `'TWSE'`)

## Root Cause

Commit `6608f5c` added Yahoo fallback but hardcoded `market='TWSE'` and `.TW` suffix for all symbols. TPEx symbols (89,507 rows in eod_prices) were being mislabeled and fetched from wrong Yahoo endpoint.

## Test plan

- [x] 4 new regression tests in `TestTPExYahooFallback`
- [x] Full `test_market_data_fetcher.py`: 55/55 passed

Fixes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)