### PR TITLE
fix/issue-508: preserve DB_PATH env var in run_backup.sh

### DIFF
--- a/bin/run_backup.sh
+++ b/bin/run_backup.sh
@@ -18,10 +18,16 @@ if [ -f "$OPENCLAW_ENV" ]; then
     set +a
 fi
 
+_ORIG_DB_PATH="${DB_PATH:-}"
 if [ -f "$REPO/frontend/backend/.env" ]; then
     set -a
     source "$REPO/frontend/backend/.env"
     set +a
+fi
+if [ -n "$_ORIG_DB_PATH" ]; then
+    DB_PATH="$_ORIG_DB_PATH"
+elif [ -z "${DB_PATH:-}" ]; then
+    unset DB_PATH
 fi
 
 DB_PATH="${DB_PATH:-$REPO/data/sqlite/trades.db}"


### PR DESCRIPTION
## 變更摘要

### 修復
- `bin/run_backup.sh`：保存呼叫端傳入的 `DB_PATH` 環境變數，避免被 `.env` 檔案的值覆蓋

## 影響評估
- LOW: 單一 shell 指令碼修正，無業務邏輯變更
- 修復 `test_skips_gracefully_when_db_missing` 失敗（Issue #508）

## Test plan
- [x] `pytest tests/test_backup_db.py -v` — 7/7 passed
- [x] `pytest tests/ frontend/backend/tests/ -x` — 1635 passed

Closes #508