### PR TITLE
feat(issue-512): Phase 1 — 基礎設施修復（共用元件 + API wrapper + Toast）

### DIFF
--- a/frontend/web/src/components/EmptyState.jsx
+++ b/frontend/web/src/components/EmptyState.jsx
@@ -1,0 +1,40 @@
+/**
+ * EmptyState — 統一的空狀態元件。
+ *
+ * 用法：
+ *   <EmptyState icon={Briefcase} title="目前無持倉" description="系統將在下次交易時段自動建倉" />
+ *   <EmptyState icon={FileText} title="尚無交易紀錄" action={{ label: '創建第一筆', onClick: handleCreate }} />
+ */
+import React from 'react'
+
+export default function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action, // { label, onClick }
+  className = '',
+}) {
+  return (
+    <div className={`flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-[rgb(var(--border))] bg-[rgb(var(--surface))/0.15] p-8 text-center ${className}`}>
+      {Icon && (
+        <div className="rounded-full bg-[rgb(var(--surface)]/0.5 p-3">
+          <Icon className="h-6 w-6 text-[rgb(var(--muted))]" />
+        </div>
+      )}
+      <div>
+        <p className="text-sm font-semibold text-[rgb(var(--text))]">{title}</p>
+        {description && (
+          <p className="mt-1 text-xs text-[rgb(var(--muted))]">{description}</p>
+        )}
+      </div>
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="mt-1 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))]/0.5 px-3 py-1.5 text-xs font-medium text-[rgb(var(--text))] hover:bg-[rgb(var(--surface))]/0.8 transition-colors"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/web/src/components/ErrorState.jsx
+++ b/frontend/web/src/components/ErrorState.jsx
@@ -1,0 +1,40 @@
+/**
+ * ErrorState — 統一的錯誤狀態元件，含「重試」按鈕。
+ *
+ * 用法：
+ *   <ErrorState message="API 請求失敗" onRetry={refetch} />
+ *   <ErrorState message={error.message} onRetry={refetch} />
+ */
+import React from 'react'
+import { AlertCircle, RefreshCw } from 'lucide-react'
+
+export default function ErrorState({
+  message = '讀取失敗',
+  description,
+  onRetry,
+  className = '',
+}) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center gap-3 rounded-2xl border border-rose-500/30 bg-rose-500/10 p-6 text-center ${className}`}
+      role="alert"
+    >
+      <AlertCircle className="h-8 w-8 text-rose-400" />
+      <div>
+        <p className="text-sm font-semibold text-rose-300">{message}</p>
+        {description && (
+          <p className="mt-1 text-xs text-rose-300/70">{description}</p>
+        )}
+      </div>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="flex items-center gap-1.5 rounded-lg border border-rose-500/40 bg-rose-500/20 px-3 py-1.5 text-xs font-medium text-rose-300 hover:bg-rose-500/30 transition-colors"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          重試
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/web/src/components/LoadingSpinner.jsx
+++ b/frontend/web/src/components/LoadingSpinner.jsx
@@ -1,0 +1,39 @@
+/**
+ * LoadingSpinner — 統一的載入動畫元件。
+ *
+ * 用法：
+ *   <LoadingSpinner />
+ *   <LoadingSpinner size="lg" />
+ *   <LoadingSpinner label="讀取持倉資料中..." />
+ */
+import React from 'react'
+
+const SIZE_CLASSES = {
+  sm: 'h-4 w-4',
+  md: 'h-6 w-6',
+  lg: 'h-10 w-10',
+}
+
+export default function LoadingSpinner({ size = 'md', label, className = '' }) {
+  const s = SIZE_CLASSES[size] || SIZE_CLASSES.md
+  return (
+    <div className={`flex flex-col items-center justify-center gap-3 ${className}`} role="status" aria-live="polite">
+      <svg
+        className={`animate-spin ${s} text-indigo-400`}
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+        />
+      </svg>
+      {label && (
+        <span className="text-xs text-[rgb(var(--muted))]">{label}</span>
+      )}
+    </div>
+  )
+}

--- a/frontend/web/src/components/ToastProvider.jsx
+++ b/frontend/web/src/components/ToastProvider.jsx
@@ -64,9 +64,20 @@ export function ToastProvider({ children }) {
     const [toasts, setToasts] = useState([])
     const idRef = useRef(0)
 
+    const MAX_TOASTS = 8
+
     const push = useCallback((type, message, duration = 4000) => {
         const id = ++idRef.current
-        setToasts(prev => [...prev.slice(-4), { id, type, message }]) // max 5 toasts
+        setToasts(prev => {
+            if (prev.length >= MAX_TOASTS) {
+                // Show overflow notice, then add new toast
+                const overflow = prev.length - MAX_TOASTS + 1
+                const overflowToast = { id: -(overflow + 100), type: 'info', message: `還有 ${overflow} 則通知被折疊`, isOverflow: true }
+                const trimmed = prev.slice(-(MAX_TOASTS - 1))
+                return [...trimmed, { id, type, message }, overflowToast]
+            }
+            return [...prev, { id, type, message }]
+        })
         if (duration > 0) {
             setTimeout(() => dismiss(id), duration)
         }
@@ -77,12 +88,17 @@ export function ToastProvider({ children }) {
         setToasts(prev => prev.filter(t => t.id !== id))
     }
 
+    function dismissAll() {
+        setToasts([])
+    }
+
     const api = {
-        success: (msg, dur) => push('success', msg, dur),
-        error: (msg, dur) => push('error', msg, dur ?? 6000),
-        warn: (msg, dur) => push('warn', msg, dur),
+        success: (msg, dur) => push('success', msg, dur ?? 4000),
+        error: (msg) => push('error', msg, 0), // Critical/error — no auto-dismiss
+        warn: (msg, dur) => push('warn', msg, dur ?? 0), // warn — no auto-dismiss either
         info: (msg, dur) => push('info', msg, dur),
         dismiss,
+        dismissAll,
     }
 
     // Expose globally so auth.js and other non-React code can call it

--- a/frontend/web/src/lib/apiFetch.js
+++ b/frontend/web/src/lib/apiFetch.js
@@ -1,0 +1,124 @@
+/**
+ * apiFetch.js — 統一 API fetch wrapper。
+ *
+ * 功能：
+ * - 自動帶 Bearer token
+ * - 統一錯誤處理（401 → auth event, 5xx → retry with backoff）
+ * - 可選 retry（預設 1 次，間隔 2s）
+ *
+ * 用法：
+ *   import { apiFetch } from './apiFetch'
+ *
+ *   // Basic
+ *   const data = await apiFetch('/api/portfolio/positions')
+ *
+ *   // With options
+ *   const data = await apiFetch('/api/positions', {
+ *     method: 'POST',
+ *     body: JSON.stringify({ symbol: '2330' }),
+ *     retry: 2,
+ *     timeout: 15000,
+ *   })
+ *
+ *   // Returns { data, error, status }
+ */
+
+import { getToken } from './auth'
+
+const DEFAULT_TIMEOUT = 10000 // 10s
+
+/**
+ * @param {string} url — relative or absolute URL
+ * @param {object} options
+ * @param {number} [options.retry=1] — number of retries on 5xx
+ * @param {number} [options.timeout=10000]
+ * @param {'get'|'post'|'put'|'delete'|'patch'} [options.method]
+ * @param {any} [options.body]
+ * @param {AbortSignal} [options.signal]
+ */
+export async function apiFetch(url, options = {}) {
+  const {
+    retry = 1,
+    timeout = DEFAULT_TIMEOUT,
+    method = 'GET',
+    body,
+    signal: externalSignal,
+    ...rest
+  } = options
+
+  const token = getToken()
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(rest.headers || {}),
+  }
+
+  let controller
+  let timeoutId
+  let signal = externalSignal
+
+  if (!externalSignal) {
+    controller = new AbortController()
+    signal = controller.signal
+    timeoutId = setTimeout(() => controller.abort(), timeout)
+  }
+
+  async function attempt(remainingRetries) {
+    try {
+      const res = await fetch(url, {
+        method,
+        headers,
+        body: body != null ? JSON.stringify(body) : undefined,
+        signal,
+        ...rest,
+      })
+
+      // 401 → fire auth event and return error
+      if (res.status === 401) {
+        window.dispatchEvent(new Event('auth:unauthorized'))
+        const text = await res.text().catch(() => '')
+        return { data: null, error: `未授權（401）${text}`, status: 401 }
+      }
+
+      // 5xx → retry
+      if (res.status >= 500 && remainingRetries > 0) {
+        await sleep(2000)
+        return attempt(remainingRetries - 1)
+      }
+
+      // 4xx (non-401) → parse error
+      if (res.status >= 400 && res.status < 500) {
+        const text = await res.text().catch(() => '')
+        return { data: null, error: `客戶端錯誤（${res.status}）${text}`, status: res.status }
+      }
+
+      // Success
+      const contentType = res.headers.get('content-type') || ''
+      const data = contentType.includes('application/json')
+        ? await res.json().catch(() => null)
+        : await res.text().catch(() => null)
+
+      return { data, error: null, status: res.status }
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        return { data: null, error: `請求超時（${timeout}ms）`, status: 0 }
+      }
+      if (remainingRetries > 0) {
+        await sleep(2000)
+        return attempt(remainingRetries - 1)
+      }
+      return { data: null, error: `網路錯誤：${err.message}`, status: 0 }
+    }
+  }
+
+  try {
+    return await attempt(retry)
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId)
+    if (controller) controller.abort()
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/frontend/web/src/lib/useApiData.js
+++ b/frontend/web/src/lib/useApiData.js
@@ -1,0 +1,93 @@
+/**
+ * useApiData — 封裝 fetch + loading + error + abort + retry 的 React hook。
+ *
+ * 用法：
+ *   const { data, error, loading, refetch } = useApiData('/api/portfolio/positions')
+ *
+ *   // or with options
+ *   const { data } = useApiData('/api/positions', {
+ *     method: 'POST',
+ *     body: { symbol: '2330' },
+ *     retry: 2,
+ *     deps: [symbol],   // re-fetch when symbol changes
+ *   })
+ *
+ * 狀態：
+ *   loading=true  → 首次載入中
+ *   error != null → 請求失敗（可重試）
+ *   data != null  → 成功取得資料
+ *   data=null + error=null → 尚未請求（skip=true 時）
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch } from './apiFetch'
+
+export function useApiData(url, options = {}) {
+  const {
+    method = 'GET',
+    body,
+    retry = 1,
+    timeout,
+    skip = false,
+    deps = [],
+  } = options
+
+  const [state, setState] = useState({
+    data: null,
+    error: null,
+    loading: !skip,
+  })
+
+  const controllerRef = useRef(null)
+  const mountedRef = useRef(true)
+
+  const fetch_ = useCallback(async () => {
+    // Abort previous
+    if (controllerRef.current) {
+      controllerRef.current.abort()
+    }
+    controllerRef.current = new AbortController()
+
+    if (!mountedRef.current) return
+
+    setState(prev => ({ ...prev, loading: true, error: null }))
+
+    const result = await apiFetch(url, {
+      method,
+      body,
+      retry,
+      timeout,
+      signal: controllerRef.current.signal,
+    })
+
+    if (!mountedRef.current) return
+
+    setState({
+      data: result.data,
+      error: result.error,
+      loading: false,
+    })
+  }, [url, method, body, retry, timeout]) // eslint-disable-line
+
+  useEffect(() => {
+    mountedRef.current = true
+    if (skip) {
+      setState({ data: null, error: null, loading: false })
+      return
+    }
+    fetch_()
+
+    return () => {
+      mountedRef.current = false
+      if (controllerRef.current) {
+        controllerRef.current.abort()
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetch_, skip, ...deps])
+
+  const refetch = useCallback(() => {
+    if (!skip) fetch_()
+  }, [fetch_, skip])
+
+  return { ...state, refetch }
+}


### PR DESCRIPTION
## 變更摘要

### 新功能
- `<LoadingSpinner>` — 統一載入動畫元件
- `<ErrorState>` — 統一錯誤狀態，含重試按鈕
- `<EmptyState>` — 統一空狀態，含 icon/title/description/action
- `apiFetch.js` — 統一 fetch wrapper（Bearer token、錯誤處理、retry）
- `useApiData.js` — API 資料 hook（loading/error/data）
- Toast 上限 5→8、超界折疊提示、warn/error 不自動消失

## Test plan
- [x] `npm test -- --run` — 129 tests ✅
- [x] `npm run build` — 成功 ✅
- [ ] 漸進替換各頁面的 raw fetch（後續 Phase）

## 影響評估
- LOW：純前端重構，不影響後端邏輯
- 新舊程式碼共存，可逐步遷移