### PR TITLE
feat/issue-512: Phase 3 — Theme系統修復（CSS變數動態切換）

### DIFF
--- a/frontend/web/src/lib/theme.jsx
+++ b/frontend/web/src/lib/theme.jsx
@@ -1,14 +1,69 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
 
-const ThemeContext = createContext();
+const ThemeContext = createContext(null);
+
+function getLocalStorage(key, fallback) {
+  try {
+    return localStorage.getItem(key) || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+const LIGHT_VARS = {
+  '--bg':      '255 255 255',
+  '--text':    '15 23 42',
+  '--surface': '248 250 252',
+  '--border':  '226 232 240',
+  '--muted':   '148 163 184',
+};
+
+const DARK_VARS = {
+  '--bg':      '2 6 23',
+  '--text':    '226 232 240',
+  '--surface': '15 23 42',
+  '--border':  '30 41 59',
+  '--muted':   '100 116 139',
+};
+
+function applyTheme(theme) {
+  if (typeof document === 'undefined') return;
+  const vars = theme === 'light' ? LIGHT_VARS : DARK_VARS;
+  const root = document.documentElement;
+  Object.entries(vars).forEach(([k, v]) => root.style.setProperty(k, v));
+  root.classList.remove('dark', 'light');
+  root.classList.add(theme);
+  root.setAttribute('data-theme', theme);
+}
 
 export function ThemeProvider({ children, defaultTheme = 'dark' }) {
-  const [theme, setTheme] = useState(defaultTheme);
+  const [theme, setTheme] = useState(() => {
+    // 1. localStorage 優先
+    const saved = getLocalStorage('theme', null);
+    if (saved === 'light' || saved === 'dark') return saved;
+    // 2. 系統偏好
+    try {
+      if (window.matchMedia?.('(prefers-color-scheme: light)').matches) return 'light';
+    } catch {}
+    // 3. 預設 dark
+    return defaultTheme;
+  });
+
+  // 初始化時應用主題
+  useEffect(() => {
+    applyTheme(theme);
+  }, []);
+
+  // 主題變更時寫入 localStorage
+  useEffect(() => {
+    try { localStorage.setItem('theme', theme); } catch {}
+    applyTheme(theme);
+  }, [theme]);
 
   const value = {
     theme,
     setTheme,
-    toggleTheme: () => setTheme(prev => prev === 'dark' ? 'light' : 'dark')
+    toggleTheme: () => setTheme(prev => prev === 'dark' ? 'light' : 'dark'),
   };
 
   return (


### PR DESCRIPTION
## 變更摘要

### Phase 3 — 主題系統修復

**`theme.jsx` 完全重寫**
- 新增 `LIGHT_VARS` / `DARK_VARS` CSS 變數定義
- `applyTheme()` 動態設定 `document.documentElement` CSS 變數 + `class="dark|light"` + `data-theme`
- 支援 localStorage 持久化（themes）
- 支援 `prefers-color-scheme` 系統偏好 fallback
- 保護 `localStorage` 與 `document` 存取（測試環境相容）

**ThemeToggle** 現在可真正切換 dark/light 主題，兩者均有完整 CSS 變數配置。

## 測試
- 前端測試：129 tests ✅
- Build：✅

## 影響評估
- LOW：主題切換功能完善，無業務邏輯變更