### PR TITLE
feat/issue-512 Phase 4: ChatButton 響應式改版 + 移除 FloatingLogout

### DIFF
--- a/frontend/web/src/components/chat/ChatButton.jsx
+++ b/frontend/web/src/components/chat/ChatButton.jsx
@@ -7,7 +7,7 @@ export default function ChatButton() {
 
   return (
     <>
-      {/* Floating toggle button — sits to the left of FloatingLogout */}
+      {/* Floating toggle button — offset to avoid FloatingLogout */}
       <button
         type="button"
         onClick={() => setOpen(v => !v)}
@@ -23,17 +23,51 @@ export default function ChatButton() {
         }
       </button>
 
-      {/* Compact floating chat window — no backdrop, no overlay */}
       {open && (
-        <div
-          className="fixed bottom-24 right-6 z-50 flex flex-col
-                     w-[360px] h-[480px] max-h-[calc(100vh-120px)]
-                     rounded-2xl border border-[rgb(var(--border))]
-                     bg-[rgb(var(--bg))] shadow-2xl shadow-black/50"
-          style={{ resize: 'none' }}
-        >
-          <ChatPanel onClose={() => setOpen(false)} />
-        </div>
+        <>
+          {/* Mobile: full-screen overlay */}
+          <div
+            className="fixed inset-0 z-50 flex sm:hidden"
+          >
+            <div
+              className="absolute inset-0 bg-black/60"
+              onClick={() => setOpen(false)}
+            />
+            <div
+              className="relative flex w-full flex-col"
+            >
+              <ChatPanel onClose={() => setOpen(false)} />
+            </div>
+          </div>
+
+          {/* Tablet: bottom drawer (sm to lg) */}
+          <div
+            className="fixed bottom-0 right-0 z-50 hidden sm:flex lg:hidden"
+          >
+            <div
+              className="absolute inset-0 bg-black/40"
+              onClick={() => setOpen(false)}
+            />
+            <div
+              className="relative mt-12 flex max-h-[60vh] w-full flex-col rounded-t-2xl border border-[rgb(var(--border))]
+                         bg-[rgb(var(--bg))] shadow-2xl"
+              style={{ resize: 'none' }}
+            >
+              <ChatPanel onClose={() => setOpen(false)} />
+            </div>
+          </div>
+
+          {/* Desktop: compact floating window */}
+          <div
+            className="fixed bottom-24 right-6 z-50 hidden lg:flex flex-col
+                       w-[360px] h-[480px] max-h-[calc(100vh-120px)]
+                       rounded-2xl border border-[rgb(var(--border))]
+                       bg-[rgb(var(--bg))] shadow-2xl shadow-black/50"
+            style={{ resize: 'none' }}
+          >
+            <ChatPanel onClose={() => setOpen(false)} />
+          </div>
+        </>
       )}
     </>
   )

--- a/frontend/web/src/main.jsx
+++ b/frontend/web/src/main.jsx
@@ -4,7 +4,6 @@ import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from './lib/theme'
 import GlobalErrorBoundary from './components/GlobalErrorBoundary'
 import { ToastProvider } from './components/ToastProvider'
-import FloatingLogout from './components/FloatingLogout'
 import App from './App'
 import './index.css'
 
@@ -15,8 +14,6 @@ ReactDOM.createRoot(document.getElementById('root')).render(
         <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <ToastProvider>
             <App />
-            {/* FloatingLogout is OUTSIDE routing so it always renders on every page */}
-            <FloatingLogout />
           </ToastProvider>
         </BrowserRouter>
       </ThemeProvider>


### PR DESCRIPTION
## 變更摘要

### 新功能
- ChatButton.jsx: 三種響應模式 (mobile full-screen / tablet bottom-drawer / desktop floating)
- main.jsx: 移除 FloatingLogout import + 元件

### 改善
- ToastProvider 已有 auth:unauthorized listener，logout 功能不受影響

## 影響評估
- LOW: 移除一個浮動元件，整合進既有架構

## 測試
- 前端 vitest: 全部通過