### PR TITLE
feat/issue-512: Phase 5 four-state coverage for all pages

### DIFF
--- a/frontend/web/src/pages/Analysis.jsx
+++ b/frontend/web/src/pages/Analysis.jsx
@@ -2,6 +2,10 @@ import React, { useState, useEffect, useCallback } from 'react'
 import { getToken, authFetch, getApiBase } from '../lib/auth'
 import { useSymbolNames, formatSymbol } from '../lib/symbolNames'
 import KlineChart from '../components/KlineChart'
+import { FileText } from 'lucide-react'
+import LoadingSpinner from '../components/LoadingSpinner'
+import EmptyState from '../components/EmptyState'
+import ErrorState from '../components/ErrorState'
 
 const TABS = ['今日市場概覽', '個股技術分析', '法人籌碼', 'AI 明日策略']
 
@@ -118,7 +122,7 @@ function StockChipsPanel({ symbol }) {
   }, [symbol])
 
   if (!symbol) return null
-  if (loading) return <div className="text-xs text-[rgb(var(--muted))]">載入籌碼中…</div>
+  if (loading) return <div className="py-8"><LoadingSpinner label="讀取籌碼資料中…" /></div>
   if (msg || !data) return (
     <div className="rounded-xl border border-slate-500/20 bg-slate-500/5 px-4 py-3 text-xs text-[rgb(var(--muted))]">
       {msg || '無籌碼資料'}
@@ -264,9 +268,9 @@ function ChipsTab({ report }) {
       .catch(() => { setError('無法載入籌碼資料'); setLoading(false) })
   }, [tradeDate])
 
-  if (loading) return <div className="text-sm text-[rgb(var(--muted))]">讀取籌碼資料中…</div>
-  if (error) return <div className="rounded-xl border border-slate-500/30 bg-slate-500/10 p-4 text-sm text-[rgb(var(--muted))]">{error}</div>
-  if (!data?.data?.length) return <div className="rounded-xl border border-slate-500/30 bg-slate-500/10 p-4 text-sm text-[rgb(var(--muted))]">本日尚無法人籌碼資料</div>
+  if (loading) return <div className="py-8"><LoadingSpinner label="讀取籌碼資料中…" /></div>
+  if (error) return <ErrorState message="讀取法人籌碼失敗" description={error} onRetry={fetch} />
+  if (!data?.data?.length) return <div className="py-6"><EmptyState icon={FileText} title="本日尚無法人籌碼資料" description="法人籌碼資料將在每日收盘后更新" /></div>
 
   const rows = data.data
   const hasMargin = rows.some(r => r.margin_balance != null)
@@ -424,7 +428,7 @@ export default function AnalysisPage() {
         )}
       </div>
 
-      {loading && <div className="text-sm text-[rgb(var(--muted))]">讀取中…</div>}
+      {loading && <div className="py-4"><LoadingSpinner label="讀取中…" /></div>}
       {noData && !loading && (
         <div className="rounded-xl border border-slate-500/30 bg-slate-500/10 p-6 text-center text-sm text-[rgb(var(--muted))]">
           📊 今日盤後分析尚未產生（每交易日 22:00 自動執行）

--- a/frontend/web/src/pages/Portfolio.jsx
+++ b/frontend/web/src/pages/Portfolio.jsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Lock, TrendingDown } from 'lucide-react'
+import { Lock, TrendingDown, Briefcase } from 'lucide-react'
 import { useToast } from '../components/ToastProvider'
 import PmStatusCard from '../components/PmStatusCard'
 import KpiCard from '../components/KpiCard'
 import AllocationDonut from '../components/charts/AllocationDonut'
 import PnlLineChart from '../components/charts/PnlLineChart'
 import PositionDetailDrawer from '../components/PositionDetailDrawer'
+import EmptyState from '../components/EmptyState'
+import LoadingSpinner from '../components/LoadingSpinner'
+import ErrorState from '../components/ErrorState'
 import { mockPositions, fetchPortfolioPositions, fetchEquityCurve, buildAllocationData, calcPortfolioKpis, fetchPortfolioKpis, fetchLockedSymbols, lockSymbol, unlockSymbol, closePosition } from '../lib/portfolio'
 import { formatCurrency, formatNumber, formatPercent } from '../lib/format'
 
@@ -291,7 +294,12 @@ export default function PortfolioPage() {
           {allocation.length ? (
             <AllocationWithWarning data={allocation} />
           ) : (
-            <div className="py-16 text-center text-sm text-[rgb(var(--muted))]">No allocation data.</div>
+            <EmptyState
+              icon={Briefcase}
+              title="尚無持倉"
+              description="無持倉資料可顯示"
+              className="my-4"
+            />
           )}
         </Panel>
 
@@ -305,7 +313,7 @@ export default function PortfolioPage() {
         <div className="flex items-center justify-between border-b border-[rgb(var(--border))] px-4 py-3">
           <div className="text-sm font-semibold">持倉列表</div>
           <div className="flex items-center gap-3">
-            <span className="text-xs text-[rgb(var(--muted))]">{positions.length} positions</span>
+            <span className="text-xs text-[rgb(var(--muted))]">{loading ? '...' : `${positions.length} positions`}</span>
             <span className="text-xs text-emerald-400/70 hidden sm:block">← 點擊任一行查看詳情</span>
           </div>
         </div>
@@ -325,7 +333,29 @@ export default function PortfolioPage() {
               </tr>
             </thead>
             <tbody className="divide-y divide-[rgb(var(--border))]">
-              {positions.map((p) => {
+              {loading ? (
+                <tr>
+                  <td colSpan={8} className="px-4 py-12">
+                    <LoadingSpinner label="讀取持倉資料中..." />
+                  </td>
+                </tr>
+              ) : error ? (
+                <tr>
+                  <td colSpan={8} className="px-4 py-8">
+                    <ErrorState message="讀取持倉失敗" onRetry={() => load(preferApi)} />
+                  </td>
+                </tr>
+              ) : positions.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="px-4 py-8">
+                    <EmptyState
+                      icon={Briefcase}
+                      title="目前無持倉"
+                      description="系統將在下次交易時段自動建倉"
+                    />
+                  </td>
+                </tr>
+              ) : positions.map((p) => {
                 const qty = Number(p.qty || 0)
                 const last = Number(p.lastPrice || p.last_price || 0)
                 const avg = Number(p.avgCost || p.avg_price)
@@ -385,14 +415,6 @@ export default function PortfolioPage() {
                   </tr>
                 )
               })}
-
-              {positions.length === 0 ? (
-                <tr>
-                  <td colSpan={8} className="px-4 py-10 text-center text-[rgb(var(--muted))]">
-                    No positions.
-                  </td>
-                </tr>
-              ) : null}
             </tbody>
           </table>
         </div>

--- a/frontend/web/src/pages/Strategy.jsx
+++ b/frontend/web/src/pages/Strategy.jsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useMemo, useState, Fragment } from 'react'
 import { useStreamApiBase, useStrategyData } from '../lib/strategyApi'
-import { CheckCircle2, XCircle, Clock, ChevronDown, ChevronRight, MessageSquare, Target, Save, FileSignature, ShieldAlert, Cpu, Copy, Check } from 'lucide-react'
+import { CheckCircle2, XCircle, Clock, ChevronDown, ChevronRight, MessageSquare, Target, Save, FileSignature, ShieldAlert, Cpu, Copy, Check, FileText, Lightbulb } from 'lucide-react'
 import { authFetch, getApiBase, getToken } from '../lib/auth'
 import { useToast } from '../components/ToastProvider'
 import { useSymbolNames, formatSymbol } from '../lib/symbolNames'
+import EmptyState from '../components/EmptyState'
+import LoadingSpinner from '../components/LoadingSpinner'
+import ErrorState from '../components/ErrorState'
 
 function formatUnixSec(sec) {
   const n = Number(sec)
@@ -102,9 +105,15 @@ function PmTracePanel() {
       </div>
 
       {loading ? (
-        <div className="text-xs text-slate-500 py-6 text-center">載入中…</div>
+        <div className="py-6"><LoadingSpinner label="讀取審核記錄中..." /></div>
       ) : traces.length === 0 ? (
-        <div className="text-xs text-slate-500 py-8 text-center">無記錄（點擊 Portfolio 頁面的「AI 審核」按鈕後才會出現）</div>
+        <div className="py-8">
+          <EmptyState
+            icon={FileText}
+            title="尚無審核記錄"
+            description="點擊 Portfolio 頁面的「AI 審核」按鈕後才會出現"
+          />
+        </div>
       ) : (
         <div className="space-y-3">
           {traces.map(t => (
@@ -212,9 +221,15 @@ function DebatePanel() {
       </div>
 
       {loading ? (
-        <div className="text-xs text-slate-500 py-6 text-center">載入中…</div>
+        <div className="py-6"><LoadingSpinner label="讀取辯論記錄中..." /></div>
       ) : parsed.length === 0 ? (
-        <div className="text-xs text-slate-500 py-8 text-center">當日無辯論記錄（按 Portfolio 頁面的「AI 審核」觸發）</div>
+        <div className="py-8">
+          <EmptyState
+            icon={Lightbulb}
+            title="當日無辯論記錄"
+            description="按 Portfolio 頁面的「AI 審核」觸發"
+          />
+        </div>
       ) : (
         <div className="space-y-4">
           {parsed.map((d, i) => (
@@ -824,8 +839,16 @@ export default function StrategyPage() {
             <tbody className="divide-y divide-slate-800">
               {pagedRows.length === 0 ? (
                 <tr>
-                  <td className="px-4 py-5 text-slate-500" colSpan={8}>
-                    {loading.proposals ? '讀取中...' : '目前無提案記錄'}
+                  <td className="px-4 py-8" colSpan={8}>
+                    {loading.proposals ? (
+                      <LoadingSpinner label="讀取提案資料中..." />
+                    ) : (
+                      <EmptyState
+                        icon={Target}
+                        title="尚無策略提案"
+                        description="系統將在下次交易時段自動產生策略提案"
+                      />
+                    )}
                   </td>
                 </tr>
               ) : (

--- a/frontend/web/src/pages/Trades.jsx
+++ b/frontend/web/src/pages/Trades.jsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { FileText } from 'lucide-react'
 import { formatCurrency, formatNumber, formatPercent } from '../lib/format'
 import { downloadTextFile, fetchTrades, fetchTradeCausalChain, mockTrades, tradesToCsv, tradesToExcelXml } from '../lib/trades'
 import { authFetch, getApiBase } from '../lib/auth'
 import { useSymbolNames, formatSymbol } from '../lib/symbolNames'
+import EmptyState from '../components/EmptyState'
+import LoadingSpinner from '../components/LoadingSpinner'
+import ErrorState from '../components/ErrorState'
 
 function toIsoDate(d) {
   if (!d) return ''
@@ -73,7 +77,7 @@ function MonthlySummaryPanel() {
         />
       </div>
       {loading ? (
-        <div className="text-xs text-slate-500 py-2">載入中…</div>
+        <div className="py-4"><LoadingSpinner label="讀取交易資料中..." /></div>
       ) : (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
           {stats.map(s => (
@@ -389,10 +393,26 @@ export default function TradesPage() {
                 )
               })}
 
-              {items.length === 0 ? (
+              {loading && items.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="px-4 py-10 text-center text-slate-400">
-                    No trades.
+                  <td colSpan={7} className="px-4 py-12">
+                    <LoadingSpinner label="讀取交易資料中..." />
+                  </td>
+                </tr>
+              ) : error && items.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-8">
+                    <ErrorState message="讀取交易紀錄失敗" description={error} onRetry={() => load()} />
+                  </td>
+                </tr>
+              ) : items.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-10">
+                    <EmptyState
+                      icon={FileText}
+                      title="尚無交易紀錄"
+                      description="開始交易後成交紀錄將顯示在這裡"
+                    />
                   </td>
                 </tr>
               ) : null}


### PR DESCRIPTION
## 變更摘要

### Phase 5 — 四態覆蓋（載入/錯誤/空值/有資料）

將 `EmptyState`、`LoadingSpinner`、`ErrorState` 元件應用於所有頁面：

- **Portfolio**: table tbody + allocation panel 四態覆蓋
- **Trades**: stats + table tbody 三態邏輯
- **Strategy**: proposals table + traces/debates tabs 空值狀態
- **Analysis**: ChipsTab + MarginTab + EOD 載入狀態

### 測試
- 129 tests passing

## Test plan
- [x] `npm test -- --run` — 129/129 passed
- [x] QA 對齊 spec 四態覆蓋檢查清單

Closes #512