### PR TITLE
fix/issue-518: improve test isolation and date-freshness

### DIFF
--- a/frontend/backend/tests/test_system_api.py
+++ b/frontend/backend/tests/test_system_api.py
@@ -807,14 +807,23 @@ class TestGraduationCheck:
         c, _, db_path = sys_client
         now_ms = int(__import__("time").time() * 1000)
         conn = sqlite3.connect(str(db_path))
+        # Use dynamic dates so the 28-day window always captures these rows.
+        from datetime import date, timedelta
+        today = date.today()
+        d1 = (today - timedelta(days=1)).isoformat()
+        d2 = (today - timedelta(days=2)).isoformat()
+        d3 = (today - timedelta(days=3)).isoformat()
         conn.execute(
-            "INSERT INTO daily_pnl_summary VALUES ('2026-03-01', 1000000, 1010000, 5000, 0, 5000, 0.005, 1010000, 0.02, 0, 'normal')"
+            "INSERT INTO daily_pnl_summary VALUES (?, 1000000, 1010000, 5000, 0, 5000, 0.005, 1010000, 0.02, 0, 'normal')",
+            (d1,)
         )
         conn.execute(
-            "INSERT INTO daily_pnl_summary VALUES ('2026-03-02', 1010000, 1020000, 6000, 0, 6000, 0.006, 1020000, 0.03, 0, 'normal')"
+            "INSERT INTO daily_pnl_summary VALUES (?, 1010000, 1020000, 6000, 0, 6000, 0.006, 1020000, 0.03, 0, 'normal')",
+            (d2,)
         )
         conn.execute(
-            "INSERT INTO daily_pnl_summary VALUES ('2026-03-03', 1020000, 1015000, -1000, 0, -1000, -0.001, 1020000, 0.03, 0, 'normal')"
+            "INSERT INTO daily_pnl_summary VALUES (?, 1020000, 1015000, -1000, 0, -1000, -0.001, 1020000, 0.03, 0, 'normal')",
+            (d3,)
         )
         conn.execute(
             "INSERT INTO positions (symbol, quantity, avg_price, current_price, chip_health_score, sector) VALUES ('2330', 100, 100.0, 100.0, NULL, NULL)"

--- a/src/tests/test_agents.py
+++ b/src/tests/test_agents.py
@@ -470,10 +470,13 @@ class TestOrchestratorHelpers:
         t = datetime(2026, 3, 2, 9, 15, tzinfo=twn)
         assert _should_run_now("08:20", t) is False
 
-    def test_pm_review_event_detected(self, tmp_path):
+    def test_pm_review_event_detected(self, tmp_path, monkeypatch):
         import json as _j
         from openclaw.agent_orchestrator import _pm_review_just_completed
         from openclaw.config_manager import get_config, reset_config
+        import openclaw.agent_orchestrator as ao
+        # Reset module-level cooldown state so this test always passes in isolation
+        monkeypatch.setattr(ao, "_LAST_STRATEGY_COMMITEE_TRIGGER", None)
         (tmp_path / "daily_pm_state.json").write_text(_j.dumps({"reviewed_at": "2026-03-02T08:25:00"}))
         reset_config()
         get_config(config_dir=tmp_path)

--- a/src/tests/test_edge_integration.py
+++ b/src/tests/test_edge_integration.py
@@ -5,6 +5,7 @@ import json
 import os
 import sqlite3
 import tempfile
+from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -108,10 +109,11 @@ def test_get_trades_for_strategy_empty(tmp_path):
 
 def test_get_trades_for_strategy_with_trades(tmp_path):
     db = str(tmp_path / "trades.db")
+    today = date.today()
     _make_trades_db(db, [
-        {"agent_id": "strategy_a", "pnl": 100.0, "timestamp": "2026-03-01T00:00:00"},
-        {"agent_id": "strategy_a", "pnl": -50.0, "timestamp": "2026-03-02T00:00:00"},
-        {"agent_id": "strategy_b", "pnl": 200.0, "timestamp": "2026-03-01T00:00:00"},
+        {"agent_id": "strategy_a", "pnl": 100.0, "timestamp": f"{(today - timedelta(days=1)).isoformat()}T00:00:00"},
+        {"agent_id": "strategy_a", "pnl": -50.0, "timestamp": f"{(today - timedelta(days=2)).isoformat()}T00:00:00"},
+        {"agent_id": "strategy_b", "pnl": 200.0, "timestamp": f"{(today - timedelta(days=1)).isoformat()}T00:00:00"},
     ])
     result = get_trades_for_strategy(db, "strategy_a", days_back=30)
     assert len(result) == 2
@@ -123,7 +125,7 @@ def test_get_trades_for_strategy_with_trades(tmp_path):
 def test_get_trades_for_strategy_pnl_none_stays_none(tmp_path):
     """Trade with pnl=None should be returned with pnl=None (no conversion)."""
     db = str(tmp_path / "trades.db")
-    _make_trades_db(db, [{"agent_id": "strategy_x", "pnl": None, "timestamp": "2026-03-01T00:00:00"}])
+    _make_trades_db(db, [{"agent_id": "strategy_x", "pnl": None, "timestamp": f"{date.today().isoformat()}T00:00:00"}])
     result = get_trades_for_strategy(db, "strategy_x", days_back=30)
     assert len(result) == 1
     assert result[0]["pnl"] is None
@@ -147,9 +149,10 @@ def test_analyze_strategy_edge_no_trades(tmp_path):
 def test_analyze_strategy_edge_insufficient_trades(tmp_path):
     """Less than min_trades pnl values → insufficient branch."""
     db = str(tmp_path / "trades.db")
+    today = date.today()
     _make_trades_db(db, [
-        {"agent_id": "strategy_a", "pnl": 10.0, "timestamp": "2026-03-01T00:00:00"},
-        {"agent_id": "strategy_a", "pnl": -5.0, "timestamp": "2026-03-02T00:00:00"},
+        {"agent_id": "strategy_a", "pnl": 10.0, "timestamp": f"{(today - timedelta(days=1)).isoformat()}T00:00:00"},
+        {"agent_id": "strategy_a", "pnl": -5.0, "timestamp": f"{(today - timedelta(days=2)).isoformat()}T00:00:00"},
     ])
     result = analyze_strategy_edge(db, "strategy_a", min_trades=10)
     assert result.trade_count == 2

--- a/tests/test_deep_suspend.py
+++ b/tests/test_deep_suspend.py
@@ -238,6 +238,9 @@ class TestApplyDrawdownActionsDeepSuspend:
         assert len(detail["monthly_losses"]) == 3
 
     def test_sends_telegram_notification(self, monkeypatch):
+        # Reset module-level cooldown state so this test always passes in isolation
+        import openclaw.drawdown_guard as dg
+        monkeypatch.setattr(dg, "_LAST_DEEP_SUSPEND_NOTIFY", None)
         conn = _make_db()
         decision = self._deep_suspend_decision()
         sent = []


### PR DESCRIPTION
## Summary
- Reset cooldown globals to fix test isolation failures in CI
- Replace hardcoded dates with dynamic calculations for date-dependent tests

## Test plan
- [x] All local pytest tests pass
- [ ] CI validation

Closes #518