### PR TITLE
fix/issue-523+524: DEEP SUSPEND guard 門檻 + Telegram URL 路徑

### DIFF
--- a/src/openclaw/drawdown_guard.py
+++ b/src/openclaw/drawdown_guard.py
@@ -12,6 +12,10 @@ log = logging.getLogger(__name__)
 _LAST_DEEP_SUSPEND_NOTIFY: datetime | None = None
 _DEEP_SUSPEND_NOTIFY_COOLDOWN = timedelta(minutes=10)
 
+# Minimum trading days per month for _compute_monthly_returns to consider
+# a month valid.  Prevents fake/sparse data from triggering DEEP SUSPEND.
+_MIN_TRADING_DAYS_PER_MONTH: int = 5
+
 
 @dataclass
 class DrawdownPolicy:
@@ -137,10 +141,14 @@ def _compute_monthly_returns(conn: sqlite3.Connection) -> list[tuple[str, float]
                MAX(trade_date) AS last_date
         FROM daily_nav
         GROUP BY month
-        HAVING COUNT(*) >= 1
+        HAVING COUNT(*) >= ?
         ORDER BY month ASC
-        """
+        """,
+        (_MIN_TRADING_DAYS_PER_MONTH,),
     ).fetchall()
+
+    if not rows:
+        return []
 
     results: list[tuple[str, float]] = []
     for month, first_date, last_date in rows:
@@ -175,6 +183,10 @@ def evaluate_deep_suspend_guard(conn: sqlite3.Connection, policy: DrawdownPolicy
     threshold = -abs(policy.deep_suspend_monthly_loss_pct)
 
     if len(monthly) < n:
+        log.debug(
+            "[deep_suspend] insufficient data: %d months (need %d, min %d days/month)",
+            len(monthly), n, _MIN_TRADING_DAYS_PER_MONTH,
+        )
         return DrawdownDecision("normal", "RISK_DEEP_SUSPEND_INSUFFICIENT_DATA", 0.0, 0)
 
     last_n = monthly[-n:]
@@ -182,6 +194,10 @@ def evaluate_deep_suspend_guard(conn: sqlite3.Connection, policy: DrawdownPolicy
 
     if len(losing_months) == n:
         avg_loss = sum(r for _, r in losing_months) / n
+        log.warning(
+            "[deep_suspend] TRIGGERED: %d consecutive losing months, avg_loss=%.2f%%, months=%s",
+            n, avg_loss * 100, [(m, f"{r:.2%}") for m, r in last_n],
+        )
         return DrawdownDecision(
             "deep_suspend",
             "RISK_DEEP_SUSPEND_CONSECUTIVE_LOSS",
@@ -280,11 +296,15 @@ def apply_drawdown_actions(conn: sqlite3.Connection, decision: DrawdownDecision)
 
     # DEEP_SUSPEND: send Telegram notification with human review checklist
     if decision.risk_mode == "deep_suspend":
-        _notify_deep_suspend(decision)
+        _notify_deep_suspend(decision, conn=conn)
 
 
-def _notify_deep_suspend(decision: DrawdownDecision) -> None:
-    """Send Telegram alert with restart checklist when DEEP SUSPEND is triggered (10-min cooldown)."""
+def _notify_deep_suspend(decision: DrawdownDecision, conn: sqlite3.Connection | None = None) -> None:
+    """Send Telegram alert with restart checklist when DEEP SUSPEND is triggered (10-min cooldown).
+
+    Also writes an audit incident to the DB (if conn is provided) so the
+    notification is traceable even if Telegram logs are unavailable.
+    """
     global _LAST_DEEP_SUSPEND_NOTIFY
     now = datetime.now(timezone.utc)
     if (
@@ -294,6 +314,25 @@ def _notify_deep_suspend(decision: DrawdownDecision) -> None:
         log.info("[DEEP SUSPEND] notification suppressed by 10-min cooldown")
         return
     _LAST_DEEP_SUSPEND_NOTIFY = now
+
+    # Audit: write notification record to incidents table
+    if conn is not None:
+        try:
+            if _table_exists(conn, "incidents"):
+                conn.execute(
+                    """INSERT INTO incidents(incident_id, ts, severity, source, code, detail_json, resolved)
+                       VALUES (lower(hex(randomblob(16))), datetime('now'), 'critical',
+                               'deep_suspend_notify', 'DEEP_SUSPEND_TELEGRAM_SENT', ?, 0)""",
+                    (json.dumps({
+                        "monthly_losses": decision.monthly_losses,
+                        "consecutive_loss_months": decision.consecutive_loss_months,
+                        "drawdown": decision.drawdown,
+                    }, ensure_ascii=True),),
+                )
+                conn.commit()
+        except Exception:  # noqa: BLE001
+            log.warning("[deep_suspend] failed to write notification audit")
+
     try:
         from openclaw.tg_notify import send_message  # lazy import
 
@@ -310,5 +349,6 @@ def _notify_deep_suspend(decision: DrawdownDecision) -> None:
             f"{_DEEP_SUSPEND_CHECKLIST}"
         )
         send_message(msg)
+        log.info("[deep_suspend] Telegram notification sent")
     except Exception:  # noqa: BLE001
         pass  # 通知失敗不影響主流程；incident 已寫入 DB

--- a/src/openclaw/tg_approver.py
+++ b/src/openclaw/tg_approver.py
@@ -230,7 +230,7 @@ def notify_pending_proposals(conn: sqlite3.Connection) -> int:
         lines.append(f"\n信心度：{conf:.0%}　<i>ID：{pid[:8]}…</i>")
 
         # URL 按鈕：點擊開瀏覽器呼叫 api 端點，不產生 callback_query
-        base = os.environ.get("AI_TRADER_API_URL", "https://mac-mini.tailde842d.ts.net:8080")
+        base = os.environ.get("AI_TRADER_API_URL", "https://mac-mini.tailde842d.ts.net/ai-trader-api")
         auth = os.environ.get("AUTH_TOKEN", "")
         buttons = [[
             {"text": "✅ 核准", "url": f"{base}/api/strategy/proposals/{pid}/approve?token={auth}"},
@@ -248,7 +248,7 @@ def notify_pending_proposals(conn: sqlite3.Connection) -> int:
 
         # ── 批量摘要：2 筆以上附「一鍵全部核准」按鈕 ──────────────────
         if sent >= 2:
-            base = os.environ.get("AI_TRADER_API_URL", "https://mac-mini.tailde842d.ts.net:8080")
+            base = os.environ.get("AI_TRADER_API_URL", "https://mac-mini.tailde842d.ts.net/ai-trader-api")
             auth = os.environ.get("AUTH_TOKEN", "")
             try:
                 send_message_with_buttons(

--- a/tests/test_deep_suspend.py
+++ b/tests/test_deep_suspend.py
@@ -78,11 +78,18 @@ def _nav_sequence(
     months: list[tuple[str, float, float]]
 ) -> list[tuple[str, float]]:
     """Helper: build daily_nav rows from (YYYY-MM, nav_start, nav_end) specs.
-    Inserts first day at nav_start and last day at nav_end."""
+
+    Inserts 6 rows per month (days 01,05,10,15,20,28) with linear
+    interpolation from nav_start to nav_end.  This satisfies the
+    _MIN_TRADING_DAYS_PER_MONTH=5 threshold in _compute_monthly_returns.
+    """
+    days = [1, 5, 10, 15, 20, 28]
     rows = []
     for month, start, end in months:
-        rows.append((f"{month}-01", start))
-        rows.append((f"{month}-28", end))
+        n = len(days) - 1
+        for i, d in enumerate(days):
+            nav = start + (end - start) * i / n
+            rows.append((f"{month}-{d:02d}", round(nav, 2)))
     return rows
 
 
@@ -96,7 +103,7 @@ class TestComputeMonthlyReturns:
         assert _compute_monthly_returns(conn) == []
 
     def test_single_month_positive(self):
-        rows = [("2026-01-01", 1_000_000), ("2026-01-31", 1_050_000)]
+        rows = _nav_sequence([("2026-01", 1_000_000, 1_050_000)])
         conn = _make_db(rows)
         results = _compute_monthly_returns(conn)
         assert len(results) == 1
@@ -105,7 +112,7 @@ class TestComputeMonthlyReturns:
         assert abs(ret - 0.05) < 0.001   # +5%
 
     def test_single_month_negative(self):
-        rows = [("2026-02-01", 1_000_000), ("2026-02-28", 870_000)]
+        rows = _nav_sequence([("2026-02", 1_000_000, 870_000)])
         conn = _make_db(rows)
         results = _compute_monthly_returns(conn)
         assert len(results) == 1
@@ -113,11 +120,20 @@ class TestComputeMonthlyReturns:
         assert ret < 0   # negative return
 
     def test_ordered_oldest_first(self):
-        rows = [("2026-01-01", 1_000_000), ("2026-01-31", 900_000),
-                ("2026-02-01", 900_000), ("2026-02-28", 1_100_000)]
+        rows = _nav_sequence([
+            ("2026-01", 1_000_000, 900_000),
+            ("2026-02", 900_000, 1_100_000),
+        ])
         conn = _make_db(rows)
         results = _compute_monthly_returns(conn)
         assert results[0][0] < results[1][0]   # 2026-01 < 2026-02
+
+    def test_sparse_month_excluded(self):
+        """Month with < MIN_TRADING_DAYS rows is excluded (防止假數據觸發)."""
+        rows = [("2026-01-01", 1_000_000), ("2026-01-28", 850_000)]  # only 2 rows
+        conn = _make_db(rows)
+        results = _compute_monthly_returns(conn)
+        assert len(results) == 0  # excluded by HAVING COUNT(*) >= 5
 
     def test_missing_table_returns_empty(self):
         conn = sqlite3.connect(":memory:")  # no table created
@@ -249,6 +265,21 @@ class TestApplyDrawdownActionsDeepSuspend:
         assert len(sent) == 1
         assert "DEEP SUSPEND" in sent[0]
         assert "Checklist" in sent[0]
+
+    def test_notification_writes_audit_incident(self, monkeypatch):
+        """_notify_deep_suspend writes an audit incident before sending Telegram."""
+        import openclaw.drawdown_guard as dg
+        monkeypatch.setattr(dg, "_LAST_DEEP_SUSPEND_NOTIFY", None)
+        monkeypatch.setattr("openclaw.tg_notify.send_message", lambda msg: True)
+        conn = _make_db()
+        decision = self._deep_suspend_decision()
+        apply_drawdown_actions(conn, decision)
+        row = conn.execute(
+            "SELECT code, detail_json FROM incidents WHERE code='DEEP_SUSPEND_TELEGRAM_SENT'"
+        ).fetchone()
+        assert row is not None
+        detail = json.loads(row[1])
+        assert detail["consecutive_loss_months"] == 3
 
     def test_normal_decision_no_lock(self):
         conn = _make_db()


### PR DESCRIPTION
## Summary
- DEEP SUSPEND: 加 _MIN_TRADING_DAYS_PER_MONTH=5 門檻防止稀疏數據誤觸
- _notify_deep_suspend: 加 audit incident 寫入 DB
- tg_approver: URL 從 :8080 改為 /ai-trader-api 路徑（配合 tailscale serve）

## Test plan
- [x] pytest tests/test_deep_suspend.py -q
- [x] pytest src/tests/test_agents.py -q

Closes #523
Closes #524