### PR TITLE
fix(issue-528): HWM 回填 + 盤後 exit signal fallback

### DIFF
--- a/src/openclaw/eod_exit_check.py
+++ b/src/openclaw/eod_exit_check.py
@@ -1,0 +1,160 @@
+"""eod_exit_check.py — 盤後 exit signal fallback
+
+盤中 ticker_watcher 可能因 Shioaji 斷線或其他異常而遺漏 exit signal。
+本模組在 eod_ingest 完成後，對所有持倉用最新 eod_prices 重跑 evaluate_exit()，
+若觸發 stop_loss / trailing_stop / take_profit，寫入 decision 表並發送 Telegram 通知。
+
+不執行實際下單 — 僅記錄 decision + 通知，由下一交易日盤中 watcher 執行。
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import uuid
+from datetime import datetime, timezone, timedelta
+from typing import List, Optional
+
+from openclaw.signal_logic import SignalParams, evaluate_exit
+
+log = logging.getLogger(__name__)
+
+_TZ_TWN = timezone(timedelta(hours=8))
+
+
+def _get_positions_with_hwm(conn: sqlite3.Connection) -> list[dict]:
+    """取得所有持倉（含 HWM 與 entry_trading_day）。"""
+    rows = conn.execute(
+        "SELECT symbol, quantity, avg_price, high_water_mark, entry_trading_day "
+        "FROM positions WHERE quantity > 0"
+    ).fetchall()
+    return [
+        {
+            "symbol": r[0],
+            "quantity": int(r[1]),
+            "avg_price": float(r[2]),
+            "high_water_mark": float(r[3]) if r[3] else None,
+            "entry_trading_day": r[4],
+        }
+        for r in rows
+    ]
+
+
+def _get_eod_closes(conn: sqlite3.Connection, symbol: str, days: int = 60) -> list[float]:
+    """從 eod_prices 取最近 N 日收盤價（由舊到新）。"""
+    rows = conn.execute(
+        "SELECT close FROM eod_prices WHERE symbol=? AND close IS NOT NULL "
+        "ORDER BY trade_date DESC LIMIT ?",
+        (symbol, days),
+    ).fetchall()
+    return [r[0] for r in reversed(rows)]
+
+
+def _persist_eod_decision(
+    conn: sqlite3.Connection,
+    *,
+    symbol: str,
+    signal_reason: str,
+) -> str:
+    """寫入 decision 表記錄 EOD fallback exit signal。"""
+    decision_id = str(uuid.uuid4())
+    now_iso = datetime.now(tz=timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO decisions (decision_id, ts, symbol, strategy_id, strategy_version, "
+        "signal_side, signal_score, signal_ttl_ms, reason_json) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            decision_id,
+            now_iso,
+            symbol,
+            "eod_exit_fallback",
+            "v1",
+            "sell",
+            0.95,
+            86400000,  # 24h TTL
+            f'{{"source": "eod_exit_check", "reason": "{signal_reason}"}}',
+        ),
+    )
+    conn.commit()
+    return decision_id
+
+
+def _send_telegram_alert(symbol: str, reason: str, avg_price: float, latest_close: float) -> None:
+    """發送 Telegram 止損/止盈告警。"""
+    try:
+        from openclaw.tg_notify import send_alert
+        pnl_pct = (latest_close - avg_price) / avg_price * 100 if avg_price > 0 else 0
+        msg = (
+            f"⚠️ EOD Exit Signal ─ {symbol}\n"
+            f"原因: {reason}\n"
+            f"均價: {avg_price:.2f} → 收盤: {latest_close:.2f} ({pnl_pct:+.1f}%)\n"
+            f"下一交易日開盤請評估是否執行賣出"
+        )
+        send_alert(msg)
+    except Exception as e:
+        log.warning("[eod_exit_check] Telegram alert failed for %s: %s", symbol, e)
+
+
+def run_eod_exit_check(
+    conn: sqlite3.Connection,
+    params: Optional[SignalParams] = None,
+) -> list[dict]:
+    """對所有持倉用最新 eod_prices 重跑 evaluate_exit()。
+
+    Returns:
+        list of dicts with keys: symbol, signal, reason, decision_id
+    """
+    if params is None:
+        params = SignalParams()
+
+    old_row_factory = conn.row_factory
+    conn.row_factory = None
+    try:
+        positions = _get_positions_with_hwm(conn)
+    finally:
+        conn.row_factory = old_row_factory
+
+    results: List[dict] = []
+
+    for pos in positions:
+        symbol = pos["symbol"]
+        conn.row_factory = None
+        try:
+            closes = _get_eod_closes(conn, symbol)
+        finally:
+            conn.row_factory = old_row_factory
+
+        if len(closes) < 5:
+            log.debug("[eod_exit_check] %s: insufficient data (%d closes)", symbol, len(closes))
+            continue
+
+        sig = evaluate_exit(
+            closes,
+            avg_price=pos["avg_price"],
+            high_water_mark=pos["high_water_mark"],
+            params=params,
+        )
+
+        if sig.signal != "sell":
+            continue
+
+        log.info("[eod_exit_check] %s: EXIT signal — %s", symbol, sig.reason)
+
+        conn.row_factory = None
+        try:
+            decision_id = _persist_eod_decision(
+                conn, symbol=symbol, signal_reason=sig.reason,
+            )
+        finally:
+            conn.row_factory = old_row_factory
+
+        latest_close = closes[-1] if closes else 0
+        _send_telegram_alert(symbol, sig.reason, pos["avg_price"], latest_close)
+
+        results.append({
+            "symbol": symbol,
+            "signal": sig.signal,
+            "reason": sig.reason,
+            "decision_id": decision_id,
+        })
+
+    return results

--- a/src/openclaw/eod_ingest.py
+++ b/src/openclaw/eod_ingest.py
@@ -417,16 +417,34 @@ def main() -> None:
                     file=__import__("sys").stderr,
                 )
 
-        # ── Positions current_price sync ──────────────────────────────────
+        # ── Positions current_price sync + HWM backfill ─────────────────
         positions_updated = 0
         if status == "success":
             try:
-                from openclaw.pnl_engine import refresh_current_prices
+                from openclaw.pnl_engine import refresh_current_prices, backfill_high_water_mark
                 conn.row_factory = None
                 positions_updated = refresh_current_prices(conn)
+                backfill_high_water_mark(conn)
             except Exception as pos_exc:
                 print(
                     f"[eod_ingest] positions price sync skipped: {pos_exc}",
+                    file=__import__("sys").stderr,
+                )
+
+            # ── EOD fallback exit signal check ───────────────────────────
+            # 盤後用最新 eod_prices 對所有持倉重跑 evaluate_exit()
+            # 補漏盤中 watcher 因故未觸發的 stop_loss / trailing_stop
+            try:
+                from openclaw.eod_exit_check import run_eod_exit_check
+                eod_exit_results = run_eod_exit_check(conn)
+                if eod_exit_results:
+                    print(
+                        f"[eod_ingest] EOD exit signals: {eod_exit_results}",
+                        file=__import__("sys").stderr,
+                    )
+            except Exception as exit_exc:
+                print(
+                    f"[eod_ingest] EOD exit check skipped: {exit_exc}",
                     file=__import__("sys").stderr,
                 )
 

--- a/src/openclaw/pnl_engine.py
+++ b/src/openclaw/pnl_engine.py
@@ -104,9 +104,13 @@ def refresh_current_prices(conn: sqlite3.Connection) -> int:
     return PnLRepository(conn).refresh_current_prices()
 
 
-def _backfill_high_water_mark(conn: sqlite3.Connection) -> None:
+def backfill_high_water_mark(conn: sqlite3.Connection) -> None:
     """Set high_water_mark from eod_prices max(close) since entry for positions missing it."""
     PnLRepository(conn).backfill_high_water_mark()
+
+
+# keep private alias for backward compat
+_backfill_high_water_mark = backfill_high_water_mark
 
 
 # ── API helpers ──────────────────────────────────────────────────────────────

--- a/tests/test_eod_exit_check.py
+++ b/tests/test_eod_exit_check.py
@@ -1,0 +1,163 @@
+"""Tests for eod_exit_check — 盤後 exit signal fallback."""
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from openclaw.eod_exit_check import run_eod_exit_check
+from openclaw.signal_logic import SignalParams
+
+
+@pytest.fixture()
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.executescript("""
+        CREATE TABLE positions (
+            symbol TEXT PRIMARY KEY, quantity INTEGER, avg_price REAL,
+            current_price REAL DEFAULT 0, unrealized_pnl REAL DEFAULT 0,
+            state TEXT DEFAULT 'ACTIVE', high_water_mark REAL,
+            entry_trading_day TEXT
+        );
+        CREATE TABLE eod_prices (
+            trade_date TEXT, symbol TEXT, open REAL, high REAL,
+            low REAL, close REAL, volume INTEGER
+        );
+        CREATE TABLE decisions (
+            decision_id TEXT PRIMARY KEY, ts TEXT NOT NULL,
+            symbol TEXT NOT NULL, strategy_id TEXT NOT NULL,
+            strategy_version TEXT NOT NULL,
+            signal_side TEXT NOT NULL CHECK (signal_side IN ('buy','sell','flat')),
+            signal_score REAL NOT NULL,
+            signal_ttl_ms INTEGER NOT NULL DEFAULT 30000,
+            llm_ref TEXT, reason_json TEXT NOT NULL
+        );
+    """)
+    return c
+
+
+def _seed_eod_prices(conn, symbol, closes, start_date="2026-03-01"):
+    """Insert eod_prices rows with ascending trade dates."""
+    for i, close in enumerate(closes):
+        d = int(start_date.split("-")[2]) + i
+        date_str = f"2026-03-{d:02d}"
+        conn.execute(
+            "INSERT INTO eod_prices VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (date_str, symbol, close, close + 2, close - 2, close, 10000),
+        )
+
+
+class TestEodExitCheckTrailingStop:
+    """trailing_stop should fire when price drops below HWM * (1 - trailing_pct)."""
+
+    def test_trailing_stop_fires_with_hwm(self, conn):
+        # Position: avg=100, HWM=120, current=110
+        # profit_pct = (120-100)/100 = 20% → Tier 2 trailing (4%)
+        # stop level = 120 * 0.96 = 115.2 → 110 < 115.2 → SELL
+        conn.execute(
+            "INSERT INTO positions VALUES ('2330', 1000, 100.0, 110.0, 10000.0, 'ACTIVE', 120.0, '2026-03-01')"
+        )
+        _seed_eod_prices(conn, "2330", [105, 110, 115, 120, 118, 115, 112, 110])
+
+        with patch("openclaw.eod_exit_check._send_telegram_alert"):
+            results = run_eod_exit_check(conn)
+
+        assert len(results) == 1
+        assert results[0]["symbol"] == "2330"
+        assert results[0]["signal"] == "sell"
+        assert "trailing_stop" in results[0]["reason"]
+
+        # Verify decision persisted
+        row = conn.execute(
+            "SELECT * FROM decisions WHERE decision_id=?",
+            (results[0]["decision_id"],),
+        ).fetchone()
+        assert row is not None
+        assert row[3] == "eod_exit_fallback"  # strategy_id
+
+    def test_no_signal_when_price_above_trailing(self, conn):
+        # avg=115, HWM=120, profit_pct=(120-115)/115=4.3% → Tier 1 (5%)
+        # stop level = 120 * 0.95 = 114 → current=116 > 114 → no trailing
+        # take_profit = 115 * 1.02 = 117.3 → current=116 < 117.3 → no take_profit
+        # stop_loss = 115 * 0.97 = 111.55 → current=116 > 111.55 → no stop_loss
+        conn.execute(
+            "INSERT INTO positions VALUES ('2330', 1000, 115.0, 116.0, 1000.0, 'ACTIVE', 120.0, '2026-03-01')"
+        )
+        _seed_eod_prices(conn, "2330", [112, 115, 118, 120, 119, 117, 116])
+
+        with patch("openclaw.eod_exit_check._send_telegram_alert"):
+            results = run_eod_exit_check(conn)
+
+        assert len(results) == 0
+
+
+class TestEodExitCheckStopLoss:
+    """stop_loss should fire when price drops below avg * (1 - stop_loss_pct)."""
+
+    def test_stop_loss_fires(self, conn):
+        # avg=100, stop_loss=3% → level=97, current=95 → SELL
+        # No HWM → trailing won't fire, but stop_loss will
+        conn.execute(
+            "INSERT INTO positions VALUES ('1303', 500, 100.0, 95.0, -2500.0, 'ACTIVE', NULL, '2026-03-01')"
+        )
+        _seed_eod_prices(conn, "1303", [100, 99, 98, 97, 96, 95])
+
+        with patch("openclaw.eod_exit_check._send_telegram_alert"):
+            results = run_eod_exit_check(conn)
+
+        assert len(results) == 1
+        assert results[0]["symbol"] == "1303"
+        assert "stop_loss" in results[0]["reason"]
+
+
+class TestEodExitCheckTakeProfit:
+    """take_profit should fire when price exceeds avg * (1 + take_profit_pct)."""
+
+    def test_take_profit_fires(self, conn):
+        # avg=100, take_profit=2% → level=102, current=103 → SELL
+        # No HWM so trailing won't fire first
+        conn.execute(
+            "INSERT INTO positions VALUES ('2886', 500, 100.0, 103.0, 1500.0, 'ACTIVE', NULL, '2026-03-01')"
+        )
+        _seed_eod_prices(conn, "2886", [100, 100.5, 101, 101.5, 102, 103])
+
+        with patch("openclaw.eod_exit_check._send_telegram_alert"):
+            results = run_eod_exit_check(conn)
+
+        assert len(results) == 1
+        assert "take_profit" in results[0]["reason"]
+
+
+class TestEodExitCheckNoPosition:
+    """No results when no positions exist."""
+
+    def test_empty_positions(self, conn):
+        results = run_eod_exit_check(conn)
+        assert results == []
+
+
+class TestEodExitCheckInsufficientData:
+    """Skip positions with insufficient eod_prices data."""
+
+    def test_skips_with_few_closes(self, conn):
+        conn.execute(
+            "INSERT INTO positions VALUES ('9999', 100, 50.0, 40.0, -1000.0, 'ACTIVE', NULL, '2026-03-01')"
+        )
+        # Only 3 data points, need at least 5
+        _seed_eod_prices(conn, "9999", [50, 45, 40])
+
+        results = run_eod_exit_check(conn)
+        assert results == []
+
+
+class TestBackfillHwmCalledByEodIngest:
+    """Verify backfill_high_water_mark is now public in pnl_engine."""
+
+    def test_public_export(self):
+        from openclaw.pnl_engine import backfill_high_water_mark
+        assert callable(backfill_high_water_mark)
+
+    def test_private_alias_still_exists(self):
+        from openclaw.pnl_engine import _backfill_high_water_mark
+        assert callable(_backfill_high_water_mark)


### PR DESCRIPTION
## Summary

- **eod_ingest** 完成後未呼叫 `backfill_high_water_mark()`，導致 `positions.high_water_mark` 為 NULL，trailing stop 完全失效
- 盤後無機制用最新 eod_prices 重跑 `evaluate_exit()`，盤中 watcher 因 Shioaji 斷線遺漏止損信號
- 1303 持倉從峰值 94.7 跌至 78.7（-16.9%）完全無觸發

### 修復內容
- `pnl_engine.py`: 公開 `backfill_high_water_mark`（原 private `_backfill_high_water_mark`）
- `eod_ingest.py`: `refresh_current_prices()` 後立即呼叫 `backfill_high_water_mark()` + 新增 `eod_exit_check` 呼叫
- **新增** `eod_exit_check.py`: 盤後對所有持倉重跑 `evaluate_exit()`，觸發時寫入 decision + Telegram 通知
- **新增** `tests/test_eod_exit_check.py`: 8 個測試覆蓋 trailing_stop / stop_loss / take_profit / edge cases

## Test plan
- [x] `pytest tests/test_eod_exit_check.py` — 8/8 passed
- [x] `pytest tests/` — 1051 passed, 0 failed
- [x] 手動回填 1303 HWM (94.7) + current_price (78.7) 確認正確

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)