### PR TITLE
fix(issue-528): fix flaky test_run_memory_hygiene_no_expiry

### DIFF
--- a/src/tests/test_memory_store.py
+++ b/src/tests/test_memory_store.py
@@ -518,7 +518,10 @@ def test_run_memory_hygiene():
 
 
 def test_run_memory_hygiene_no_expiry():
+    from datetime import datetime, timedelta
     conn = _conn()
+    # Use a recent date (within 90-day window) to avoid date-sensitive flakiness
+    recent_date = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
     upsert_semantic_rule(
         conn,
         SemanticRule(
@@ -526,7 +529,7 @@ def test_run_memory_hygiene_no_expiry():
             confidence=0.9,
             source_episodes=[],
             sample_count=1,
-            last_validated_date="2026-01-01",
+            last_validated_date=recent_date,
         ),
     )
     result = run_memory_hygiene(conn)


### PR DESCRIPTION
## Summary
- `test_run_memory_hygiene_no_expiry` 使用硬編碼 `2026-01-01` 作為 `last_validated_date`，超過 90 天過期閾值後 CI 失敗
- 改為使用 `today - 30 days` 相對日期，永不過期

## Test plan
- [x] `pytest src/tests/test_memory_store.py::test_run_memory_hygiene_no_expiry` — passed

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)