### PR TITLE
feat: add market regime filter — block buy when 0050 MA5<MA20

### DIFF
--- a/src/openclaw/ticker_watcher.py
+++ b/src/openclaw/ticker_watcher.py
@@ -157,6 +157,61 @@ def _get_orders_last_60s(conn: sqlite3.Connection) -> int:
         return 0
 
 
+# ── 市場制度濾波器 (#531) ─────────────────────────────────────────────────
+_MARKET_REGIME_SYMBOL: str = _os.environ.get("MARKET_REGIME_SYMBOL", "0050")
+_MARKET_REGIME_MA_SHORT: int = int(_os.environ.get("MARKET_REGIME_MA_SHORT", "5"))
+_MARKET_REGIME_MA_LONG: int = int(_os.environ.get("MARKET_REGIME_MA_LONG", "20"))
+
+# Cache: (date_str, result) — recalculate once per calendar day
+_market_regime_cache: tuple[Optional[str], bool] = (None, True)
+
+
+def _is_market_bullish(conn: sqlite3.Connection) -> bool:
+    """0050 MA5 >= MA20 時視為多頭市場，允許建倉。
+
+    Bearish (MA5 < MA20) → 禁止新建倉（buy 信號降級為 hold），只允許賣出。
+    資料不足（< MA_LONG 筆 eod_prices）→ 不阻擋（fail-open）。
+    結果按日快取，避免每個 symbol 重複查詢。
+
+    Issue: #531
+    """
+    global _market_regime_cache
+
+    today_str = dt.datetime.now(tz=dt.timezone(dt.timedelta(hours=8))).strftime("%Y-%m-%d")
+    if _market_regime_cache[0] == today_str:
+        return _market_regime_cache[1]
+
+    try:
+        rows = conn.execute(
+            "SELECT close FROM eod_prices WHERE symbol = ? "
+            "ORDER BY trade_date DESC LIMIT ?",
+            (_MARKET_REGIME_SYMBOL, _MARKET_REGIME_MA_LONG),
+        ).fetchall()
+
+        if len(rows) < _MARKET_REGIME_MA_LONG:
+            log.warning("market regime: insufficient data (%d rows) for %s — fail-open",
+                        len(rows), _MARKET_REGIME_SYMBOL)
+            _market_regime_cache = (today_str, True)
+            return True
+
+        # rows are newest-first from DESC; reverse for chronological
+        closes = [float(r[0]) for r in reversed(rows)]
+        ma_short = sum(closes[-_MARKET_REGIME_MA_SHORT:]) / _MARKET_REGIME_MA_SHORT
+        ma_long = sum(closes) / _MARKET_REGIME_MA_LONG
+        bullish = ma_short >= ma_long
+
+        _market_regime_cache = (today_str, bullish)
+        log.info("market regime: %s MA%d=%.2f MA%d=%.2f → %s",
+                 _MARKET_REGIME_SYMBOL, _MARKET_REGIME_MA_SHORT, ma_short,
+                 _MARKET_REGIME_MA_LONG, ma_long,
+                 "BULLISH" if bullish else "BEARISH")
+        return bullish
+    except sqlite3.Error as e:
+        log.warning("market regime check failed: %s — fail-open", e)
+        _market_regime_cache = (today_str, True)
+        return True
+
+
 def _get_today_buy_filled_symbols(conn: sqlite3.Connection) -> set:
     """返回今日（UTC+8）已有 fills 的 buy 訂單 symbol 集合，用於 wash sale 防護。"""
     try:
@@ -1304,6 +1359,17 @@ def run_watcher() -> None:
                                approved=False, reject_code="RISK_MOCK_DATA_FORBIDDEN",
                                decision_id=decision_id, extra_meta=_agg_meta)
                     log.info("[%s] signal=buy BLOCKED — mock data mode", symbol)
+                    continue
+
+                # ── 市場制度濾波器：大盤 MA5<MA20 時禁止建倉 (#531) ────────
+                if sig == "buy" and not _is_market_bullish(conn):
+                    _agg_meta["market_regime"] = "bearish"
+                    _log_trace(conn, symbol=symbol, signal=sig, snap=snap,
+                               approved=False, reject_code="RISK_MARKET_REGIME_BEARISH",
+                               decision_id=decision_id, extra_meta=_agg_meta)
+                    log.info("[%s] signal=buy BLOCKED — market regime bearish (%s MA%d < MA%d)",
+                             symbol, _MARKET_REGIME_SYMBOL,
+                             _MARKET_REGIME_MA_SHORT, _MARKET_REGIME_MA_LONG)
                     continue
 
                 # ── 策略立場守衛：委員會 stance 影響買入決策 (#383) ────────

--- a/tests/test_market_regime_filter.py
+++ b/tests/test_market_regime_filter.py
@@ -1,0 +1,191 @@
+"""Tests for market regime filter (#531).
+
+Covers:
+- _is_market_bullish returns True when MA5 >= MA20 (bullish)
+- _is_market_bullish returns False when MA5 < MA20 (bearish)
+- Fail-open when insufficient data (< 20 rows)
+- Fail-open on DB error
+- Daily cache — same day returns cached result without re-querying
+- Cache resets on new day
+- Environment variable overrides for symbol and MA periods
+"""
+from __future__ import annotations
+
+import datetime as dt
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper: build in-memory DB with eod_prices table
+# ---------------------------------------------------------------------------
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE eod_prices (
+            trade_date TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            open REAL, high REAL, low REAL,
+            close REAL,
+            volume REAL,
+            PRIMARY KEY (trade_date, symbol)
+        )
+        """
+    )
+    return conn
+
+
+def _insert_prices(
+    conn: sqlite3.Connection,
+    symbol: str,
+    closes: list[float],
+    start_date: str = "2026-03-10",
+) -> None:
+    """Insert daily close prices starting from start_date (newest last)."""
+    base = dt.datetime.strptime(start_date, "%Y-%m-%d")
+    for i, close in enumerate(closes):
+        trade_date = (base + dt.timedelta(days=i)).strftime("%Y-%m-%d")
+        conn.execute(
+            "INSERT INTO eod_prices (trade_date, symbol, open, high, low, close, volume) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (trade_date, symbol, close, close, close, close, 1000),
+        )
+    conn.commit()
+
+
+def _reset_cache() -> None:
+    """Reset the module-level regime cache between tests."""
+    import openclaw.ticker_watcher as tw
+    tw._market_regime_cache = (None, True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _is_market_bullish
+# ---------------------------------------------------------------------------
+
+class TestIsMarketBullish:
+    def setup_method(self):
+        _reset_cache()
+
+    def test_bullish_when_ma5_above_ma20(self):
+        """MA5 > MA20 → bullish (True)."""
+        from openclaw.ticker_watcher import _is_market_bullish
+        conn = _make_db()
+        # 20 prices: first 15 low, last 5 high → MA5 > MA20
+        closes = [70.0] * 15 + [80.0] * 5
+        _insert_prices(conn, "0050", closes)
+        assert _is_market_bullish(conn) is True
+
+    def test_bearish_when_ma5_below_ma20(self):
+        """MA5 < MA20 → bearish (False)."""
+        from openclaw.ticker_watcher import _is_market_bullish
+        conn = _make_db()
+        # 20 prices: first 15 high, last 5 low → MA5 < MA20
+        closes = [80.0] * 15 + [70.0] * 5
+        _insert_prices(conn, "0050", closes)
+        assert _is_market_bullish(conn) is False
+
+    def test_bullish_when_ma5_equals_ma20(self):
+        """MA5 == MA20 → treated as bullish (>=)."""
+        from openclaw.ticker_watcher import _is_market_bullish
+        conn = _make_db()
+        # All same price → MA5 == MA20
+        closes = [75.0] * 20
+        _insert_prices(conn, "0050", closes)
+        assert _is_market_bullish(conn) is True
+
+    def test_fail_open_insufficient_data(self):
+        """< 20 rows → fail-open (True) to avoid blocking trades without data."""
+        from openclaw.ticker_watcher import _is_market_bullish
+        conn = _make_db()
+        closes = [70.0] * 10  # only 10 rows, need 20
+        _insert_prices(conn, "0050", closes)
+        assert _is_market_bullish(conn) is True
+
+    def test_fail_open_empty_table(self):
+        """No data at all → fail-open (True)."""
+        from openclaw.ticker_watcher import _is_market_bullish
+        conn = _make_db()
+        assert _is_market_bullish(conn) is True
+
+    def test_fail_open_on_db_error(self):
+        """DB error → fail-open (True)."""
+        from openclaw.ticker_watcher import _is_market_bullish
+        conn = _make_db()
+        conn.execute("DROP TABLE eod_prices")
+        assert _is_market_bullish(conn) is True
+
+    def test_cache_returns_same_result_on_same_day(self):
+        """Cache prevents re-query within the same calendar day."""
+        from openclaw.ticker_watcher import _is_market_bullish
+        conn = _make_db()
+        # First call: bearish
+        closes = [80.0] * 15 + [70.0] * 5
+        _insert_prices(conn, "0050", closes)
+        assert _is_market_bullish(conn) is False
+
+        # Change data to bullish, but cache should still return False
+        conn.execute("DELETE FROM eod_prices")
+        closes_bull = [70.0] * 15 + [80.0] * 5
+        _insert_prices(conn, "0050", closes_bull)
+        assert _is_market_bullish(conn) is False  # cached
+
+    def test_cache_resets_on_new_day(self):
+        """Cache invalidates when the date changes."""
+        import openclaw.ticker_watcher as tw
+        from openclaw.ticker_watcher import _is_market_bullish
+
+        conn = _make_db()
+        closes = [80.0] * 15 + [70.0] * 5
+        _insert_prices(conn, "0050", closes)
+        assert _is_market_bullish(conn) is False
+
+        # Simulate next day by clearing cache with a different date
+        tw._market_regime_cache = (None, True)
+
+        # Now insert bullish data
+        conn.execute("DELETE FROM eod_prices")
+        closes_bull = [70.0] * 15 + [80.0] * 5
+        _insert_prices(conn, "0050", closes_bull)
+        assert _is_market_bullish(conn) is True
+
+    def test_uses_correct_symbol_from_env(self, monkeypatch):
+        """MARKET_REGIME_SYMBOL env var overrides the default 0050."""
+        _reset_cache()
+        monkeypatch.setenv("MARKET_REGIME_SYMBOL", "0051")
+
+        # Need to reload to pick up env var
+        import importlib
+        import openclaw.ticker_watcher as tw
+        old_symbol = tw._MARKET_REGIME_SYMBOL
+        tw._MARKET_REGIME_SYMBOL = "0051"
+
+        try:
+            conn = _make_db()
+            # Insert 0050 bearish (should be ignored)
+            _insert_prices(conn, "0050", [80.0] * 15 + [70.0] * 5)
+            # Insert 0051 bullish
+            _insert_prices(conn, "0051", [70.0] * 15 + [80.0] * 5)
+
+            from openclaw.ticker_watcher import _is_market_bullish
+            assert _is_market_bullish(conn) is True
+        finally:
+            tw._MARKET_REGIME_SYMBOL = old_symbol
+
+    def test_realistic_price_sequence(self):
+        """Test with realistic 0050 price data (recent actual bearish)."""
+        from openclaw.ticker_watcher import _is_market_bullish
+        conn = _make_db()
+        # Simulated 0050: declining trend (MA5 < MA20)
+        closes = [
+            78.75, 77.40, 76.85, 75.60, 75.20, 78.20, 76.60, 75.95,
+            75.60, 76.65, 76.00, 77.80, 76.20, 75.80, 75.00, 73.90,
+            72.35, 75.45, 73.95, 74.00,
+        ]
+        _insert_prices(conn, "0050", closes)
+        # MA5 ≈ 74.15, MA20 ≈ 75.69 → bearish
+        assert _is_market_bullish(conn) is False


### PR DESCRIPTION
## Summary
- 新增市場制度濾波器 `_is_market_bullish()`：當 0050 MA5 < MA20（空頭制度）時，所有 buy 信號被攔截（reject code: `RISK_MARKET_REGIME_BEARISH`）
- 插入 `ticker_watcher.py` 的 buy guard chain（mock 防護之後、委員會 stance 之前）
- 10 個單元測試覆蓋：多頭/空頭/邊界/fail-open/快取/env 覆寫

## 背景
2026-03-02 至 04-02 期間，系統在大盤死亡交叉（MA5 < MA20）時建立 9 筆倉位，**全數虧損（0% 勝率）**，Sharpe -13.85。根因：缺乏大盤趨勢過濾，逆勢建倉。

## 設計決策
- **Fail-open**：資料不足或 DB 錯誤時不阻擋交易（避免 false negative）
- **按日快取**：同一天內只查一次 eod_prices，避免每 symbol 重複查詢
- **環境變數覆寫**：`MARKET_REGIME_SYMBOL`、`MARKET_REGIME_MA_SHORT`、`MARKET_REGIME_MA_LONG`
- 放在 `ticker_watcher.py`（風控攔截層）而非 `signal_logic.py`（純函數層），保持信號邏輯的可測試性

## Test plan
- [x] 10 unit tests all pass (`pytest tests/test_market_regime_filter.py -v`)
- [x] Full test suite 1061 passed, 0 failed
- [ ] simulation_mode 觀察 7 天確認無副作用
- [ ] PM2 restart 後 watcher 正常運行

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)