### PR TITLE
feat(security): red team simulator

### DIFF
--- a/tools/redteam/__init__.py
+++ b/tools/redteam/__init__.py
@@ -1,0 +1,1 @@
+"""Security Red Team Simulator for ai-trader."""

--- a/tools/redteam/attack_simulators/__init__.py
+++ b/tools/redteam/attack_simulators/__init__.py
@@ -1,0 +1,1 @@
+"""Attack simulator modules — safe, localhost-only payloads."""

--- a/tools/redteam/attack_simulators/auth_bypass.py
+++ b/tools/redteam/attack_simulators/auth_bypass.py
@@ -1,0 +1,85 @@
+"""auth_bypass.py — Test no-token / expired-token / empty-bearer scenarios."""
+from __future__ import annotations
+
+import json
+from typing import List
+
+import urllib.request
+import urllib.error
+
+from ..finding_scorer import Finding
+
+# Endpoints commonly requiring auth
+_AUTH_ENDPOINTS = [
+    "/api/portfolio",
+    "/api/trades",
+    "/api/config",
+    "/api/agents",
+    "/api/admin",
+    "/api/user/profile",
+]
+
+_BYPASS_CASES = [
+    ("no-token", {}),
+    ("empty-bearer", {"Authorization": "Bearer "}),
+    ("null-bearer", {"Authorization": "Bearer null"}),
+    ("expired-token", {"Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjB9.invalid"}),
+]
+
+
+def scan_auth_bypass(
+    base_url: str,
+    max_requests: int = 10,
+    timeout: int = 5,
+) -> List[Finding]:
+    """Test authentication bypass on API endpoints (localhost only)."""
+    if not base_url.startswith(("http://localhost", "http://127.0.0.1")):
+        return []
+
+    findings: List[Finding] = []
+    request_count = 0
+
+    for endpoint in _AUTH_ENDPOINTS:
+        for case_name, headers in _BYPASS_CASES:
+            if request_count >= max_requests:
+                return findings
+
+            url = f"{base_url}{endpoint}"
+            request_count += 1
+
+            try:
+                req = urllib.request.Request(url, method="GET")
+                req.add_header("User-Agent", "RedTeam-Scanner/1.0 (security-audit)")
+                for k, v in headers.items():
+                    req.add_header(k, v)
+
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    body = resp.read(4096).decode("utf-8", errors="ignore")
+                    status = resp.status
+
+                    # 2xx without auth = finding
+                    if 200 <= status < 300:
+                        # Check if we actually got data (not a generic "ok" page)
+                        is_data = False
+                        try:
+                            parsed = json.loads(body)
+                            is_data = bool(parsed) and not parsed.get("error")
+                        except (json.JSONDecodeError, AttributeError):
+                            is_data = len(body) > 50
+
+                        if is_data:
+                            findings.append(Finding(
+                                title=f"Auth bypass: {endpoint} ({case_name})",
+                                description=f"Endpoint returned data without valid authentication",
+                                category="auth-bypass",
+                                evidence=f"URL: {url}, Case: {case_name}, Status: {status}, Body: {body[:100]}",
+                                remediation="Enforce authentication middleware on all API endpoints",
+                            ))
+            except urllib.error.HTTPError as e:
+                # 401/403 is expected — endpoint is properly protected
+                if e.code not in (401, 403):
+                    pass
+            except (urllib.error.URLError, OSError, TimeoutError):
+                pass
+
+    return findings

--- a/tools/redteam/attack_simulators/auth_bypass.py
+++ b/tools/redteam/attack_simulators/auth_bypass.py
@@ -6,8 +6,15 @@ from typing import List
 
 import urllib.request
 import urllib.error
+from urllib.parse import urlparse
 
 from ..finding_scorer import Finding
+
+
+def _is_localhost(url: str) -> bool:
+    """Check if URL targets localhost using proper URL parsing."""
+    parsed = urlparse(url)
+    return parsed.hostname in ("localhost", "127.0.0.1", "::1")
 
 # Endpoints commonly requiring auth
 _AUTH_ENDPOINTS = [
@@ -33,7 +40,7 @@ def scan_auth_bypass(
     timeout: int = 5,
 ) -> List[Finding]:
     """Test authentication bypass on API endpoints (localhost only)."""
-    if not base_url.startswith(("http://localhost", "http://127.0.0.1")):
+    if not _is_localhost(base_url):
         return []
 
     findings: List[Finding] = []
@@ -68,11 +75,18 @@ def scan_auth_bypass(
                             is_data = len(body) > 50
 
                         if is_data:
+                            # Summarise response structure, not actual values (avoid leaking sensitive data)
+                            try:
+                                parsed_summary = json.loads(body)
+                                body_summary = f"JSON keys: {list(parsed_summary.keys())[:5]}"
+                            except (json.JSONDecodeError, AttributeError):
+                                body_summary = f"text, {len(body)} bytes"
+
                             findings.append(Finding(
                                 title=f"Auth bypass: {endpoint} ({case_name})",
                                 description=f"Endpoint returned data without valid authentication",
                                 category="auth-bypass",
-                                evidence=f"URL: {url}, Case: {case_name}, Status: {status}, Body: {body[:100]}",
+                                evidence=f"URL: {url}, Case: {case_name}, Status: {status}, Response: {body_summary}",
                                 remediation="Enforce authentication middleware on all API endpoints",
                             ))
             except urllib.error.HTTPError as e:

--- a/tools/redteam/attack_simulators/path_traversal.py
+++ b/tools/redteam/attack_simulators/path_traversal.py
@@ -1,0 +1,61 @@
+"""path_traversal.py — Test directory traversal with safe payloads."""
+from __future__ import annotations
+
+from typing import List
+from urllib.parse import quote
+
+import urllib.request
+import urllib.error
+
+from ..finding_scorer import Finding
+
+# Safe payloads — only attempt to read known-safe files
+_TRAVERSAL_PAYLOADS = [
+    "../../../etc/passwd",
+    "..%2F..%2F..%2Fetc%2Fpasswd",
+    "....//....//....//etc/passwd",
+    "%2e%2e/%2e%2e/%2e%2e/etc/passwd",
+    "..\\..\\..\\etc\\passwd",
+]
+
+# Common endpoints that might accept file parameters
+_FILE_PARAMS = ["file", "path", "page", "template", "include", "doc"]
+
+
+def scan_path_traversal(
+    base_url: str,
+    max_requests: int = 10,
+    timeout: int = 5,
+) -> List[Finding]:
+    """Send path traversal payloads to a target (localhost only)."""
+    if not base_url.startswith(("http://localhost", "http://127.0.0.1")):
+        return []
+
+    findings: List[Finding] = []
+    request_count = 0
+
+    for param in _FILE_PARAMS:
+        for payload in _TRAVERSAL_PAYLOADS:
+            if request_count >= max_requests:
+                return findings
+
+            url = f"{base_url}?{param}={quote(payload, safe='')}"
+            request_count += 1
+
+            try:
+                req = urllib.request.Request(url, method="GET")
+                req.add_header("User-Agent", "RedTeam-Scanner/1.0 (security-audit)")
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    body = resp.read(4096).decode("utf-8", errors="ignore")
+                    if "root:" in body or "/bin/bash" in body or "/bin/sh" in body:
+                        findings.append(Finding(
+                            title=f"Path traversal via ?{param}=",
+                            description=f"Server returned sensitive file content for payload: {payload}",
+                            category="path-traversal",
+                            evidence=f"URL: {url}, Status: {resp.status}, Body snippet: {body[:100]}",
+                            remediation="Sanitize file path inputs; use allowlist for accessible files",
+                        ))
+            except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
+                pass
+
+    return findings

--- a/tools/redteam/attack_simulators/ssrf.py
+++ b/tools/redteam/attack_simulators/ssrf.py
@@ -2,12 +2,28 @@
 from __future__ import annotations
 
 from typing import List
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import urllib.request
 import urllib.error
 
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Block HTTP redirects to prevent the SSRF scanner itself becoming an SSRF vector."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_no_redirect_opener = urllib.request.build_opener(_NoRedirectHandler())
+
 from ..finding_scorer import Finding
+
+
+def _is_localhost(url: str) -> bool:
+    """Check if URL targets localhost using proper URL parsing."""
+    parsed = urlparse(url)
+    return parsed.hostname in ("localhost", "127.0.0.1", "::1")
 
 # Internal IP payloads to test for SSRF
 _SSRF_PAYLOADS = [
@@ -30,7 +46,7 @@ def scan_ssrf(
     timeout: int = 5,
 ) -> List[Finding]:
     """Test SSRF by injecting internal IPs into URL parameters (localhost only)."""
-    if not base_url.startswith(("http://localhost", "http://127.0.0.1")):
+    if not _is_localhost(base_url):
         return []
 
     findings: List[Finding] = []
@@ -47,7 +63,7 @@ def scan_ssrf(
             try:
                 req = urllib.request.Request(url, method="GET")
                 req.add_header("User-Agent", "RedTeam-Scanner/1.0 (security-audit)")
-                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                with _no_redirect_opener.open(req, timeout=timeout) as resp:
                     body = resp.read(4096).decode("utf-8", errors="ignore")
                     status = resp.status
 

--- a/tools/redteam/attack_simulators/ssrf.py
+++ b/tools/redteam/attack_simulators/ssrf.py
@@ -1,0 +1,78 @@
+"""ssrf.py — Test internal IP injection (SSRF) with safe payloads."""
+from __future__ import annotations
+
+from typing import List
+from urllib.parse import quote
+
+import urllib.request
+import urllib.error
+
+from ..finding_scorer import Finding
+
+# Internal IP payloads to test for SSRF
+_SSRF_PAYLOADS = [
+    "http://169.254.169.254/latest/meta-data/",   # AWS metadata
+    "http://169.254.169.254/metadata/instance",     # Azure metadata
+    "http://metadata.google.internal/",             # GCP metadata
+    "http://127.0.0.1:22",                          # local SSH
+    "http://0.0.0.0:22",
+    "http://[::1]:22",
+    "http://localhost:6379",                         # Redis
+]
+
+# Endpoints that might accept URL parameters
+_URL_PARAMS = ["url", "target", "redirect", "next", "callback", "webhook"]
+
+
+def scan_ssrf(
+    base_url: str,
+    max_requests: int = 10,
+    timeout: int = 5,
+) -> List[Finding]:
+    """Test SSRF by injecting internal IPs into URL parameters (localhost only)."""
+    if not base_url.startswith(("http://localhost", "http://127.0.0.1")):
+        return []
+
+    findings: List[Finding] = []
+    request_count = 0
+
+    for param in _URL_PARAMS:
+        for payload in _SSRF_PAYLOADS:
+            if request_count >= max_requests:
+                return findings
+
+            url = f"{base_url}?{param}={quote(payload, safe='')}"
+            request_count += 1
+
+            try:
+                req = urllib.request.Request(url, method="GET")
+                req.add_header("User-Agent", "RedTeam-Scanner/1.0 (security-audit)")
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    body = resp.read(4096).decode("utf-8", errors="ignore")
+                    status = resp.status
+
+                    # Signs of successful SSRF
+                    ssrf_indicators = [
+                        "ami-id",           # AWS metadata
+                        "instance-id",
+                        "meta-data",
+                        "SSH-",             # SSH banner
+                        "REDIS",            # Redis
+                        "+PONG",
+                    ]
+
+                    if any(indicator.lower() in body.lower() for indicator in ssrf_indicators):
+                        findings.append(Finding(
+                            title=f"SSRF via ?{param}=",
+                            description=f"Server followed internal URL: {payload}",
+                            category="ssrf",
+                            evidence=f"URL: {url}, Status: {status}, Body: {body[:100]}",
+                            remediation=(
+                                "Validate and sanitize URL parameters; "
+                                "block requests to internal IPs and cloud metadata endpoints"
+                            ),
+                        ))
+            except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
+                pass
+
+    return findings

--- a/tools/redteam/config.yaml
+++ b/tools/redteam/config.yaml
@@ -1,0 +1,30 @@
+# Red Team Simulator Configuration
+# All scans are localhost-only with safe payloads.
+
+scan:
+  max_requests_per_endpoint: 10
+  timeout_seconds: 5
+  localhost_only: true
+
+targets:
+  - name: ai-trader-web
+    url: http://localhost:3000
+    type: web
+  - name: ai-trader-api
+    url: http://localhost:8000
+    type: api
+  - name: ai-trader-ws
+    url: ws://localhost:8080
+    type: websocket
+
+repo_paths:
+  ai-trader: /Users/openclaw/.openclaw/shared/projects/ai-trader
+
+known_config_files:
+  - ecosystem.config.js
+  - .env
+  - .env.production
+  - .env.local
+
+nginx_config_path: /etc/nginx/sites-enabled/
+pm2_binary: pm2

--- a/tools/redteam/config.yaml
+++ b/tools/redteam/config.yaml
@@ -17,8 +17,10 @@ targets:
     url: ws://localhost:8080
     type: websocket
 
+# repo_paths: use relative path (relative to project root) or set via
+# environment variable REDTEAM_REPO_PATH.
 repo_paths:
-  ai-trader: /Users/openclaw/.openclaw/shared/projects/ai-trader
+  ai-trader: .
 
 known_config_files:
   - ecosystem.config.js
@@ -26,5 +28,7 @@ known_config_files:
   - .env.production
   - .env.local
 
+# nginx_config_path / pm2_binary: must match the allowlist in
+# service_enumerator.py (ALLOWED_NGINX_DIRS / ALLOWED_PM2_BINS).
 nginx_config_path: /etc/nginx/sites-enabled/
 pm2_binary: pm2

--- a/tools/redteam/config_auditor.py
+++ b/tools/redteam/config_auditor.py
@@ -1,0 +1,135 @@
+"""config_auditor.py — Check .env permissions, nginx headers, hardcoded secrets."""
+from __future__ import annotations
+
+import os
+import re
+import stat
+from pathlib import Path
+from typing import List
+
+from .finding_scorer import Finding
+
+# Patterns that indicate hardcoded secrets
+_SECRET_PATTERNS = [
+    (r'(?:BOT_TOKEN|API_KEY|SECRET|PASSWORD|PRIVATE_KEY)\s*[:=]\s*["\']?[A-Za-z0-9_\-:]{20,}', "hardcoded-secret"),
+    (r'(?:apiKey|authDomain|messagingSenderId)\s*[:=]\s*["\'][^"\']{10,}["\']', "hardcoded-api-key"),
+    (r'ghp_[A-Za-z0-9]{36}', "hardcoded-secret"),  # GitHub PAT
+    (r'xoxb-[A-Za-z0-9\-]+', "hardcoded-secret"),  # Slack bot token
+]
+
+# Required nginx security headers
+_REQUIRED_HEADERS = [
+    "X-Content-Type-Options",
+    "X-Frame-Options",
+    "Strict-Transport-Security",
+    "Content-Security-Policy",
+]
+
+
+def check_env_permissions(repo_path: str) -> List[Finding]:
+    """Check that .env files are not world-readable."""
+    findings: List[Finding] = []
+    repo = Path(repo_path)
+
+    for env_file in repo.rglob(".env*"):
+        if env_file.is_file() and not env_file.name.endswith(".example"):
+            try:
+                file_stat = os.stat(env_file)
+                mode = file_stat.st_mode
+                if mode & stat.S_IROTH:
+                    findings.append(Finding(
+                        title=f".env world-readable: {env_file.name}",
+                        description=f"{env_file} is readable by all users (mode: {oct(mode)})",
+                        category="insecure-permission",
+                        source_file=str(env_file),
+                        evidence=f"File mode: {oct(mode)}",
+                        remediation=f"Run: chmod 600 {env_file}",
+                    ))
+            except OSError:
+                pass
+    return findings
+
+
+def check_hardcoded_secrets(file_path: str) -> List[Finding]:
+    """Scan a single file for hardcoded secrets."""
+    findings: List[Finding] = []
+    path = Path(file_path)
+
+    if not path.is_file():
+        return findings
+
+    try:
+        content = path.read_text(errors="ignore")
+    except OSError:
+        return findings
+
+    for line_no, line in enumerate(content.splitlines(), start=1):
+        for pattern, category in _SECRET_PATTERNS:
+            if re.search(pattern, line):
+                # Mask the actual value in evidence
+                masked = re.sub(r'([A-Za-z0-9_\-]{4})[A-Za-z0-9_\-]{16,}', r'\1****', line.strip())
+                findings.append(Finding(
+                    title=f"Hardcoded secret in {path.name}",
+                    description=f"Potential secret found at line {line_no}",
+                    category=category,
+                    source_file=str(path),
+                    source_line=line_no,
+                    evidence=f"Line {line_no}: {masked[:120]}",
+                    remediation="Move secret to .env file and reference via environment variable",
+                ))
+                break  # One finding per line
+    return findings
+
+
+def check_nginx_headers(config_dir: str = "/etc/nginx/sites-enabled/") -> List[Finding]:
+    """Check nginx configs for missing security headers."""
+    findings: List[Finding] = []
+    config_path = Path(config_dir)
+
+    if not config_path.exists():
+        return findings
+
+    for conf_file in config_path.iterdir():
+        if not conf_file.is_file():
+            continue
+        try:
+            content = conf_file.read_text()
+        except (OSError, PermissionError):
+            continue
+
+        for header in _REQUIRED_HEADERS:
+            if header.lower() not in content.lower():
+                findings.append(Finding(
+                    title=f"Missing header: {header}",
+                    description=f"nginx config {conf_file.name} lacks {header}",
+                    category="missing-header",
+                    source_file=str(conf_file),
+                    remediation=f"Add: add_header {header} <value>;",
+                ))
+    return findings
+
+
+def audit_config(repo_path: str, nginx_dir: str = "/etc/nginx/sites-enabled/") -> List[Finding]:
+    """Run all config audits for a repo."""
+    findings: List[Finding] = []
+    repo = Path(repo_path)
+
+    # .env permissions
+    findings.extend(check_env_permissions(repo_path))
+
+    # Hardcoded secrets in key config files
+    for config_name in ["ecosystem.config.js", "ecosystem.config.cjs"]:
+        config_file = repo / config_name
+        if config_file.exists():
+            findings.extend(check_hardcoded_secrets(str(config_file)))
+
+    # Check for firebase config files with hardcoded keys
+    for ts_file in repo.rglob("firebase*.ts"):
+        findings.extend(check_hardcoded_secrets(str(ts_file)))
+    for ts_file in repo.rglob("firebase*.js"):
+        findings.extend(check_hardcoded_secrets(str(ts_file)))
+
+    # nginx headers
+    findings.extend(check_nginx_headers(nginx_dir))
+
+    return findings

--- a/tools/redteam/dependency_auditor.py
+++ b/tools/redteam/dependency_auditor.py
@@ -1,0 +1,94 @@
+"""dependency_auditor.py — Run npm audit / pip audit per repo, unified Finding format."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import List
+
+from .finding_scorer import Finding
+
+
+def _run_json(cmd: List[str], cwd: str, timeout: int = 60) -> dict:
+    """Run a command expecting JSON output; return parsed dict or empty."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd,
+        )
+        # npm audit returns non-zero when vulns found — still valid JSON
+        output = result.stdout.strip()
+        if output:
+            return json.loads(output)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError, json.JSONDecodeError):
+        pass
+    return {}
+
+
+def audit_npm(repo_path: str) -> List[Finding]:
+    """Run `npm audit --json` and convert to Finding list."""
+    pkg_json = Path(repo_path) / "package.json"
+    if not pkg_json.exists():
+        return []
+
+    data = _run_json(["npm", "audit", "--json"], cwd=repo_path)
+    if not data:
+        return []
+
+    findings: List[Finding] = []
+    vulnerabilities = data.get("vulnerabilities", {})
+    for pkg_name, vuln_info in vulnerabilities.items():
+        severity = vuln_info.get("severity", "info")
+        category = f"dependency-vuln-{severity}"
+        finding = Finding(
+            title=f"npm: {pkg_name} ({severity})",
+            description=vuln_info.get("title", f"Vulnerability in {pkg_name}"),
+            category=category,
+            source_file="package.json",
+            evidence=f"Range: {vuln_info.get('range', 'unknown')}",
+            remediation=f"Run: npm audit fix or upgrade {pkg_name}",
+        )
+        findings.append(finding)
+    return findings
+
+
+def audit_pip(repo_path: str) -> List[Finding]:
+    """Run `pip audit --format=json` and convert to Finding list."""
+    requirements = Path(repo_path) / "requirements.txt"
+    pyproject = Path(repo_path) / "pyproject.toml"
+    if not requirements.exists() and not pyproject.exists():
+        return []
+
+    data = _run_json(["pip", "audit", "--format=json"], cwd=repo_path)
+    if not data:
+        return []
+
+    findings: List[Finding] = []
+    for vuln in data.get("vulnerabilities", []):
+        pkg = vuln.get("name", "unknown")
+        vuln_id = vuln.get("id", "")
+        desc = vuln.get("description", "")
+        fix_ver = vuln.get("fix_versions", [])
+
+        finding = Finding(
+            title=f"pip: {pkg} ({vuln_id})",
+            description=desc[:200] if desc else f"Vulnerability in {pkg}",
+            category="dependency-vuln-high",
+            source_file="requirements.txt",
+            evidence=f"Installed: {vuln.get('version', '?')}, ID: {vuln_id}",
+            remediation=f"Upgrade to: {', '.join(fix_ver)}" if fix_ver else "Check advisory",
+        )
+        findings.append(finding)
+    return findings
+
+
+def audit_all(repo_paths: dict[str, str]) -> List[Finding]:
+    """Run all dependency audits across configured repos."""
+    findings: List[Finding] = []
+    for _name, path in repo_paths.items():
+        findings.extend(audit_npm(path))
+        findings.extend(audit_pip(path))
+    return findings

--- a/tools/redteam/dependency_auditor.py
+++ b/tools/redteam/dependency_auditor.py
@@ -55,6 +55,18 @@ def audit_npm(repo_path: str) -> List[Finding]:
     return findings
 
 
+# Map pip-audit severity aliases to normalised categories (like npm)
+_PIP_SEVERITY_MAP = {
+    "critical": "critical",
+    "high": "high",
+    "moderate": "medium",
+    "medium": "medium",
+    "low": "low",
+    "info": "info",
+    "unknown": "medium",
+}
+
+
 def audit_pip(repo_path: str) -> List[Finding]:
     """Run `pip audit --format=json` and convert to Finding list."""
     requirements = Path(repo_path) / "requirements.txt"
@@ -73,10 +85,19 @@ def audit_pip(repo_path: str) -> List[Finding]:
         desc = vuln.get("description", "")
         fix_ver = vuln.get("fix_versions", [])
 
+        raw_severity = vuln.get("aliases", [{}])[0] if vuln.get("aliases") else ""
+        # pip-audit may report severity in different fields depending on version
+        sev_str = (
+            vuln.get("severity")
+            or vuln.get("fix_versions_severity", "")
+            or "unknown"
+        ).lower()
+        normalised_sev = _PIP_SEVERITY_MAP.get(sev_str, "medium")
+
         finding = Finding(
             title=f"pip: {pkg} ({vuln_id})",
             description=desc[:200] if desc else f"Vulnerability in {pkg}",
-            category="dependency-vuln-high",
+            category=f"dependency-vuln-{normalised_sev}",
             source_file="requirements.txt",
             evidence=f"Installed: {vuln.get('version', '?')}, ID: {vuln_id}",
             remediation=f"Upgrade to: {', '.join(fix_ver)}" if fix_ver else "Check advisory",

--- a/tools/redteam/finding_scorer.py
+++ b/tools/redteam/finding_scorer.py
@@ -1,0 +1,125 @@
+"""finding_scorer.py — CVSS-like scoring and data models for red team findings."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+
+class Severity(str, Enum):
+    CRITICAL = "Critical"
+    HIGH = "High"
+    MEDIUM = "Medium"
+    LOW = "Low"
+    INFO = "Info"
+
+
+@dataclass
+class Finding:
+    """A single security finding before scoring."""
+
+    title: str
+    description: str
+    category: str  # e.g. "hardcoded-secret", "missing-header", "auth-bypass"
+    source_file: Optional[str] = None
+    source_line: Optional[int] = None
+    evidence: str = ""
+    remediation: str = ""
+
+
+@dataclass
+class ScoredFinding:
+    """A Finding with CVSS-like score and severity."""
+
+    finding: Finding
+    cvss_score: float = 0.0
+    severity: Severity = Severity.INFO
+
+    @property
+    def title(self) -> str:
+        return self.finding.title
+
+    @property
+    def category(self) -> str:
+        return self.finding.category
+
+
+@dataclass
+class ServiceInfo:
+    """Information about a discovered service."""
+
+    name: str
+    pid: Optional[int] = None
+    port: Optional[int] = None
+    status: str = "unknown"
+    pm2_id: Optional[int] = None
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class RedTeamReport:
+    """Aggregated report from all scanners."""
+
+    findings: List[ScoredFinding] = field(default_factory=list)
+    services: List[ServiceInfo] = field(default_factory=list)
+    scan_duration_seconds: float = 0.0
+    scanner_version: str = "1.0.0"
+
+    @property
+    def critical_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == Severity.CRITICAL)
+
+    @property
+    def high_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == Severity.HIGH)
+
+    @property
+    def summary(self) -> str:
+        total = len(self.findings)
+        return (
+            f"{total} findings: "
+            f"{self.critical_count} Critical, {self.high_count} High, "
+            f"{sum(1 for f in self.findings if f.severity == Severity.MEDIUM)} Medium, "
+            f"{sum(1 for f in self.findings if f.severity == Severity.LOW)} Low, "
+            f"{sum(1 for f in self.findings if f.severity == Severity.INFO)} Info"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scoring logic
+# ---------------------------------------------------------------------------
+
+_CATEGORY_BASE_SCORES: dict[str, float] = {
+    "hardcoded-secret": 9.0,
+    "hardcoded-api-key": 8.5,
+    "auth-bypass": 9.5,
+    "path-traversal": 8.0,
+    "ssrf": 8.5,
+    "missing-header": 4.0,
+    "insecure-permission": 6.0,
+    "dependency-vuln-critical": 9.0,
+    "dependency-vuln-high": 7.5,
+    "dependency-vuln-medium": 5.0,
+    "dependency-vuln-low": 3.0,
+}
+
+
+def score_finding(finding: Finding) -> ScoredFinding:
+    """Assign a CVSS-like score and severity to a Finding."""
+    base = _CATEGORY_BASE_SCORES.get(finding.category, 5.0)
+
+    # Clamp to [0, 10]
+    score = max(0.0, min(10.0, base))
+
+    if score >= 9.0:
+        severity = Severity.CRITICAL
+    elif score >= 7.0:
+        severity = Severity.HIGH
+    elif score >= 4.0:
+        severity = Severity.MEDIUM
+    elif score >= 1.0:
+        severity = Severity.LOW
+    else:
+        severity = Severity.INFO
+
+    return ScoredFinding(finding=finding, cvss_score=score, severity=severity)

--- a/tools/redteam/red_team.py
+++ b/tools/redteam/red_team.py
@@ -13,14 +13,22 @@ from .config_auditor import audit_config
 from .dependency_auditor import audit_all as audit_deps
 from .finding_scorer import Finding, RedTeamReport, score_finding
 from .report_generator import generate_report
-from .service_enumerator import enumerate_all
+from .service_enumerator import enumerate_all, ALLOWED_PM2_BINS, ALLOWED_NGINX_DIRS
 
 # Attack simulators
 from .attack_simulators.auth_bypass import scan_auth_bypass
 from .attack_simulators.path_traversal import scan_path_traversal
 from .attack_simulators.ssrf import scan_ssrf
 
+from urllib.parse import urlparse
+
 _DEFAULT_CONFIG = Path(__file__).parent / "config.yaml"
+
+
+def _is_localhost(url: str) -> bool:
+    """Check if URL targets localhost using proper URL parsing."""
+    parsed = urlparse(url)
+    return parsed.hostname in ("localhost", "127.0.0.1", "::1")
 
 
 def load_config(config_path: Optional[str] = None) -> dict:
@@ -61,7 +69,7 @@ def run_scan(config_path: Optional[str] = None) -> RedTeamReport:
     targets = config.get("targets", [])
     for target in targets:
         url = target.get("url", "")
-        if not url.startswith(("http://localhost", "http://127.0.0.1")):
+        if not _is_localhost(url):
             continue
 
         attack_findings.extend(scan_path_traversal(url, max_requests=max_req, timeout=timeout))

--- a/tools/redteam/red_team.py
+++ b/tools/redteam/red_team.py
@@ -1,0 +1,118 @@
+"""red_team.py — Main controller, orchestrates the security scan."""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from .config_auditor import audit_config
+from .dependency_auditor import audit_all as audit_deps
+from .finding_scorer import Finding, RedTeamReport, score_finding
+from .report_generator import generate_report
+from .service_enumerator import enumerate_all
+
+# Attack simulators
+from .attack_simulators.auth_bypass import scan_auth_bypass
+from .attack_simulators.path_traversal import scan_path_traversal
+from .attack_simulators.ssrf import scan_ssrf
+
+_DEFAULT_CONFIG = Path(__file__).parent / "config.yaml"
+
+
+def load_config(config_path: Optional[str] = None) -> dict:
+    """Load scan configuration from YAML."""
+    path = Path(config_path) if config_path else _DEFAULT_CONFIG
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def run_scan(config_path: Optional[str] = None) -> RedTeamReport:
+    """Execute the full red team scan and return a report."""
+    config = load_config(config_path)
+    scan_cfg = config.get("scan", {})
+    max_req = scan_cfg.get("max_requests_per_endpoint", 10)
+    timeout = scan_cfg.get("timeout_seconds", 5)
+
+    report = RedTeamReport()
+    start = time.time()
+
+    # 1. Service enumeration
+    pm2_bin = config.get("pm2_binary", "pm2")
+    nginx_dir = config.get("nginx_config_path", "/etc/nginx/sites-enabled/")
+    report.services = enumerate_all(pm2_bin=pm2_bin, nginx_dir=nginx_dir)
+
+    # 2. Dependency audit
+    repo_paths = config.get("repo_paths", {})
+    dep_findings = audit_deps(repo_paths)
+
+    # 3. Config audit
+    config_findings: list[Finding] = []
+    for _name, path in repo_paths.items():
+        config_findings.extend(audit_config(path, nginx_dir))
+
+    # 4. Attack simulations (localhost only)
+    attack_findings: list[Finding] = []
+    targets = config.get("targets", [])
+    for target in targets:
+        url = target.get("url", "")
+        if not url.startswith(("http://localhost", "http://127.0.0.1")):
+            continue
+
+        attack_findings.extend(scan_path_traversal(url, max_requests=max_req, timeout=timeout))
+        attack_findings.extend(scan_auth_bypass(url, max_requests=max_req, timeout=timeout))
+        attack_findings.extend(scan_ssrf(url, max_requests=max_req, timeout=timeout))
+
+    # 5. Score all findings
+    all_findings = dep_findings + config_findings + attack_findings
+    report.findings = [score_finding(f) for f in all_findings]
+    report.scan_duration_seconds = time.time() - start
+
+    return report
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Security Red Team Simulator for ai-trader"
+    )
+    parser.add_argument(
+        "--config", "-c",
+        default=None,
+        help="Path to config.yaml (default: tools/redteam/config.yaml)",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default=None,
+        help="Output path for Markdown report",
+    )
+    parser.add_argument(
+        "--quiet", "-q",
+        action="store_true",
+        help="Only print summary line",
+    )
+    args = parser.parse_args(argv)
+
+    report = run_scan(args.config)
+
+    if args.quiet:
+        print(report.summary)
+    else:
+        md = generate_report(report, output_path=args.output)
+        if not args.output:
+            print(md)
+        else:
+            print(f"Report written to {args.output}")
+            print(report.summary)
+
+    # Exit with non-zero if critical findings exist
+    return 1 if report.critical_count > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/redteam/report_generator.py
+++ b/tools/redteam/report_generator.py
@@ -38,10 +38,11 @@ def _finding_section(idx: int, sf: ScoredFinding) -> str:
         "",
     ])
     if f.evidence:
+        safe_evidence = f.evidence.replace("```", "~~~")
         lines.extend([
             "**Evidence:**",
             f"```",
-            f.evidence,
+            safe_evidence,
             f"```",
             "",
         ])
@@ -190,7 +191,7 @@ def generate_report(
     content = "\n".join(sections)
 
     if output_path:
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             f.write(content)
 
     return content

--- a/tools/redteam/report_generator.py
+++ b/tools/redteam/report_generator.py
@@ -1,0 +1,196 @@
+"""report_generator.py — Generate CISSP-standard pentest report in Markdown."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from .finding_scorer import RedTeamReport, ScoredFinding, Severity
+
+
+def _severity_icon(severity: Severity) -> str:
+    icons = {
+        Severity.CRITICAL: "[CRITICAL]",
+        Severity.HIGH: "[HIGH]",
+        Severity.MEDIUM: "[MEDIUM]",
+        Severity.LOW: "[LOW]",
+        Severity.INFO: "[INFO]",
+    }
+    return icons.get(severity, "[?]")
+
+
+def _finding_section(idx: int, sf: ScoredFinding) -> str:
+    f = sf.finding
+    lines = [
+        f"### {idx}. {_severity_icon(sf.severity)} {f.title}",
+        "",
+        f"- **CVSS Score:** {sf.cvss_score:.1f}",
+        f"- **Severity:** {sf.severity.value}",
+        f"- **Category:** {f.category}",
+    ]
+    if f.source_file:
+        loc = f.source_file
+        if f.source_line:
+            loc += f":{f.source_line}"
+        lines.append(f"- **Location:** `{loc}`")
+    lines.extend([
+        "",
+        f"**Description:** {f.description}",
+        "",
+    ])
+    if f.evidence:
+        lines.extend([
+            "**Evidence:**",
+            f"```",
+            f.evidence,
+            f"```",
+            "",
+        ])
+    if f.remediation:
+        lines.extend([
+            f"**Remediation:** {f.remediation}",
+            "",
+        ])
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def generate_report(
+    report: RedTeamReport,
+    repo_name: str = "ai-trader",
+    output_path: Optional[str] = None,
+) -> str:
+    """Generate a CISSP-standard penetration test report in Markdown."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    sections = [
+        f"# Security Red Team Assessment Report",
+        "",
+        f"**Target:** {repo_name}",
+        f"**Date:** {now}",
+        f"**Scanner Version:** {report.scanner_version}",
+        f"**Scan Duration:** {report.scan_duration_seconds:.1f}s",
+        "",
+        "---",
+        "",
+        "## 1. Executive Summary",
+        "",
+        f"This automated security assessment identified **{len(report.findings)} findings** across the {repo_name} infrastructure.",
+        "",
+        f"- **Critical:** {report.critical_count}",
+        f"- **High:** {report.high_count}",
+        f"- **Medium:** {sum(1 for f in report.findings if f.severity == Severity.MEDIUM)}",
+        f"- **Low:** {sum(1 for f in report.findings if f.severity == Severity.LOW)}",
+        f"- **Informational:** {sum(1 for f in report.findings if f.severity == Severity.INFO)}",
+        "",
+    ]
+
+    if report.critical_count > 0:
+        sections.append(
+            "**Immediate action required:** Critical findings must be remediated before next deployment."
+        )
+        sections.append("")
+
+    # Risk rating
+    if report.critical_count > 0:
+        risk = "CRITICAL"
+    elif report.high_count > 0:
+        risk = "HIGH"
+    elif any(f.severity == Severity.MEDIUM for f in report.findings):
+        risk = "MEDIUM"
+    else:
+        risk = "LOW"
+    sections.extend([
+        f"**Overall Risk Rating: {risk}**",
+        "",
+        "---",
+        "",
+        "## 2. Scope",
+        "",
+        "| Item | Detail |",
+        "|------|--------|",
+        f"| Target System | {repo_name} |",
+        f"| Services Enumerated | {len(report.services)} |",
+        "| Scan Type | Automated (safe payloads, localhost only) |",
+        f"| Max Requests/Endpoint | 10 |",
+        "",
+    ])
+
+    # Services
+    if report.services:
+        sections.extend([
+            "---",
+            "",
+            "## 3. Discovered Services",
+            "",
+            "| Name | Status | PID | Details |",
+            "|------|--------|-----|---------|",
+        ])
+        for svc in report.services:
+            pid = str(svc.pid) if svc.pid else "-"
+            extra_str = ", ".join(f"{k}={v}" for k, v in svc.extra.items()) if svc.extra else "-"
+            sections.append(f"| {svc.name} | {svc.status} | {pid} | {extra_str} |")
+        sections.append("")
+
+    # Findings
+    sections.extend([
+        "---",
+        "",
+        "## 4. Detailed Findings",
+        "",
+    ])
+
+    # Sort by severity (Critical first)
+    severity_order = {
+        Severity.CRITICAL: 0,
+        Severity.HIGH: 1,
+        Severity.MEDIUM: 2,
+        Severity.LOW: 3,
+        Severity.INFO: 4,
+    }
+    sorted_findings = sorted(report.findings, key=lambda f: severity_order.get(f.severity, 5))
+
+    if not sorted_findings:
+        sections.append("No findings detected.")
+    else:
+        for idx, sf in enumerate(sorted_findings, start=1):
+            sections.append(_finding_section(idx, sf))
+            sections.append("")
+
+    # Recommendations
+    sections.extend([
+        "---",
+        "",
+        "## 5. Recommendations",
+        "",
+        "1. **Secrets Management:** Move all hardcoded secrets to environment variables or a vault service",
+        "2. **Dependency Updates:** Remediate all critical/high dependency vulnerabilities",
+        "3. **Authentication:** Ensure all API endpoints require valid authentication tokens",
+        "4. **Input Validation:** Sanitize file paths and URL parameters to prevent traversal/SSRF",
+        "5. **HTTP Headers:** Add security headers (HSTS, CSP, X-Frame-Options) to all web responses",
+        "6. **File Permissions:** Ensure .env files are not world-readable (chmod 600)",
+        "",
+        "---",
+        "",
+        "## 6. Methodology",
+        "",
+        "This assessment followed a CISSP-aligned penetration testing methodology:",
+        "",
+        "1. **Reconnaissance:** Service enumeration via pm2, nginx, tailscale",
+        "2. **Vulnerability Assessment:** Dependency auditing (npm/pip), configuration review",
+        "3. **Exploitation Simulation:** Safe payload testing for path traversal, auth bypass, SSRF",
+        "4. **Reporting:** CVSS-based scoring with actionable remediation guidance",
+        "",
+        "All testing was conducted on localhost with safe, non-destructive payloads.",
+        "",
+        "---",
+        "",
+        f"*Report generated by Red Team Simulator v{report.scanner_version}*",
+    ])
+
+    content = "\n".join(sections)
+
+    if output_path:
+        with open(output_path, "w") as f:
+            f.write(content)
+
+    return content

--- a/tools/redteam/service_enumerator.py
+++ b/tools/redteam/service_enumerator.py
@@ -1,0 +1,109 @@
+"""service_enumerator.py — Discover running services via pm2, nginx, tailscale."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import List
+
+from .finding_scorer import ServiceInfo
+
+
+def _run(cmd: List[str], timeout: int = 10) -> str:
+    """Run a command and return stdout; empty string on failure."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return ""
+
+
+def enumerate_pm2(pm2_bin: str = "pm2") -> List[ServiceInfo]:
+    """List services managed by pm2."""
+    raw = _run([pm2_bin, "jlist"])
+    if not raw:
+        return []
+
+    try:
+        items = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+
+    services: List[ServiceInfo] = []
+    for item in items:
+        svc = ServiceInfo(
+            name=item.get("name", "unknown"),
+            pid=item.get("pid"),
+            status=item.get("pm2_env", {}).get("status", "unknown"),
+            pm2_id=item.get("pm_id"),
+            extra={"interpreter": item.get("pm2_env", {}).get("exec_interpreter", "")},
+        )
+        services.append(svc)
+    return services
+
+
+def enumerate_nginx(config_dir: str = "/etc/nginx/sites-enabled/") -> List[ServiceInfo]:
+    """Parse nginx configs to find upstream services."""
+    config_path = Path(config_dir)
+    if not config_path.exists():
+        return []
+
+    services: List[ServiceInfo] = []
+    for conf_file in config_path.iterdir():
+        if conf_file.is_file():
+            try:
+                content = conf_file.read_text()
+            except PermissionError:
+                continue
+            # Simple heuristic: extract proxy_pass targets
+            for line in content.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("proxy_pass"):
+                    url = stripped.split()[-1].rstrip(";")
+                    svc = ServiceInfo(
+                        name=f"nginx-upstream:{conf_file.name}",
+                        status="configured",
+                        extra={"proxy_pass": url, "config_file": str(conf_file)},
+                    )
+                    services.append(svc)
+    return services
+
+
+def enumerate_tailscale() -> List[ServiceInfo]:
+    """Check tailscale status for exposed services."""
+    raw = _run(["tailscale", "status", "--json"])
+    if not raw:
+        return []
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+
+    services: List[ServiceInfo] = []
+    self_node = data.get("Self", {})
+    if self_node:
+        svc = ServiceInfo(
+            name=f"tailscale:{self_node.get('HostName', 'unknown')}",
+            status="online" if data.get("BackendState") == "Running" else "offline",
+            extra={
+                "tailscale_ips": self_node.get("TailscaleIPs", []),
+                "os": self_node.get("OS", ""),
+            },
+        )
+        services.append(svc)
+    return services
+
+
+def enumerate_all(pm2_bin: str = "pm2", nginx_dir: str = "/etc/nginx/sites-enabled/") -> List[ServiceInfo]:
+    """Run all enumerators and return combined results."""
+    services: List[ServiceInfo] = []
+    services.extend(enumerate_pm2(pm2_bin))
+    services.extend(enumerate_nginx(nginx_dir))
+    services.extend(enumerate_tailscale())
+    return services

--- a/tools/redteam/service_enumerator.py
+++ b/tools/redteam/service_enumerator.py
@@ -8,6 +8,27 @@ from typing import List
 
 from .finding_scorer import ServiceInfo
 
+ALLOWED_PM2_BINS = {"pm2", "/usr/local/bin/pm2", "/opt/homebrew/bin/pm2", "/usr/bin/pm2"}
+
+ALLOWED_NGINX_DIRS = {
+    "/etc/nginx/sites-enabled",
+    "/etc/nginx/conf.d",
+    "/opt/homebrew/etc/nginx/servers",
+}
+
+
+def _validate_pm2_binary(pm2_bin: str) -> None:
+    """Validate pm2_binary against allowlist to prevent arbitrary command execution."""
+    if pm2_bin not in ALLOWED_PM2_BINS:
+        raise ValueError(f"Disallowed pm2_binary: {pm2_bin}")
+
+
+def _validate_nginx_dir(nginx_dir: str) -> None:
+    """Validate nginx config path is under allowed directories."""
+    normalised = nginx_dir.rstrip("/")
+    if normalised not in ALLOWED_NGINX_DIRS:
+        raise ValueError(f"Disallowed nginx_config_path: {nginx_dir}")
+
 
 def _run(cmd: List[str], timeout: int = 10) -> str:
     """Run a command and return stdout; empty string on failure."""
@@ -25,6 +46,7 @@ def _run(cmd: List[str], timeout: int = 10) -> str:
 
 def enumerate_pm2(pm2_bin: str = "pm2") -> List[ServiceInfo]:
     """List services managed by pm2."""
+    _validate_pm2_binary(pm2_bin)
     raw = _run([pm2_bin, "jlist"])
     if not raw:
         return []
@@ -49,6 +71,7 @@ def enumerate_pm2(pm2_bin: str = "pm2") -> List[ServiceInfo]:
 
 def enumerate_nginx(config_dir: str = "/etc/nginx/sites-enabled/") -> List[ServiceInfo]:
     """Parse nginx configs to find upstream services."""
+    _validate_nginx_dir(config_dir)
     config_path = Path(config_dir)
     if not config_path.exists():
         return []

--- a/tools/redteam/tests/conftest.py
+++ b/tools/redteam/tests/conftest.py
@@ -1,0 +1,6 @@
+"""Conftest — restrict test collection to tests/ directory only."""
+import sys
+
+# Ensure pytest only collects from this tests/ directory, not from
+# the parent attack_simulators/ whose functions start with test_*.
+collect_ignore_glob = ["../attack_simulators/*"]

--- a/tools/redteam/tests/test_attack_simulators.py
+++ b/tools/redteam/tests/test_attack_simulators.py
@@ -83,21 +83,21 @@ class TestSsrf:
         findings = scan_ssrf("http://example.com")
         assert findings == []
 
-    @patch("tools.redteam.attack_simulators.ssrf.urllib.request.urlopen")
-    def test_detects_ssrf(self, mock_urlopen):
+    @patch("tools.redteam.attack_simulators.ssrf._no_redirect_opener")
+    def test_detects_ssrf(self, mock_opener):
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.read.return_value = b'{"ami-id": "ami-12345", "instance-id": "i-abc"}'
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_resp
+        mock_opener.open.return_value = mock_resp
 
         findings = scan_ssrf("http://localhost:3000", max_requests=2)
         assert len(findings) >= 1
         assert findings[0].category == "ssrf"
 
-    @patch("tools.redteam.attack_simulators.ssrf.urllib.request.urlopen")
-    def test_respects_max_requests(self, mock_urlopen):
-        mock_urlopen.side_effect = urllib.error.URLError("refused")
+    @patch("tools.redteam.attack_simulators.ssrf._no_redirect_opener")
+    def test_respects_max_requests(self, mock_opener):
+        mock_opener.open.side_effect = urllib.error.URLError("refused")
         scan_ssrf("http://localhost:3000", max_requests=5)
-        assert mock_urlopen.call_count <= 5
+        assert mock_opener.open.call_count <= 5

--- a/tools/redteam/tests/test_attack_simulators.py
+++ b/tools/redteam/tests/test_attack_simulators.py
@@ -1,0 +1,103 @@
+"""Tests for attack simulator modules."""
+from unittest.mock import patch, MagicMock
+import urllib.error
+
+import pytest
+
+from tools.redteam.attack_simulators.path_traversal import scan_path_traversal
+from tools.redteam.attack_simulators.auth_bypass import scan_auth_bypass
+from tools.redteam.attack_simulators.ssrf import scan_ssrf
+
+
+class TestPathTraversal:
+    def test_rejects_non_localhost(self):
+        findings = scan_path_traversal("http://example.com")
+        assert findings == []
+
+    @patch("tools.redteam.attack_simulators.path_traversal.urllib.request.urlopen")
+    def test_detects_traversal(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b"root:x:0:0:root:/root:/bin/bash\n"
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        findings = scan_path_traversal("http://localhost:3000", max_requests=2)
+        assert len(findings) >= 1
+        assert findings[0].category == "path-traversal"
+
+    @patch("tools.redteam.attack_simulators.path_traversal.urllib.request.urlopen")
+    def test_no_finding_on_safe_response(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b"<html>Not Found</html>"
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        findings = scan_path_traversal("http://localhost:3000", max_requests=2)
+        assert findings == []
+
+    @patch("tools.redteam.attack_simulators.path_traversal.urllib.request.urlopen")
+    def test_respects_max_requests(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+        scan_path_traversal("http://localhost:3000", max_requests=3)
+        assert mock_urlopen.call_count <= 3
+
+
+class TestAuthBypass:
+    def test_rejects_non_localhost(self):
+        findings = scan_auth_bypass("http://example.com")
+        assert findings == []
+
+    @patch("tools.redteam.attack_simulators.auth_bypass.urllib.request.urlopen")
+    def test_detects_bypass(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"data": [{"id": 1}]}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        findings = scan_auth_bypass("http://localhost:8000", max_requests=2)
+        assert len(findings) >= 1
+        assert findings[0].category == "auth-bypass"
+
+    @patch("tools.redteam.attack_simulators.auth_bypass.urllib.request.urlopen")
+    def test_no_finding_on_401(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="http://localhost:8000/api/portfolio",
+            code=401,
+            msg="Unauthorized",
+            hdrs={},
+            fp=None,
+        )
+
+        findings = scan_auth_bypass("http://localhost:8000", max_requests=2)
+        assert findings == []
+
+
+class TestSsrf:
+    def test_rejects_non_localhost(self):
+        findings = scan_ssrf("http://example.com")
+        assert findings == []
+
+    @patch("tools.redteam.attack_simulators.ssrf.urllib.request.urlopen")
+    def test_detects_ssrf(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"ami-id": "ami-12345", "instance-id": "i-abc"}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        findings = scan_ssrf("http://localhost:3000", max_requests=2)
+        assert len(findings) >= 1
+        assert findings[0].category == "ssrf"
+
+    @patch("tools.redteam.attack_simulators.ssrf.urllib.request.urlopen")
+    def test_respects_max_requests(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("refused")
+        scan_ssrf("http://localhost:3000", max_requests=5)
+        assert mock_urlopen.call_count <= 5

--- a/tools/redteam/tests/test_config_auditor.py
+++ b/tools/redteam/tests/test_config_auditor.py
@@ -1,0 +1,120 @@
+"""Tests for config_auditor module."""
+import os
+import stat
+import tempfile
+
+import pytest
+
+from tools.redteam.config_auditor import (
+    check_env_permissions,
+    check_hardcoded_secrets,
+    check_nginx_headers,
+    audit_config,
+)
+
+
+class TestCheckEnvPermissions:
+    def test_detects_world_readable_env(self):
+        with tempfile.TemporaryDirectory() as d:
+            env_file = os.path.join(d, ".env")
+            with open(env_file, "w") as f:
+                f.write("SECRET=value\n")
+            os.chmod(env_file, 0o644)
+
+            findings = check_env_permissions(d)
+            assert len(findings) == 1
+            assert "world-readable" in findings[0].title
+
+    def test_ignores_secure_env(self):
+        with tempfile.TemporaryDirectory() as d:
+            env_file = os.path.join(d, ".env")
+            with open(env_file, "w") as f:
+                f.write("SECRET=value\n")
+            os.chmod(env_file, 0o600)
+
+            findings = check_env_permissions(d)
+            assert len(findings) == 0
+
+    def test_ignores_env_example(self):
+        with tempfile.TemporaryDirectory() as d:
+            env_file = os.path.join(d, ".env.example")
+            with open(env_file, "w") as f:
+                f.write("SECRET=placeholder\n")
+            os.chmod(env_file, 0o644)
+
+            findings = check_env_permissions(d)
+            assert len(findings) == 0
+
+
+class TestCheckHardcodedSecrets:
+    def test_detects_bot_token(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
+            f.write('const config = {\n')
+            f.write('  WATCHER_TELEGRAM_BOT_TOKEN: "8773751510:AAHFORPaipYCA_993wx8B5fGH_eOAq5jqP0",\n')
+            f.write('};\n')
+            f.flush()
+
+            findings = check_hardcoded_secrets(f.name)
+            assert len(findings) >= 1
+            assert findings[0].category == "hardcoded-secret"
+            # Verify the actual token value is masked in evidence
+            for finding in findings:
+                assert "AAHFORPaipYCA_993wx8B5fGH_eOAq5jqP0" not in finding.evidence
+
+        os.unlink(f.name)
+
+    def test_detects_api_key(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".ts", delete=False) as f:
+            f.write('export const firebaseConfig = {\n')
+            f.write('  apiKey: "AIzaSyD1234567890abcdefghijklmnop",\n')
+            f.write('};\n')
+            f.flush()
+
+            findings = check_hardcoded_secrets(f.name)
+            assert len(findings) >= 1
+            assert any(f.category == "hardcoded-api-key" for f in findings)
+
+        os.unlink(f.name)
+
+    def test_clean_file_no_findings(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
+            f.write('const x = 1;\nconst y = "hello";\n')
+            f.flush()
+
+            findings = check_hardcoded_secrets(f.name)
+            assert len(findings) == 0
+
+        os.unlink(f.name)
+
+    def test_nonexistent_file(self):
+        findings = check_hardcoded_secrets("/nonexistent/file.js")
+        assert findings == []
+
+
+class TestCheckNginxHeaders:
+    def test_returns_empty_for_missing_dir(self):
+        assert check_nginx_headers("/nonexistent/") == []
+
+    def test_detects_missing_headers(self):
+        with tempfile.TemporaryDirectory() as d:
+            conf = os.path.join(d, "default.conf")
+            with open(conf, "w") as f:
+                f.write("server { listen 80; }\n")
+
+            findings = check_nginx_headers(d)
+            # Should detect all 4 missing headers
+            assert len(findings) == 4
+            titles = {f.title for f in findings}
+            assert "Missing header: X-Content-Type-Options" in titles
+
+
+class TestAuditConfig:
+    def test_scans_ecosystem_config(self):
+        with tempfile.TemporaryDirectory() as d:
+            eco = os.path.join(d, "ecosystem.config.js")
+            with open(eco, "w") as f:
+                f.write('BOT_TOKEN: "8773751510:AAHFORPaipYCA_993wx8B5fGH_eOAq5jqP0"\n')
+
+            findings = audit_config(d, nginx_dir="/nonexistent/")
+            secret_findings = [f for f in findings if f.category == "hardcoded-secret"]
+            assert len(secret_findings) >= 1

--- a/tools/redteam/tests/test_dependency_auditor.py
+++ b/tools/redteam/tests/test_dependency_auditor.py
@@ -1,0 +1,94 @@
+"""Tests for dependency_auditor module."""
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from tools.redteam.dependency_auditor import audit_npm, audit_pip, audit_all
+
+
+class TestAuditNpm:
+    def test_skips_if_no_package_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            assert audit_npm(d) == []
+
+    @patch("tools.redteam.dependency_auditor._run_json")
+    def test_parses_npm_audit(self, mock_run):
+        mock_run.return_value = {
+            "vulnerabilities": {
+                "lodash": {
+                    "severity": "high",
+                    "title": "Prototype Pollution",
+                    "range": "<4.17.21",
+                },
+                "minimist": {
+                    "severity": "critical",
+                    "title": "Prototype Pollution",
+                    "range": "<1.2.6",
+                },
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as d:
+            # Create package.json so the check passes
+            with open(os.path.join(d, "package.json"), "w") as f:
+                f.write("{}")
+
+            findings = audit_npm(d)
+            assert len(findings) == 2
+            categories = {f.category for f in findings}
+            assert "dependency-vuln-high" in categories
+            assert "dependency-vuln-critical" in categories
+
+    @patch("tools.redteam.dependency_auditor._run_json")
+    def test_empty_on_no_vulns(self, mock_run):
+        mock_run.return_value = {"vulnerabilities": {}}
+
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "package.json"), "w") as f:
+                f.write("{}")
+            assert audit_npm(d) == []
+
+
+class TestAuditPip:
+    def test_skips_if_no_requirements(self):
+        with tempfile.TemporaryDirectory() as d:
+            assert audit_pip(d) == []
+
+    @patch("tools.redteam.dependency_auditor._run_json")
+    def test_parses_pip_audit(self, mock_run):
+        mock_run.return_value = {
+            "vulnerabilities": [
+                {
+                    "name": "requests",
+                    "id": "CVE-2023-1234",
+                    "description": "SSRF vulnerability",
+                    "version": "2.28.0",
+                    "fix_versions": ["2.31.0"],
+                },
+            ]
+        }
+
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "requirements.txt"), "w") as f:
+                f.write("requests==2.28.0\n")
+
+            findings = audit_pip(d)
+            assert len(findings) == 1
+            assert "requests" in findings[0].title
+            assert "CVE-2023-1234" in findings[0].evidence
+
+
+class TestAuditAll:
+    @patch("tools.redteam.dependency_auditor.audit_pip")
+    @patch("tools.redteam.dependency_auditor.audit_npm")
+    def test_combines_results(self, mock_npm, mock_pip):
+        from tools.redteam.finding_scorer import Finding
+
+        mock_npm.return_value = [Finding(title="npm-vuln", description="d", category="dependency-vuln-high")]
+        mock_pip.return_value = [Finding(title="pip-vuln", description="d", category="dependency-vuln-high")]
+
+        result = audit_all({"repo1": "/some/path"})
+        assert len(result) == 2

--- a/tools/redteam/tests/test_finding_scorer.py
+++ b/tools/redteam/tests/test_finding_scorer.py
@@ -1,0 +1,104 @@
+"""Tests for finding_scorer module."""
+import pytest
+
+from tools.redteam.finding_scorer import (
+    Finding,
+    RedTeamReport,
+    ScoredFinding,
+    Severity,
+    score_finding,
+)
+
+
+class TestFinding:
+    def test_basic_creation(self):
+        f = Finding(
+            title="Test finding",
+            description="A test",
+            category="hardcoded-secret",
+        )
+        assert f.title == "Test finding"
+        assert f.source_file is None
+        assert f.source_line is None
+
+    def test_full_creation(self):
+        f = Finding(
+            title="Secret in config",
+            description="Found a token",
+            category="hardcoded-secret",
+            source_file="ecosystem.config.js",
+            source_line=47,
+            evidence="BOT_TOKEN=****",
+            remediation="Use env vars",
+        )
+        assert f.source_line == 47
+        assert f.source_file == "ecosystem.config.js"
+
+
+class TestScoreFinding:
+    def test_hardcoded_secret_is_critical(self):
+        f = Finding(title="t", description="d", category="hardcoded-secret")
+        scored = score_finding(f)
+        assert scored.severity == Severity.CRITICAL
+        assert scored.cvss_score == 9.0
+
+    def test_auth_bypass_is_critical(self):
+        f = Finding(title="t", description="d", category="auth-bypass")
+        scored = score_finding(f)
+        assert scored.severity == Severity.CRITICAL
+        assert scored.cvss_score == 9.5
+
+    def test_missing_header_is_medium(self):
+        f = Finding(title="t", description="d", category="missing-header")
+        scored = score_finding(f)
+        assert scored.severity == Severity.MEDIUM
+        assert scored.cvss_score == 4.0
+
+    def test_unknown_category_defaults_medium(self):
+        f = Finding(title="t", description="d", category="unknown-thing")
+        scored = score_finding(f)
+        assert scored.cvss_score == 5.0
+        assert scored.severity == Severity.MEDIUM
+
+    def test_dependency_vuln_low(self):
+        f = Finding(title="t", description="d", category="dependency-vuln-low")
+        scored = score_finding(f)
+        assert scored.severity == Severity.LOW
+        assert scored.cvss_score == 3.0
+
+    def test_scored_finding_delegates_properties(self):
+        f = Finding(title="My Title", description="d", category="ssrf")
+        sf = score_finding(f)
+        assert sf.title == "My Title"
+        assert sf.category == "ssrf"
+
+
+class TestRedTeamReport:
+    def test_empty_report(self):
+        r = RedTeamReport()
+        assert r.critical_count == 0
+        assert r.high_count == 0
+        assert "0 findings" in r.summary
+
+    def test_summary_counts(self):
+        findings = [
+            ScoredFinding(
+                finding=Finding(title="a", description="", category="x"),
+                cvss_score=9.5,
+                severity=Severity.CRITICAL,
+            ),
+            ScoredFinding(
+                finding=Finding(title="b", description="", category="y"),
+                cvss_score=7.5,
+                severity=Severity.HIGH,
+            ),
+            ScoredFinding(
+                finding=Finding(title="c", description="", category="z"),
+                cvss_score=4.0,
+                severity=Severity.MEDIUM,
+            ),
+        ]
+        r = RedTeamReport(findings=findings)
+        assert r.critical_count == 1
+        assert r.high_count == 1
+        assert "3 findings" in r.summary

--- a/tools/redteam/tests/test_red_team.py
+++ b/tools/redteam/tests/test_red_team.py
@@ -1,0 +1,87 @@
+"""Tests for red_team main controller."""
+import tempfile
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tools.redteam.red_team import load_config, run_scan, main
+
+
+class TestLoadConfig:
+    def test_loads_yaml(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("scan:\n  max_requests_per_endpoint: 5\n")
+            f.flush()
+
+            config = load_config(f.name)
+            assert config["scan"]["max_requests_per_endpoint"] == 5
+
+        os.unlink(f.name)
+
+    def test_returns_empty_on_missing_file(self):
+        config = load_config("/nonexistent/config.yaml")
+        assert config == {}
+
+
+class TestRunScan:
+    @patch("tools.redteam.red_team.enumerate_all")
+    @patch("tools.redteam.red_team.audit_deps")
+    @patch("tools.redteam.red_team.audit_config")
+    @patch("tools.redteam.red_team.scan_path_traversal")
+    @patch("tools.redteam.red_team.scan_auth_bypass")
+    @patch("tools.redteam.red_team.scan_ssrf")
+    def test_orchestrates_all_scanners(
+        self, mock_ssrf, mock_auth, mock_traversal,
+        mock_config, mock_deps, mock_enum
+    ):
+        from tools.redteam.finding_scorer import Finding, ServiceInfo
+
+        mock_enum.return_value = [ServiceInfo(name="test-svc")]
+        mock_deps.return_value = [Finding(title="dep", description="d", category="dependency-vuln-high")]
+        mock_config.return_value = [Finding(title="cfg", description="d", category="hardcoded-secret")]
+        mock_traversal.return_value = []
+        mock_auth.return_value = []
+        mock_ssrf.return_value = []
+
+        # Use a minimal config with no targets
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("scan:\n  max_requests_per_endpoint: 5\nrepo_paths:\n  test: /tmp\n")
+            f.flush()
+            report = run_scan(f.name)
+
+        os.unlink(f.name)
+
+        assert len(report.services) == 1
+        assert len(report.findings) == 2
+        assert report.scan_duration_seconds > 0
+
+
+class TestMain:
+    @patch("tools.redteam.red_team.run_scan")
+    def test_quiet_mode(self, mock_scan):
+        from tools.redteam.finding_scorer import RedTeamReport
+
+        mock_scan.return_value = RedTeamReport()
+
+        exit_code = main(["--quiet", "--config", "/nonexistent.yaml"])
+        assert exit_code == 0
+
+    @patch("tools.redteam.red_team.run_scan")
+    def test_returns_1_on_critical(self, mock_scan):
+        from tools.redteam.finding_scorer import (
+            Finding, RedTeamReport, ScoredFinding, Severity
+        )
+
+        mock_scan.return_value = RedTeamReport(
+            findings=[
+                ScoredFinding(
+                    finding=Finding(title="x", description="d", category="c"),
+                    cvss_score=9.5,
+                    severity=Severity.CRITICAL,
+                )
+            ]
+        )
+
+        exit_code = main(["--quiet"])
+        assert exit_code == 1

--- a/tools/redteam/tests/test_report_generator.py
+++ b/tools/redteam/tests/test_report_generator.py
@@ -1,0 +1,107 @@
+"""Tests for report_generator module."""
+import tempfile
+import os
+
+import pytest
+
+from tools.redteam.finding_scorer import (
+    Finding,
+    RedTeamReport,
+    ScoredFinding,
+    ServiceInfo,
+    Severity,
+)
+from tools.redteam.report_generator import generate_report
+
+
+class TestGenerateReport:
+    def _make_report(self) -> RedTeamReport:
+        return RedTeamReport(
+            findings=[
+                ScoredFinding(
+                    finding=Finding(
+                        title="Hardcoded token in ecosystem.config.js",
+                        description="Telegram bot token is hardcoded",
+                        category="hardcoded-secret",
+                        source_file="ecosystem.config.js",
+                        source_line=47,
+                        evidence="BOT_TOKEN=8773****",
+                        remediation="Use env var",
+                    ),
+                    cvss_score=9.0,
+                    severity=Severity.CRITICAL,
+                ),
+                ScoredFinding(
+                    finding=Finding(
+                        title="Missing X-Frame-Options",
+                        description="Nginx missing header",
+                        category="missing-header",
+                    ),
+                    cvss_score=4.0,
+                    severity=Severity.MEDIUM,
+                ),
+            ],
+            services=[
+                ServiceInfo(name="ai-trader-web", pid=1234, status="online"),
+            ],
+            scan_duration_seconds=2.5,
+        )
+
+    def test_contains_executive_summary(self):
+        report = self._make_report()
+        md = generate_report(report)
+        assert "Executive Summary" in md
+        assert "2 findings" in md
+
+    def test_contains_critical_count(self):
+        report = self._make_report()
+        md = generate_report(report)
+        assert "Critical:** 1" in md
+
+    def test_contains_finding_details(self):
+        report = self._make_report()
+        md = generate_report(report)
+        assert "Hardcoded token" in md
+        assert "ecosystem.config.js:47" in md
+
+    def test_contains_services(self):
+        report = self._make_report()
+        md = generate_report(report)
+        assert "ai-trader-web" in md
+
+    def test_contains_methodology(self):
+        report = self._make_report()
+        md = generate_report(report)
+        assert "Methodology" in md
+        assert "CISSP" in md
+
+    def test_overall_risk_critical(self):
+        report = self._make_report()
+        md = generate_report(report)
+        assert "Overall Risk Rating: CRITICAL" in md
+
+    def test_writes_to_file(self):
+        report = self._make_report()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            path = f.name
+
+        generate_report(report, output_path=path)
+        with open(path) as f:
+            content = f.read()
+        assert "Executive Summary" in content
+        os.unlink(path)
+
+    def test_empty_report(self):
+        report = RedTeamReport()
+        md = generate_report(report)
+        assert "0 findings" in md
+        assert "No findings detected" in md
+        assert "Overall Risk Rating: LOW" in md
+
+    def test_findings_sorted_by_severity(self):
+        report = self._make_report()
+        md = generate_report(report)
+        # Critical should appear before Medium
+        critical_pos = md.index("[CRITICAL]")
+        medium_pos = md.index("[MEDIUM]")
+        assert critical_pos < medium_pos

--- a/tools/redteam/tests/test_service_enumerator.py
+++ b/tools/redteam/tests/test_service_enumerator.py
@@ -56,7 +56,12 @@ class TestEnumeratePm2:
 
 class TestEnumerateNginx:
     def test_empty_on_missing_dir(self):
-        assert enumerate_nginx("/nonexistent/path/") == []
+        # Uses an allowed dir that doesn't exist on this machine
+        assert enumerate_nginx("/etc/nginx/sites-enabled/") == []
+
+    def test_rejects_disallowed_dir(self):
+        with pytest.raises(ValueError, match="Disallowed nginx_config_path"):
+            enumerate_nginx("/nonexistent/path/")
 
 
 class TestEnumerateTailscale:

--- a/tools/redteam/tests/test_service_enumerator.py
+++ b/tools/redteam/tests/test_service_enumerator.py
@@ -1,0 +1,99 @@
+"""Tests for service_enumerator module."""
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tools.redteam.service_enumerator import (
+    enumerate_pm2,
+    enumerate_nginx,
+    enumerate_tailscale,
+    enumerate_all,
+)
+
+
+class TestEnumeratePm2:
+    @patch("tools.redteam.service_enumerator._run")
+    def test_parses_pm2_jlist(self, mock_run):
+        mock_run.return_value = json.dumps([
+            {
+                "name": "ai-trader-web",
+                "pid": 1234,
+                "pm_id": 0,
+                "pm2_env": {
+                    "status": "online",
+                    "exec_interpreter": "node",
+                },
+            },
+            {
+                "name": "ai-trader-api",
+                "pid": 5678,
+                "pm_id": 1,
+                "pm2_env": {
+                    "status": "stopped",
+                    "exec_interpreter": "python3",
+                },
+            },
+        ])
+
+        services = enumerate_pm2()
+        assert len(services) == 2
+        assert services[0].name == "ai-trader-web"
+        assert services[0].pid == 1234
+        assert services[0].status == "online"
+        assert services[1].status == "stopped"
+
+    @patch("tools.redteam.service_enumerator._run")
+    def test_empty_on_failure(self, mock_run):
+        mock_run.return_value = ""
+        assert enumerate_pm2() == []
+
+    @patch("tools.redteam.service_enumerator._run")
+    def test_empty_on_invalid_json(self, mock_run):
+        mock_run.return_value = "not json"
+        assert enumerate_pm2() == []
+
+
+class TestEnumerateNginx:
+    def test_empty_on_missing_dir(self):
+        assert enumerate_nginx("/nonexistent/path/") == []
+
+
+class TestEnumerateTailscale:
+    @patch("tools.redteam.service_enumerator._run")
+    def test_parses_tailscale_status(self, mock_run):
+        mock_run.return_value = json.dumps({
+            "BackendState": "Running",
+            "Self": {
+                "HostName": "my-server",
+                "TailscaleIPs": ["100.64.0.1"],
+                "OS": "linux",
+            },
+        })
+
+        services = enumerate_tailscale()
+        assert len(services) == 1
+        assert "my-server" in services[0].name
+        assert services[0].status == "online"
+
+    @patch("tools.redteam.service_enumerator._run")
+    def test_empty_on_failure(self, mock_run):
+        mock_run.return_value = ""
+        assert enumerate_tailscale() == []
+
+
+class TestEnumerateAll:
+    @patch("tools.redteam.service_enumerator.enumerate_tailscale")
+    @patch("tools.redteam.service_enumerator.enumerate_nginx")
+    @patch("tools.redteam.service_enumerator.enumerate_pm2")
+    def test_combines_all_sources(self, mock_pm2, mock_nginx, mock_ts):
+        from tools.redteam.finding_scorer import ServiceInfo
+
+        mock_pm2.return_value = [ServiceInfo(name="pm2-svc")]
+        mock_nginx.return_value = [ServiceInfo(name="nginx-svc")]
+        mock_ts.return_value = [ServiceInfo(name="ts-svc")]
+
+        result = enumerate_all()
+        assert len(result) == 3
+        names = {s.name for s in result}
+        assert names == {"pm2-svc", "nginx-svc", "ts-svc"}


### PR DESCRIPTION
## Summary

- Automated security red team scanner with CISSP-standard pentest reporting
- Covers: service enumeration (pm2/nginx/tailscale), dependency audit (npm/pip), config audit (hardcoded secrets, .env permissions, nginx headers), attack simulation (path traversal, auth bypass, SSRF)
- All scans are localhost-only with safe payloads; max 10 requests per endpoint

## Known Issues Detected

- `ecosystem.config.js` line 45: `WATCHER_TELEGRAM_BOT_TOKEN` hardcoded (Critical, CVSS 9.0)
- No `firebase.ts` file found in current repo (no firebase key exposure)

## Files (all in `tools/redteam/`)

| File | Purpose |
|------|---------|
| `red_team.py` | Main controller / CLI entry point |
| `service_enumerator.py` | pm2, nginx, tailscale discovery |
| `dependency_auditor.py` | npm audit / pip audit |
| `config_auditor.py` | .env perms, hardcoded secrets, nginx headers |
| `attack_simulators/path_traversal.py` | Directory traversal scanner |
| `attack_simulators/auth_bypass.py` | Auth bypass scanner |
| `attack_simulators/ssrf.py` | SSRF scanner |
| `finding_scorer.py` | CVSS-like scoring + dataclasses |
| `report_generator.py` | Markdown pentest report |
| `config.yaml` | Scan targets config |
| `tests/` | 57 unit tests |

## Test Plan

- [x] 57 unit tests pass (`pytest tools/redteam/tests/ -v`)
- [ ] Manual: `python -m tools.redteam.red_team --quiet` on production server

Closes #539