### PR TITLE
feat(infra): backend infrastructure — cache, circuit breaker, WAL, research.db

### DIFF
--- a/frontend/backend/app/core/cache.py
+++ b/frontend/backend/app/core/cache.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from functools import wraps
+
+from cachetools import TTLCache
+
+
+def cached(ttl: int = 60, maxsize: int = 128):
+    """TTL cache decorator.
+
+    Args:
+        ttl: Time-to-live in seconds (default 60).
+        maxsize: Maximum number of entries in the cache (default 128).
+
+    Usage::
+
+        @cached(ttl=300, maxsize=64)
+        def expensive_lookup(symbol: str) -> dict:
+            ...
+    """
+    cache: TTLCache = TTLCache(maxsize=maxsize, ttl=ttl)
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            key = str(args) + str(sorted(kwargs.items()))
+            if key in cache:
+                return cache[key]
+            result = func(*args, **kwargs)
+            cache[key] = result
+            return result
+
+        # Expose the underlying cache for inspection / manual invalidation.
+        wrapper.cache = cache  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator

--- a/frontend/backend/app/core/circuit_breaker.py
+++ b/frontend/backend/app/core/circuit_breaker.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import logging
+import time
+from enum import Enum
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitState(str, Enum):
+    CLOSED = "closed"      # Normal — calls pass through.
+    OPEN = "open"          # Degraded — calls fail fast.
+    HALF_OPEN = "half_open"  # Probe — one trial call allowed.
+
+
+class CircuitBreakerError(Exception):
+    """Raised when the circuit is OPEN and the call is rejected."""
+
+
+class CircuitBreaker:
+    """Simple failure-counting circuit breaker.
+
+    States:
+    - CLOSED  → calls execute normally; failures are counted.
+    - OPEN    → calls are rejected immediately after *failure_threshold* consecutive
+                failures; the circuit opens for *reset_timeout* seconds.
+    - HALF_OPEN → after *reset_timeout* elapses, one trial call is allowed.
+                  Success → CLOSED (counter reset).
+                  Failure → OPEN again (timer restarted).
+
+    Args:
+        failure_threshold: Consecutive failures before tripping (default 5).
+        reset_timeout: Seconds to wait before attempting a probe call (default 300).
+        name: Optional label used in log messages.
+    """
+
+    def __init__(
+        self,
+        failure_threshold: int = 5,
+        reset_timeout: int = 300,
+        name: str = "circuit_breaker",
+    ) -> None:
+        self.failure_threshold = failure_threshold
+        self.reset_timeout = reset_timeout
+        self.name = name
+
+        self._state: CircuitState = CircuitState.CLOSED
+        self._failure_count: int = 0
+        self._opened_at: float | None = None
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> CircuitState:
+        self._evaluate_timeout()
+        return self._state
+
+    def call(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
+        """Execute *func* through the circuit breaker.
+
+        Raises:
+            CircuitBreakerError: When the circuit is OPEN.
+            Exception: Any exception raised by *func* itself (also recorded as failure).
+        """
+        self._evaluate_timeout()
+
+        if self._state == CircuitState.OPEN:
+            raise CircuitBreakerError(
+                f"[{self.name}] Circuit is OPEN — call rejected. "
+                f"Retry after {self._seconds_until_probe():.0f}s."
+            )
+
+        if self._state == CircuitState.HALF_OPEN:
+            return self._probe(func, *args, **kwargs)
+
+        # CLOSED — normal execution.
+        return self._execute(func, *args, **kwargs)
+
+    def reset(self) -> None:
+        """Manually reset the circuit to CLOSED."""
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._opened_at = None
+        logger.info("[%s] Circuit manually reset to CLOSED.", self.name)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _evaluate_timeout(self) -> None:
+        if self._state == CircuitState.OPEN and self._opened_at is not None:
+            elapsed = time.monotonic() - self._opened_at
+            if elapsed >= self.reset_timeout:
+                logger.info(
+                    "[%s] Reset timeout elapsed (%.0fs); entering HALF_OPEN.",
+                    self.name,
+                    elapsed,
+                )
+                self._state = CircuitState.HALF_OPEN
+
+    def _execute(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
+        try:
+            result = func(*args, **kwargs)
+            self._on_success()
+            return result
+        except Exception as exc:
+            self._on_failure(exc)
+            raise
+
+    def _probe(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
+        """Single trial call in HALF_OPEN state."""
+        try:
+            result = func(*args, **kwargs)
+            logger.info("[%s] Probe succeeded; circuit CLOSED.", self.name)
+            self._state = CircuitState.CLOSED
+            self._failure_count = 0
+            self._opened_at = None
+            return result
+        except Exception as exc:
+            logger.warning("[%s] Probe failed; circuit re-OPENED. Error: %s", self.name, exc)
+            self._trip()
+            raise
+
+    def _on_success(self) -> None:
+        if self._failure_count:
+            logger.debug("[%s] Success; failure counter reset.", self.name)
+        self._failure_count = 0
+
+    def _on_failure(self, exc: Exception) -> None:
+        self._failure_count += 1
+        logger.warning(
+            "[%s] Failure %d/%d: %s",
+            self.name,
+            self._failure_count,
+            self.failure_threshold,
+            exc,
+        )
+        if self._failure_count >= self.failure_threshold:
+            self._trip()
+
+    def _trip(self) -> None:
+        self._state = CircuitState.OPEN
+        self._opened_at = time.monotonic()
+        logger.error(
+            "[%s] Circuit OPEN after %d consecutive failures. Will probe in %ds.",
+            self.name,
+            self._failure_count,
+            self.reset_timeout,
+        )
+
+    def _seconds_until_probe(self) -> float:
+        if self._opened_at is None:
+            return 0.0
+        remaining = self.reset_timeout - (time.monotonic() - self._opened_at)
+        return max(0.0, remaining)

--- a/frontend/backend/app/core/response.py
+++ b/frontend/backend/app/core/response.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def api_response(
+    data: Any,
+    *,
+    total: Optional[int] = None,
+    page: int = 1,
+    per_page: int = 50,
+    source: Optional[str] = None,
+    freshness: Optional[str] = None,
+    cache_hit: bool = False,
+) -> dict:
+    """Build a unified API response envelope.
+
+    Args:
+        data: The primary payload (list, dict, or scalar).
+        total: Total record count for paginated responses.
+        page: Current page number (1-indexed).
+        per_page: Records per page.
+        source: Data origin label (e.g. ``"sqlite"``, ``"yfinance"``).
+        freshness: ISO-8601 timestamp or human label for data age.
+        cache_hit: Whether the result was served from cache.
+
+    Returns:
+        A dict with ``status``, ``data``, and ``meta`` keys.
+
+    Example::
+
+        return api_response(rows, total=len(rows), source="sqlite", cache_hit=True)
+    """
+    return {
+        "status": "ok",
+        "data": data,
+        "meta": {
+            "total": total,
+            "page": page,
+            "per_page": per_page,
+            "data_freshness": freshness,
+            "source": source,
+            "cache_hit": cache_hit,
+        },
+    }

--- a/frontend/backend/app/db.py
+++ b/frontend/backend/app/db.py
@@ -178,6 +178,8 @@ def connect_rw(db_path: Path = DB_PATH) -> sqlite3.Connection:
 
     conn = sqlite3.connect(db_path.as_posix(), check_same_thread=False)
     conn.row_factory = sqlite3.Row
+    # WAL mode gives better concurrent read performance and crash safety.
+    conn.execute("PRAGMA journal_mode=WAL")
     return conn
 
 

--- a/frontend/backend/app/db/research_db.py
+++ b/frontend/backend/app/db/research_db.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+"""research_db.py — Initialize and manage the research.db SQLite database.
+
+Provides WAL-mode setup and schema creation for all AI Investment Research
+Platform tables:
+
+  - market_indices        — daily snapshots of major index levels
+  - geopolitical_events   — curated macro / geopolitical risk events
+  - research_reports      — generated investment research reports
+  - data_source_health    — connectivity / staleness health for data providers
+  - risk_snapshots        — periodic portfolio-level risk metric snapshots
+"""
+
+import logging
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_research_db_path() -> Path:
+    """Resolve research.db path from env or default relative to repo layout.
+
+    Default: <repo_root>/data/sqlite/research.db
+    Override: set RESEARCH_DB_PATH env variable.
+    """
+    env_path = os.environ.get("RESEARCH_DB_PATH")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+
+    # backend/app/db/research_db.py -> backend root -> ../../data/sqlite/research.db
+    backend_root = Path(__file__).resolve().parent.parent.parent
+    return (backend_root / ".." / ".." / "data" / "sqlite" / "research.db").resolve()
+
+
+RESEARCH_DB_PATH: Path = _resolve_research_db_path()
+
+
+# ---------------------------------------------------------------------------
+# DDL
+# ---------------------------------------------------------------------------
+
+_DDL_STATEMENTS = [
+    # ------------------------------------------------------------------
+    # market_indices: daily closing levels for major indices.
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS market_indices (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        symbol          TEXT    NOT NULL,
+        name            TEXT,
+        close_price     REAL    NOT NULL,
+        open_price      REAL,
+        high_price      REAL,
+        low_price       REAL,
+        volume          INTEGER,
+        change_pct      REAL,
+        trade_date      TEXT    NOT NULL,           -- ISO-8601 YYYY-MM-DD
+        source          TEXT    NOT NULL DEFAULT 'yfinance',
+        fetched_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (symbol, trade_date)
+    )
+    """,
+
+    # ------------------------------------------------------------------
+    # geopolitical_events: macro / geopolitical risk items.
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS geopolitical_events (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_date      TEXT    NOT NULL,           -- ISO-8601 YYYY-MM-DD
+        title           TEXT    NOT NULL,
+        summary         TEXT,
+        region          TEXT,                       -- e.g. "APAC", "MENA", "GLOBAL"
+        severity        TEXT    NOT NULL DEFAULT 'medium', -- low / medium / high / critical
+        tags            TEXT,                       -- JSON array of keyword tags
+        source_url      TEXT,
+        created_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+    )
+    """,
+
+    # ------------------------------------------------------------------
+    # research_reports: AI-generated investment research outputs.
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS research_reports (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        report_date     TEXT    NOT NULL,           -- ISO-8601 YYYY-MM-DD
+        report_type     TEXT    NOT NULL,           -- e.g. "daily_brief", "sector_deep_dive"
+        title           TEXT    NOT NULL,
+        summary         TEXT,
+        body            TEXT,                       -- Full markdown / JSON content
+        tickers         TEXT,                       -- JSON array of relevant tickers
+        sentiment       TEXT,                       -- bullish / bearish / neutral
+        confidence      REAL,                       -- 0.0 – 1.0
+        model_id        TEXT,                       -- AI model that produced the report
+        created_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+    )
+    """,
+
+    # ------------------------------------------------------------------
+    # data_source_health: track connectivity / staleness of data providers.
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS data_source_health (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        source_name     TEXT    NOT NULL,           -- e.g. "yfinance", "fred", "twse"
+        status          TEXT    NOT NULL DEFAULT 'unknown', -- ok / degraded / down / unknown
+        last_success_at TEXT,
+        last_failure_at TEXT,
+        failure_count   INTEGER NOT NULL DEFAULT 0,
+        latency_ms      REAL,
+        error_message   TEXT,
+        checked_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (source_name)
+    )
+    """,
+
+    # ------------------------------------------------------------------
+    # risk_snapshots: periodic portfolio-level risk metric captures.
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS risk_snapshots (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        snapshot_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+        portfolio_id    TEXT    NOT NULL DEFAULT 'default',
+        var_1d          REAL,                       -- 1-day Value at Risk (95 %)
+        var_5d          REAL,                       -- 5-day Value at Risk (95 %)
+        beta            REAL,                       -- Portfolio beta vs. benchmark
+        sharpe_ratio    REAL,
+        max_drawdown    REAL,
+        gross_exposure  REAL,
+        net_exposure    REAL,
+        concentration   REAL,                       -- Herfindahl index
+        notes           TEXT
+    )
+    """,
+
+    # ------------------------------------------------------------------
+    # Indices for common query patterns.
+    # ------------------------------------------------------------------
+    "CREATE INDEX IF NOT EXISTS idx_market_indices_date   ON market_indices (trade_date DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_market_indices_symbol ON market_indices (symbol)",
+    "CREATE INDEX IF NOT EXISTS idx_geo_events_date       ON geopolitical_events (event_date DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_research_date         ON research_reports (report_date DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_risk_snapshot_at      ON risk_snapshots (snapshot_at DESC)",
+]
+
+
+# ---------------------------------------------------------------------------
+# Connection helpers
+# ---------------------------------------------------------------------------
+
+def connect_research(db_path: Path = RESEARCH_DB_PATH) -> sqlite3.Connection:
+    """Open a read-write connection to research.db with WAL mode enabled."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path.as_posix(), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    # Enable WAL for better concurrent read performance.
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    return conn
+
+
+@contextmanager
+def get_research_conn(db_path: Path = RESEARCH_DB_PATH) -> Iterator[sqlite3.Connection]:
+    """Context-manager for a read-write research.db connection (auto-commits)."""
+    conn = connect_research(db_path)
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Schema initialisation
+# ---------------------------------------------------------------------------
+
+def init_research_db(db_path: Path = RESEARCH_DB_PATH) -> None:
+    """Create research.db and apply all DDL statements.
+
+    Safe to call multiple times — all statements use IF NOT EXISTS / IF NOT EXISTS.
+    """
+    logger.info("Initialising research.db at %s", db_path)
+    with get_research_conn(db_path) as conn:
+        for stmt in _DDL_STATEMENTS:
+            conn.execute(stmt)
+    logger.info("research.db schema ready.")
+
+
+# ---------------------------------------------------------------------------
+# Convenience: run directly to bootstrap the database.
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import sys
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else RESEARCH_DB_PATH
+    init_research_db(path)
+    print(f"research.db initialised at {path}")

--- a/frontend/backend/requirements.txt
+++ b/frontend/backend/requirements.txt
@@ -7,6 +7,7 @@ pytest>=8.0
 hypothesis>=6.0
 httpx>=0.27
 psutil>=5.9
+cachetools>=5.3
 
 # SSE
 sse-starlette>=2.1


### PR DESCRIPTION
## Summary

- **cache.py** — `@cached(ttl, maxsize)` decorator backed by `cachetools.TTLCache`; exposes `.cache` attribute for manual invalidation
- **circuit_breaker.py** — `CircuitBreaker` with CLOSED / OPEN / HALF_OPEN state machine, configurable `failure_threshold` and `reset_timeout`, structured logging at each state transition
- **response.py** — `api_response()` unified envelope with `status`, `data`, and `meta` (total, page, per_page, source, data_freshness, cache_hit)
- **db/research_db.py** — initialises `research.db` in WAL mode with 5 tables: `market_indices`, `geopolitical_events`, `research_reports`, `data_source_health`, `risk_snapshots`; plus covering indices
- **db.py** — `connect_rw()` now sets `PRAGMA journal_mode=WAL` on `trades.db`
- **requirements.txt** — adds `cachetools>=5.3`
- **main.py** — CORS was already correctly configured; no change needed

## Test plan

- [ ] `python -m app.db.research_db` bootstraps `research.db` without errors
- [ ] WAL files (`trades.db-wal`, `trades.db-shm`) appear after first write to trades.db
- [ ] `@cached(ttl=5)` decorator returns cached result on second call within TTL, re-fetches after expiry
- [ ] `CircuitBreaker` trips to OPEN after 5 failures, rejects further calls, probes after timeout
- [ ] `/api/health` endpoint returns `{"status": "ok"}` (smoke test CORS + import chain)

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)