### PR TITLE
feat(infra): frontend infrastructure — React Query, design tokens, shared components

### DIFF
--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -8,6 +8,8 @@
       "name": "ai-trader-dashboard",
       "version": "4.7.19",
       "dependencies": {
+        "@tanstack/react-query": "^5.96.1",
+        "lightweight-charts": "^5.1.0",
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1392,6 +1394,32 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.1.tgz",
+      "integrity": "sha512-u1yBgtavSy+N8wgtW3PiER6UpxcplMje65yXnnVgiHTqiMwLlxiw4WvQDrXyn+UD6lnn8kHaxmerJUzQcV/MMg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.1.tgz",
+      "integrity": "sha512-2X7KYK5KKWUKGeWCVcqxXAkYefJtrKB7tSKWgeG++b0H6BRHxQaLSSi8AxcgjmUnnosHuh9WsFZqvE16P1WCzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.96.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -2787,6 +2815,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-equals": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
@@ -3640,6 +3674,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.1.0.tgz",
+      "integrity": "sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/lilconfig": {

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -12,6 +12,8 @@
     "coverage": "vitest --config vitest.config.js run"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.96.1",
+    "lightweight-charts": "^5.1.0",
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/web/src/App.jsx
+++ b/frontend/web/src/App.jsx
@@ -1,6 +1,8 @@
 import React, { Suspense, useEffect } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { isAuthenticated } from './lib/auth'
+import { queryClient } from './lib/queryClient'
 import DashboardLayout from './layouts/DashboardLayout'
 import LoginPage from './pages/Login'
 
@@ -16,6 +18,16 @@ const SystemPage     = React.lazy(() => import('./pages/System'))
 const AgentsPage     = React.lazy(() => import('./pages/Agents'))
 const AnalysisPage   = React.lazy(() => import('./pages/Analysis'))
 const SettingsPage   = React.lazy(() => import('./pages/Settings'))
+
+// ── Research / new routes (lazy) ────────────────────────────────────────────
+const ResearchLayout    = React.lazy(() => import('./layouts/ResearchLayout'))
+const ResearchDashboard = React.lazy(() => import('./pages/research/ResearchDashboard'))
+const StockResearch     = React.lazy(() => import('./pages/research/StockResearch'))
+const Screener          = React.lazy(() => import('./pages/research/Screener'))
+const DashboardPage     = React.lazy(() => import('./pages/Dashboard'))
+const RiskPage          = React.lazy(() => import('./pages/Risk'))
+const GeopoliticalPage  = React.lazy(() => import('./pages/Geopolitical'))
+const ReportsPage       = React.lazy(() => import('./pages/Reports'))
 
 // Restore variant preference from sessionStorage
 const STORAGE_KEY = 'ai-trader-theme-variant'
@@ -47,7 +59,7 @@ function BattleLayout() {
 
 export default function App() {
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       {/* Inject Google Fonts + global keyframes once */}
       <BattleTheme />
 
@@ -120,6 +132,75 @@ export default function App() {
               </Suspense>
             }
           />
+
+          {/* Research nested routes */}
+          <Route
+            path="/research"
+            element={
+              <Suspense fallback={<PageFallback />}>
+                <ResearchLayout />
+              </Suspense>
+            }
+          >
+            <Route
+              index
+              element={
+                <Suspense fallback={<PageFallback />}>
+                  <ResearchDashboard />
+                </Suspense>
+              }
+            />
+            <Route
+              path="stock"
+              element={
+                <Suspense fallback={<PageFallback />}>
+                  <StockResearch />
+                </Suspense>
+              }
+            />
+            <Route
+              path="screener"
+              element={
+                <Suspense fallback={<PageFallback />}>
+                  <Screener />
+                </Suspense>
+              }
+            />
+          </Route>
+
+          {/* Top-level new routes */}
+          <Route
+            path="/dashboard"
+            element={
+              <Suspense fallback={<PageFallback />}>
+                <DashboardPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/risk"
+            element={
+              <Suspense fallback={<PageFallback />}>
+                <RiskPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/geopolitical"
+            element={
+              <Suspense fallback={<PageFallback />}>
+                <GeopoliticalPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/reports"
+            element={
+              <Suspense fallback={<PageFallback />}>
+                <ReportsPage />
+              </Suspense>
+            }
+          />
         </Route>
 
         {/* Catch-all */}
@@ -128,6 +209,6 @@ export default function App() {
           element={isAuthenticated() ? <Navigate to="/portfolio" replace /> : <Navigate to="/login" replace />}
         />
       </Routes>
-    </>
+    </QueryClientProvider>
   )
 }

--- a/frontend/web/src/components/charts/PriceChart.jsx
+++ b/frontend/web/src/components/charts/PriceChart.jsx
@@ -1,0 +1,179 @@
+import React, { useEffect, useRef } from 'react'
+import { createChart, CandlestickSeries, LineSeries } from 'lightweight-charts'
+
+/**
+ * Calculate Simple Moving Average
+ * @param {Array} data - OHLCV array [{time, open, high, low, close}]
+ * @param {number} period
+ * @returns {Array} [{time, value}]
+ */
+function calcMA(data, period) {
+  const result = []
+  for (let i = period - 1; i < data.length; i++) {
+    const slice = data.slice(i - period + 1, i + 1)
+    const avg = slice.reduce((sum, d) => sum + d.close, 0) / period
+    result.push({ time: data[i].time, value: parseFloat(avg.toFixed(2)) })
+  }
+  return result
+}
+
+/**
+ * PriceChart — TradingView lightweight-charts candlestick chart
+ * with MA5 / MA20 / MA60 overlay
+ *
+ * Props:
+ *   data   — Array of { time: 'YYYY-MM-DD', open, high, low, close, volume }
+ *   symbol — Ticker string shown in top-left label
+ *   height — Number (default 320)
+ */
+export function PriceChart({ data = [], symbol = '', height = 320 }) {
+  const containerRef = useRef(null)
+  const chartRef = useRef(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    // Resolve CSS variable colors from :root
+    const style = getComputedStyle(document.documentElement)
+    const resolve = (varName, fallback) => {
+      const raw = style.getPropertyValue(varName).trim()
+      return raw ? `rgb(${raw})` : fallback
+    }
+
+    const upColor   = resolve('--up',      '#10b981')
+    const downColor = resolve('--down',    '#e11d48')
+    const bgColor   = resolve('--card',    '#0d131e')
+    const gridColor = resolve('--border',  '#334155')
+    const textColor = resolve('--muted',   '#64748b')
+
+    const chart = createChart(containerRef.current, {
+      width:  containerRef.current.clientWidth,
+      height,
+      layout: {
+        background: { color: bgColor },
+        textColor,
+        fontFamily: 'var(--font-data), "Fira Code", monospace',
+        fontSize: 11,
+      },
+      grid: {
+        vertLines:  { color: `${gridColor}55` },
+        horzLines:  { color: `${gridColor}55` },
+      },
+      crosshair: {
+        mode: 1,
+      },
+      rightPriceScale: {
+        borderColor: gridColor,
+      },
+      timeScale: {
+        borderColor: gridColor,
+        timeVisible: true,
+        secondsVisible: false,
+      },
+    })
+
+    chartRef.current = chart
+
+    // Candlestick series
+    const candleSeries = chart.addSeries(CandlestickSeries, {
+      upColor,
+      downColor,
+      borderUpColor:   upColor,
+      borderDownColor: downColor,
+      wickUpColor:     upColor,
+      wickDownColor:   downColor,
+    })
+
+    if (data.length > 0) {
+      candleSeries.setData(data)
+
+      // MA5 — short-term (info color)
+      const ma5Color = resolve('--info', '#06b6d4')
+      const ma5Series = chart.addSeries(LineSeries, {
+        color:       ma5Color,
+        lineWidth:   1,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        crosshairMarkerVisible: false,
+      })
+      ma5Series.setData(calcMA(data, 5))
+
+      // MA20 — medium-term (warn color)
+      const ma20Color = resolve('--warn', '#fb923c')
+      const ma20Series = chart.addSeries(LineSeries, {
+        color:       ma20Color,
+        lineWidth:   1,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        crosshairMarkerVisible: false,
+      })
+      ma20Series.setData(calcMA(data, 20))
+
+      // MA60 — long-term (gold color)
+      const ma60Color = resolve('--gold', '#a18a5a')
+      const ma60Series = chart.addSeries(LineSeries, {
+        color:       ma60Color,
+        lineWidth:   1,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        crosshairMarkerVisible: false,
+      })
+      ma60Series.setData(calcMA(data, 60))
+
+      chart.timeScale().fitContent()
+    }
+
+    // Responsive resize
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        chart.applyOptions({ width: entry.contentRect.width })
+      }
+    })
+    ro.observe(containerRef.current)
+
+    return () => {
+      ro.disconnect()
+      chart.remove()
+      chartRef.current = null
+    }
+  }, [data, height])
+
+  return (
+    <div className="relative w-full rounded-sm overflow-hidden border border-th-border bg-th-card">
+      {/* Symbol label overlay */}
+      {symbol && (
+        <div
+          className="absolute top-2 left-3 z-10 text-xs text-th-accent pointer-events-none"
+          style={{ fontFamily: 'var(--font-data)' }}
+        >
+          {symbol}
+        </div>
+      )}
+
+      {/* MA legend */}
+      <div
+        className="absolute top-2 right-3 z-10 flex items-center gap-3 text-xs pointer-events-none"
+        style={{ fontFamily: 'var(--font-data)', fontSize: '10px' }}
+      >
+        <span style={{ color: 'rgb(var(--info))' }}>MA5</span>
+        <span style={{ color: 'rgb(var(--warn))' }}>MA20</span>
+        <span style={{ color: 'rgb(var(--gold))' }}>MA60</span>
+      </div>
+
+      {data.length === 0 && (
+        <div
+          className="absolute inset-0 flex items-center justify-center z-10"
+          style={{ height }}
+        >
+          <span className="text-xs text-th-muted" style={{ fontFamily: 'var(--font-ui)' }}>
+            尚無 K 線資料
+          </span>
+        </div>
+      )}
+
+      <div ref={containerRef} style={{ width: '100%', height }} />
+    </div>
+  )
+}
+
+export default PriceChart

--- a/frontend/web/src/components/ui/AlertBadge.jsx
+++ b/frontend/web/src/components/ui/AlertBadge.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+
+/**
+ * AlertBadge — alert level indicator with optional action button
+ * level: 'red' | 'yellow' | 'green'
+ */
+export function AlertBadge({ level = 'yellow', message, actionLabel, onAction }) {
+  const config = {
+    red: {
+      borderVar: 'rgb(var(--danger))',
+      textVar: 'rgb(var(--danger))',
+      bgVar: 'rgba(var(--danger), 0.08)',
+      className: 'animate-lava-pulse',
+      icon: '!',
+    },
+    yellow: {
+      borderVar: 'rgb(var(--warn))',
+      textVar: 'rgb(var(--warn))',
+      bgVar: 'rgba(var(--warn), 0.08)',
+      className: '',
+      icon: '⚠',
+    },
+    green: {
+      borderVar: 'rgb(var(--up))',
+      textVar: 'rgb(var(--up))',
+      bgVar: 'rgba(var(--up), 0.06)',
+      className: '',
+      icon: '✓',
+    },
+  }
+
+  const { borderVar, textVar, bgVar, className, icon } = config[level] ?? config.yellow
+
+  return (
+    <div
+      className={`
+        flex items-start gap-2 px-3 py-2 rounded-sm border
+        ${className}
+      `}
+      style={{
+        borderColor: borderVar,
+        backgroundColor: bgVar,
+      }}
+    >
+      <span
+        className="text-xs font-bold flex-shrink-0 mt-px"
+        style={{ color: textVar, fontFamily: 'var(--font-mono)' }}
+      >
+        {icon}
+      </span>
+      <span
+        className="text-xs flex-1"
+        style={{ color: textVar, fontFamily: 'var(--font-ui)' }}
+      >
+        {message}
+      </span>
+      {actionLabel && onAction && (
+        <button
+          onClick={onAction}
+          className="text-xs px-2 py-0.5 rounded-sm border flex-shrink-0 transition-opacity hover:opacity-80"
+          style={{
+            color: textVar,
+            borderColor: borderVar,
+            fontFamily: 'var(--font-mono)',
+          }}
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default AlertBadge

--- a/frontend/web/src/components/ui/DataCard.jsx
+++ b/frontend/web/src/components/ui/DataCard.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+
+/**
+ * DataCard — BattleTheme-compatible reusable card
+ * Supports loading/error/empty states with accent border
+ */
+export function DataCard({ title, loading, error, empty, children, className = '', accentColor }) {
+  const accentStyle = accentColor
+    ? { borderLeftColor: accentColor }
+    : {}
+
+  return (
+    <div
+      className={`
+        relative bg-th-card border border-th-border border-l-2
+        rounded-sm shadow-panel overflow-hidden
+        ${className}
+      `}
+      style={{ borderLeftColor: accentColor || 'rgb(var(--accent))', ...accentStyle }}
+    >
+      {title && (
+        <div className="px-3 py-2 border-b border-th-border flex items-center justify-between">
+          <span
+            className="text-xs font-medium tracking-widest uppercase text-th-muted"
+            style={{ fontFamily: 'var(--font-mono)' }}
+          >
+            {title}
+          </span>
+        </div>
+      )}
+
+      <div className="p-3">
+        {loading && (
+          <div className="flex items-center justify-center min-h-[80px]">
+            <div
+              className="w-5 h-5 border-2 border-th-border border-t-th-accent rounded-full animate-spin"
+              style={{ borderTopColor: 'rgb(var(--accent))' }}
+            />
+            <span className="ml-2 text-xs text-th-muted" style={{ fontFamily: 'var(--font-ui)' }}>
+              載入中…
+            </span>
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="flex items-start gap-2 min-h-[80px] py-2">
+            <span className="text-th-danger text-xs mt-0.5">!</span>
+            <span className="text-xs text-th-danger" style={{ fontFamily: 'var(--font-ui)' }}>
+              {typeof error === 'string' ? error : error?.message || '資料載入失敗'}
+            </span>
+          </div>
+        )}
+
+        {!loading && !error && empty && (
+          <div className="flex items-center justify-center min-h-[80px]">
+            <span className="text-xs text-th-muted" style={{ fontFamily: 'var(--font-ui)' }}>
+              {typeof empty === 'string' ? empty : '尚無資料'}
+            </span>
+          </div>
+        )}
+
+        {!loading && !error && !empty && children}
+      </div>
+    </div>
+  )
+}
+
+export default DataCard

--- a/frontend/web/src/components/ui/MetricBadge.jsx
+++ b/frontend/web/src/components/ui/MetricBadge.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+
+/**
+ * MetricBadge — monospace number display with trend arrow + color
+ * trend: 'up' | 'down' | 'flat'
+ * format: 'currency' | 'percent' | 'number' | 'raw'
+ */
+export function MetricBadge({ value, label, trend, format = 'raw' }) {
+  const formatValue = (val) => {
+    if (val === null || val === undefined) return '—'
+    switch (format) {
+      case 'currency':
+        return new Intl.NumberFormat('zh-TW', {
+          style: 'currency',
+          currency: 'TWD',
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 0,
+        }).format(val)
+      case 'percent':
+        return `${Number(val).toFixed(2)}%`
+      case 'number':
+        return new Intl.NumberFormat('zh-TW').format(val)
+      default:
+        return String(val)
+    }
+  }
+
+  const trendArrow = trend === 'up' ? '▲' : trend === 'down' ? '▼' : '─'
+  const trendColorVar =
+    trend === 'up' ? 'var(--up)' : trend === 'down' ? 'var(--down)' : 'var(--muted)'
+  const trendColor = `rgb(${trendColorVar})`
+
+  return (
+    <div className="inline-flex flex-col items-start min-w-0">
+      {label && (
+        <span
+          className="text-xs text-th-muted mb-0.5 truncate"
+          style={{ fontFamily: 'var(--font-ui)', fontSize: '10px' }}
+        >
+          {label}
+        </span>
+      )}
+      <div className="flex items-baseline gap-1">
+        <span
+          className="text-base tabular-nums"
+          style={{
+            fontFamily: 'var(--font-data)',
+            color: trend ? trendColor : 'rgb(var(--text))',
+          }}
+        >
+          {formatValue(value)}
+        </span>
+        {trend && (
+          <span
+            className="text-xs"
+            style={{ color: trendColor, fontFamily: 'var(--font-mono)' }}
+          >
+            {trendArrow}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default MetricBadge

--- a/frontend/web/src/components/ui/SentimentIndicator.jsx
+++ b/frontend/web/src/components/ui/SentimentIndicator.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+/**
+ * SentimentIndicator
+ * sentiment: 'bullish' | 'bearish' | 'neutral'
+ */
+export function SentimentIndicator({ sentiment = 'neutral' }) {
+  const config = {
+    bullish: {
+      dot: 'rgb(var(--up))',
+      arrow: '▲',
+      label: '看多',
+      glow: '0 0 6px rgba(var(--up-glow))',
+    },
+    bearish: {
+      dot: 'rgb(var(--down))',
+      arrow: '▼',
+      label: '看空',
+      glow: '0 0 6px rgba(var(--down-glow))',
+    },
+    neutral: {
+      dot: 'rgb(var(--warn))',
+      arrow: '─',
+      label: '中性',
+      glow: 'none',
+    },
+  }
+
+  const { dot, arrow, label, glow } = config[sentiment] ?? config.neutral
+
+  return (
+    <div className="inline-flex items-center gap-1.5">
+      <span
+        className="inline-block w-2 h-2 rounded-full flex-shrink-0"
+        style={{ backgroundColor: dot, boxShadow: glow }}
+      />
+      <span
+        className="text-xs"
+        style={{ color: dot, fontFamily: 'var(--font-mono)' }}
+      >
+        {arrow}
+      </span>
+      <span
+        className="text-xs text-th-muted"
+        style={{ fontFamily: 'var(--font-ui)' }}
+      >
+        {label}
+      </span>
+    </div>
+  )
+}
+
+export default SentimentIndicator

--- a/frontend/web/src/layouts/ResearchLayout.jsx
+++ b/frontend/web/src/layouts/ResearchLayout.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { NavLink, Outlet } from 'react-router-dom'
+
+const NAV_ITEMS = [
+  { path: '/research', label: '總覽', icon: '◈', end: true },
+  { path: '/research/stock', label: '個股分析', icon: '◉' },
+  { path: '/research/screener', label: '選股器', icon: '▦' },
+]
+
+function ResearchNavLink({ path, label, icon, end }) {
+  return (
+    <NavLink
+      to={path}
+      end={end}
+      className={({ isActive }) => `
+        flex items-center gap-2 px-3 py-2 rounded-sm text-xs transition-colors
+        ${isActive
+          ? 'text-th-accent bg-th-card border-l-2'
+          : 'text-th-muted hover:text-th-text hover:bg-th-card/50 border-l-2 border-transparent'
+        }
+      `}
+      style={({ isActive }) => ({
+        fontFamily: 'var(--font-ui)',
+        borderLeftColor: isActive ? 'rgb(var(--accent))' : 'transparent',
+      })}
+    >
+      <span style={{ fontFamily: 'var(--font-mono)', fontSize: '10px' }}>{icon}</span>
+      {label}
+    </NavLink>
+  )
+}
+
+/**
+ * ResearchLayout — nested layout for /research/* routes
+ * Left sidebar with sub-navigation + main content area
+ */
+export default function ResearchLayout() {
+  return (
+    <div className="flex min-h-full w-full">
+      {/* Left sidebar */}
+      <aside className="w-40 flex-shrink-0 border-r border-th-border bg-th-surface/50 py-4 px-2 hidden sm:flex flex-col gap-1">
+        <div
+          className="px-3 py-1 mb-2 text-xs tracking-widest uppercase text-th-muted"
+          style={{ fontFamily: 'var(--font-mono)', fontSize: '9px' }}
+        >
+          研究中心
+        </div>
+        {NAV_ITEMS.map((item) => (
+          <ResearchNavLink key={item.path} {...item} />
+        ))}
+      </aside>
+
+      {/* Mobile top nav */}
+      <div className="sm:hidden w-full absolute top-0 left-0 z-10 bg-th-surface border-b border-th-border px-2 py-1 flex gap-1 overflow-x-auto">
+        {NAV_ITEMS.map((item) => (
+          <ResearchNavLink key={item.path} {...item} />
+        ))}
+      </div>
+
+      {/* Main content */}
+      <main className="flex-1 min-w-0 p-4 sm:p-6 overflow-auto">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/frontend/web/src/lib/queryClient.ts
+++ b/frontend/web/src/lib/queryClient.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000, // 5 min default
+      gcTime: 30 * 60 * 1000,
+      retry: 2,
+      refetchOnWindowFocus: false,
+    },
+  },
+})

--- a/frontend/web/src/pages/Geopolitical.jsx
+++ b/frontend/web/src/pages/Geopolitical.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { DataCard } from '../components/ui/DataCard'
+
+/**
+ * Geopolitical — placeholder for /geopolitical
+ */
+export default function Geopolitical() {
+  return (
+    <div className="space-y-4 p-4">
+      <h1
+        className="text-lg font-medium text-th-text mb-4"
+        style={{ fontFamily: 'var(--font-ui)' }}
+      >
+        地緣政治分析
+      </h1>
+      <DataCard title="全球風險地圖" empty="地緣政治模組開發中" />
+      <DataCard title="新聞情緒" empty="即將上線" />
+    </div>
+  )
+}

--- a/frontend/web/src/pages/Reports.jsx
+++ b/frontend/web/src/pages/Reports.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { DataCard } from '../components/ui/DataCard'
+
+/**
+ * Reports — placeholder for /reports
+ */
+export default function Reports() {
+  return (
+    <div className="space-y-4 p-4">
+      <h1
+        className="text-lg font-medium text-th-text mb-4"
+        style={{ fontFamily: 'var(--font-ui)' }}
+      >
+        研究報告
+      </h1>
+      <DataCard title="AI 生成報告" empty="報告模組開發中" />
+      <DataCard title="歷史報告" empty="即將上線" />
+    </div>
+  )
+}

--- a/frontend/web/src/pages/Risk.jsx
+++ b/frontend/web/src/pages/Risk.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { DataCard } from '../components/ui/DataCard'
+import { AlertBadge } from '../components/ui/AlertBadge'
+
+/**
+ * Risk — placeholder for /risk
+ */
+export default function Risk() {
+  return (
+    <div className="space-y-4 p-4">
+      <h1
+        className="text-lg font-medium text-th-text mb-4"
+        style={{ fontFamily: 'var(--font-ui)' }}
+      >
+        風險管理
+      </h1>
+      <AlertBadge level="yellow" message="風險模組建置中，即將上線" />
+      <DataCard title="曝險分析" empty="即將上線" />
+    </div>
+  )
+}

--- a/frontend/web/src/pages/research/ResearchDashboard.jsx
+++ b/frontend/web/src/pages/research/ResearchDashboard.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { DataCard } from '../../components/ui/DataCard'
+import { SentimentIndicator } from '../../components/ui/SentimentIndicator'
+
+/**
+ * ResearchDashboard — placeholder for /research index
+ * Will be replaced with full AI research overview in Sprint 5
+ */
+export default function ResearchDashboard() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between mb-2">
+        <h1
+          className="text-lg font-medium text-th-text"
+          style={{ fontFamily: 'var(--font-ui)' }}
+        >
+          AI 投資研究中心
+        </h1>
+        <SentimentIndicator sentiment="neutral" />
+      </div>
+
+      <DataCard title="市場概況" accentColor="rgb(var(--info))" empty="研究模組建置中，敬請期待" />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <DataCard title="熱門標的" empty="即將上線" />
+        <DataCard title="AI 訊號" empty="即將上線" />
+      </div>
+    </div>
+  )
+}

--- a/frontend/web/src/pages/research/Screener.jsx
+++ b/frontend/web/src/pages/research/Screener.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { DataCard } from '../../components/ui/DataCard'
+
+/**
+ * Screener — placeholder for /research/screener
+ */
+export default function Screener() {
+  return (
+    <div className="space-y-4">
+      <h1
+        className="text-lg font-medium text-th-text mb-4"
+        style={{ fontFamily: 'var(--font-ui)' }}
+      >
+        選股器
+      </h1>
+      <DataCard title="條件篩選" empty="選股功能開發中" />
+    </div>
+  )
+}

--- a/frontend/web/src/pages/research/StockResearch.jsx
+++ b/frontend/web/src/pages/research/StockResearch.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { DataCard } from '../../components/ui/DataCard'
+
+/**
+ * StockResearch — placeholder for /research/stock
+ */
+export default function StockResearch() {
+  return (
+    <div className="space-y-4">
+      <h1
+        className="text-lg font-medium text-th-text mb-4"
+        style={{ fontFamily: 'var(--font-ui)' }}
+      >
+        個股分析
+      </h1>
+      <DataCard title="K 線圖" empty="請輸入股票代碼開始分析" />
+      <DataCard title="財務指標" empty="即將上線" />
+    </div>
+  )
+}

--- a/frontend/web/tailwind.config.cjs
+++ b/frontend/web/tailwind.config.cjs
@@ -33,6 +33,31 @@ module.exports = {
         mono: 'var(--font-mono)',
         data: 'var(--font-data)',
       },
+      spacing: {
+        '0.5': '2px',
+        '1':   '4px',
+        '2':   '8px',
+        '3':   '12px',
+        '4':   '16px',
+        '6':   '24px',
+        '8':   '32px',
+        '12':  '48px',
+      },
+      borderRadius: {
+        'none': '0',
+        'sm':   '2px',
+        'md':   '4px',
+        'lg':   '8px',
+      },
+      fontSize: {
+        'xs':   '10px',
+        'sm':   '12px',
+        'base': '14px',
+        'lg':   '16px',
+        'xl':   '20px',
+        '2xl':  '24px',
+        '3xl':  '32px',
+      },
     }
   },
   plugins: []


### PR DESCRIPTION
## Summary

Closes #559

- **React Query**: Install `@tanstack/react-query`, create `queryClient.ts` with 5-min stale time / 30-min gcTime / retry:2 / no refetch on focus, wrap App root with `QueryClientProvider`
- **Design tokens**: Extend `tailwind.config.cjs` with explicit `spacing`, `borderRadius`, `fontSize` scales matching the BattleTheme system
- **Shared UI components** (`src/components/ui/`): `DataCard` (loading/error/empty states + accent border), `MetricBadge` (monospace + trend arrow), `SentimentIndicator` (bullish/bearish/neutral), `AlertBadge` (red pulsing / yellow / green levels)
- **PriceChart** (`src/components/charts/`): lightweight-charts candlestick with MA5/MA20/MA60 overlay, ResizeObserver responsive, BattleTheme CSS variable colors
- **ResearchLayout** (`src/layouts/`): nested layout for `/research/*` with left sidebar nav (hidden on mobile, top-bar fallback)
- **New routes**: `/research` (nested: `/research/stock`, `/research/screener`), `/dashboard`, `/risk`, `/geopolitical`, `/reports` — all with placeholder pages

## Test plan

- [x] `npm run build` passes with zero errors (1974 modules, 1.94s)
- [x] Pre-existing test failures (2 files: Strategy, PortfolioPage) confirmed present on `main` before this branch — not introduced by this PR
- [ ] Manual smoke test: navigate to `/research`, `/risk`, `/reports` — layout renders
- [ ] Verify QueryClientProvider wraps routes (React Query DevTools shows client)
- [ ] Resize to 375px — ResearchLayout switches to top-bar nav, DataCard responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)