### PR TITLE
feat(page): stock analysis — AI scoring, K-line, debate

### DIFF
--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -15,8 +15,10 @@
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.22.3",
+        "react-simple-maps": "^3.0.0",
         "recharts": "^2.7.2",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "topojson-client": "^3.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.0",
@@ -2489,6 +2491,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -2506,6 +2524,30 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/d3-geo/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-geo/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
@@ -2543,6 +2585,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -2587,6 +2635,77 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
+      },
+      "peerDependencies": {
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-transition/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition/node_modules/d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition/node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-transition/node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-zoom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
+    "node_modules/d3-zoom/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-zoom/node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
       }
     },
     "node_modules/data-urls": {
@@ -5556,6 +5675,23 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-simple-maps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-3.0.0.tgz",
+      "integrity": "sha512-vKNFrvpPG8Vyfdjnz5Ne1N56rZlDfHXv5THNXOVZMqbX1rWZA48zQuYT03mx6PAKanqarJu/PDLgshIZAfHHqw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "^2.0.2",
+        "d3-selection": "^2.0.0",
+        "d3-zoom": "^2.0.0",
+        "topojson-client": "^3.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.7.2",
+        "react": "^16.8.0 || 17.x || 18.x",
+        "react-dom": "^16.8.0 || 17.x || 18.x"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -6385,6 +6521,26 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -19,8 +19,10 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.22.3",
+    "react-simple-maps": "^3.0.0",
     "recharts": "^2.7.2",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.0",

--- a/frontend/web/src/pages/Geopolitical.jsx
+++ b/frontend/web/src/pages/Geopolitical.jsx
@@ -1,20 +1,781 @@
-import React from 'react'
-import { DataCard } from '../components/ui/DataCard'
-
 /**
- * Geopolitical — placeholder for /geopolitical
+ * Geopolitical.jsx — Geopolitical Dashboard
+ *
+ * Desktop layout: 60/40 split — World Map (left) + News Feed (right)
+ * Mobile (<768px): hide map, show news feed + market impact + category filter
+ *
+ * Data sources:
+ *   GET /api/geopolitical/latest  — latest 20 events (React Query, staleTime 15 min)
+ *   GET /api/geopolitical/events  — paginated event list
  */
+
+import React, { useState, useCallback } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  ComposableMap,
+  Geographies,
+  Geography,
+  Marker,
+} from 'react-simple-maps'
+import { DataCard } from '../components/ui/DataCard'
+import { SentimentIndicator } from '../components/ui/SentimentIndicator'
+import { AlertBadge } from '../components/ui/AlertBadge'
+import { getApiBase } from '../lib/auth'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const GEO_URL =
+  'https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json'
+
+const CATEGORY_CONFIG = {
+  conflict:  { color: '#ef4444', label: '衝突',   dot: '#ef4444' },
+  trade_war: { color: '#f97316', label: '貿易戰', dot: '#f97316' },
+  sanctions: { color: '#eab308', label: '制裁',   dot: '#eab308' },
+  policy:    { color: '#3b82f6', label: '政策',   dot: '#3b82f6' },
+  election:  { color: '#a855f7', label: '選舉',   dot: '#a855f7' },
+}
+
+const ALL_CATEGORIES = ['conflict', 'trade_war', 'sanctions', 'policy', 'election']
+
+// ── API helpers ───────────────────────────────────────────────────────────────
+
+async function fetchLatest() {
+  const base = getApiBase()
+  const res = await fetch(`${base}/api/geopolitical/latest`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const json = await res.json()
+  if (!json.ok) throw new Error('API returned ok=false')
+  return json.data ?? []
+}
+
+// ── Utility helpers ───────────────────────────────────────────────────────────
+
+function timeAgo(dateStr) {
+  if (!dateStr) return ''
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return '剛剛'
+  if (mins < 60) return `${mins} 分鐘前`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs} 小時前`
+  const days = Math.floor(hrs / 24)
+  return `${days} 天前`
+}
+
+function truncate(str, len = 100) {
+  if (!str) return ''
+  return str.length > len ? str.slice(0, len) + '…' : str
+}
+
+function impactColor(score) {
+  if (score >= 8) return '#ef4444'
+  if (score >= 5) return '#f97316'
+  return '#eab308'
+}
+
+/** Derive market impact summary cards from top events */
+function buildMarketImpact(events) {
+  const impacts = []
+  for (const ev of events.slice(0, 10)) {
+    const mi = ev.market_impact
+    if (!mi || typeof mi !== 'object') continue
+    Object.entries(mi).forEach(([sector, val]) => {
+      impacts.push({ sector, val, category: ev.category })
+    })
+  }
+  return impacts.slice(0, 6)
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+/** Category badge — colored dot + label */
+function CategoryBadge({ category }) {
+  const cfg = CATEGORY_CONFIG[category] || { dot: '#71717a', label: category }
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className="inline-block w-2 h-2 rounded-full flex-shrink-0"
+        style={{ backgroundColor: cfg.dot }}
+      />
+      <span
+        className="text-xs"
+        style={{ color: cfg.dot, fontFamily: 'var(--font-ui)' }}
+      >
+        {cfg.label}
+      </span>
+    </span>
+  )
+}
+
+/** Impact score badge */
+function ImpactBadge({ score }) {
+  if (score == null) return null
+  const color = impactColor(score)
+  return (
+    <span
+      className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-xs font-mono"
+      style={{
+        backgroundColor: `${color}22`,
+        color,
+        border: `1px solid ${color}55`,
+      }}
+    >
+      {score}
+    </span>
+  )
+}
+
+/** Tooltip overlay for map markers */
+function MapTooltip({ event, x, y }) {
+  if (!event) return null
+  return (
+    <div
+      className="absolute z-50 pointer-events-none"
+      style={{ left: x + 10, top: y - 10 }}
+    >
+      <div
+        className="rounded-sm shadow-lg px-3 py-2 text-xs max-w-[200px]"
+        style={{
+          backgroundColor: 'rgb(var(--card))',
+          border: '1px solid rgb(var(--border))',
+          fontFamily: 'var(--font-ui)',
+          color: 'rgb(var(--text))',
+        }}
+      >
+        <div className="font-medium mb-1 leading-snug">{event.title}</div>
+        <div className="flex items-center gap-2">
+          <CategoryBadge category={event.category} />
+          <ImpactBadge score={event.impact_score} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Single news feed item */
+function NewsFeedItem({ event, isSelected, onClick }) {
+  const [expanded, setExpanded] = useState(false)
+  const cfg = CATEGORY_CONFIG[event.category] || { dot: '#71717a' }
+
+  function handleClick() {
+    onClick(event)
+    setExpanded(prev => !prev)
+  }
+
+  const links = Array.isArray(event.source_links)
+    ? event.source_links
+    : typeof event.source_links === 'string'
+    ? [event.source_links]
+    : []
+
+  return (
+    <div
+      className="cursor-pointer rounded-sm transition-colors"
+      style={{
+        borderLeft: `2px solid ${isSelected ? cfg.dot : 'transparent'}`,
+        backgroundColor: isSelected ? `${cfg.dot}11` : 'transparent',
+        paddingLeft: 8,
+        paddingRight: 8,
+        paddingTop: 8,
+        paddingBottom: 8,
+      }}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={e => e.key === 'Enter' && handleClick()}
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-2 mb-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <CategoryBadge category={event.category} />
+          <ImpactBadge score={event.impact_score} />
+        </div>
+        <span
+          className="text-xs text-th-muted flex-shrink-0"
+          style={{ fontFamily: 'var(--font-mono)', color: 'rgb(var(--muted))' }}
+        >
+          {timeAgo(event.event_date)}
+        </span>
+      </div>
+
+      {/* Title */}
+      <div
+        className="text-sm font-medium leading-snug mb-1"
+        style={{ fontFamily: 'var(--font-ui)', color: 'rgb(var(--text))' }}
+      >
+        {event.title}
+      </div>
+
+      {/* Summary — truncated or full */}
+      <div
+        className="text-xs leading-relaxed"
+        style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+      >
+        {expanded ? event.summary : truncate(event.summary, 100)}
+      </div>
+
+      {/* Source links when expanded */}
+      {expanded && links.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {links.map((link, i) => (
+            <a
+              key={i}
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs underline"
+              style={{ color: 'rgb(var(--accent))' }}
+              onClick={e => e.stopPropagation()}
+            >
+              來源 {i + 1}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Market impact summary card strip */
+function MarketImpactStrip({ events }) {
+  const impacts = buildMarketImpact(events)
+  if (impacts.length === 0) return null
+
+  return (
+    <div
+      className="rounded-sm border p-3"
+      style={{
+        backgroundColor: 'rgb(var(--card))',
+        borderColor: 'rgb(var(--border))',
+      }}
+    >
+      <div
+        className="text-xs font-medium tracking-widest uppercase mb-3"
+        style={{
+          fontFamily: 'var(--font-mono)',
+          color: 'rgb(var(--muted))',
+        }}
+      >
+        市場影響概況
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {impacts.map((item, i) => {
+          const val = parseFloat(item.val)
+          const isPositive = val >= 0
+          const color = isPositive ? 'rgb(var(--up))' : 'rgb(var(--danger))'
+          return (
+            <div
+              key={i}
+              className="px-3 py-2 rounded-sm text-xs flex items-center gap-2"
+              style={{
+                backgroundColor: isPositive
+                  ? 'rgba(var(--up), 0.08)'
+                  : 'rgba(var(--danger), 0.08)',
+                border: `1px solid ${isPositive ? 'rgba(var(--up),0.2)' : 'rgba(var(--danger),0.2)'}`,
+                fontFamily: 'var(--font-ui)',
+                color: 'rgb(var(--text))',
+              }}
+            >
+              <span>最受影響板塊: {item.sector}</span>
+              <span style={{ color, fontFamily: 'var(--font-mono)' }}>
+                {isPositive ? '▲' : '▼'}
+                {Math.abs(val).toFixed(1)}%
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/** Category filter tabs (mobile) */
+function CategoryFilterTabs({ active, onChange }) {
+  return (
+    <div className="flex overflow-x-auto gap-1 pb-1">
+      <button
+        className="px-3 py-1.5 rounded-sm text-xs flex-shrink-0 transition-colors"
+        style={{
+          fontFamily: 'var(--font-ui)',
+          backgroundColor: active === null ? 'rgb(var(--accent))' : 'rgb(var(--card))',
+          color: active === null ? '#000' : 'rgb(var(--muted))',
+          border: '1px solid rgb(var(--border))',
+        }}
+        onClick={() => onChange(null)}
+      >
+        全部
+      </button>
+      {ALL_CATEGORIES.map(cat => {
+        const cfg = CATEGORY_CONFIG[cat]
+        const isActive = active === cat
+        return (
+          <button
+            key={cat}
+            className="px-3 py-1.5 rounded-sm text-xs flex-shrink-0 transition-colors"
+            style={{
+              fontFamily: 'var(--font-ui)',
+              backgroundColor: isActive ? cfg.dot : 'rgb(var(--card))',
+              color: isActive ? '#fff' : 'rgb(var(--muted))',
+              border: `1px solid ${isActive ? cfg.dot : 'rgb(var(--border))'}`,
+            }}
+            onClick={() => onChange(cat)}
+          >
+            {cfg.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── World Map panel ───────────────────────────────────────────────────────────
+
+function WorldMapPanel({ events, selectedEvent, onSelectEvent }) {
+  const [tooltip, setTooltip] = useState({ event: null, x: 0, y: 0 })
+
+  // Only events with coordinates
+  const markers = events.filter(
+    ev => ev.lat != null && ev.lng != null
+  )
+
+  function markerRadius(score) {
+    const s = Number(score) || 3
+    return Math.max(4, Math.min(16, s * 1.4))
+  }
+
+  return (
+    <div
+      className="rounded-sm border overflow-hidden relative"
+      style={{
+        backgroundColor: 'rgb(var(--card))',
+        borderColor: 'rgb(var(--border))',
+        minHeight: 340,
+      }}
+    >
+      {/* Panel header */}
+      <div
+        className="px-3 py-2 border-b flex items-center justify-between"
+        style={{ borderColor: 'rgb(var(--border))' }}
+      >
+        <span
+          className="text-xs font-medium tracking-widest uppercase"
+          style={{ fontFamily: 'var(--font-mono)', color: 'rgb(var(--muted))' }}
+        >
+          全球風險地圖
+        </span>
+        <div className="flex items-center gap-3">
+          {ALL_CATEGORIES.map(cat => (
+            <span key={cat} className="flex items-center gap-1">
+              <span
+                className="inline-block w-2 h-2 rounded-full"
+                style={{ backgroundColor: CATEGORY_CONFIG[cat].dot }}
+              />
+              <span
+                className="text-xs"
+                style={{
+                  color: 'rgb(var(--muted))',
+                  fontFamily: 'var(--font-ui)',
+                  fontSize: 10,
+                }}
+              >
+                {CATEGORY_CONFIG[cat].label}
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Map */}
+      <div className="relative">
+        <ComposableMap
+          projectionConfig={{ scale: 130, center: [10, 10] }}
+          style={{ width: '100%', height: 'auto' }}
+        >
+          <Geographies geography={GEO_URL}>
+            {({ geographies }) =>
+              geographies.map(geo => (
+                <Geography
+                  key={geo.rsmKey}
+                  geography={geo}
+                  style={{
+                    default: {
+                      fill: 'rgba(var(--grid), 0.15)',
+                      stroke: 'rgb(var(--border))',
+                      strokeWidth: 0.4,
+                      outline: 'none',
+                    },
+                    hover: {
+                      fill: 'rgba(var(--grid), 0.25)',
+                      stroke: 'rgb(var(--border))',
+                      strokeWidth: 0.4,
+                      outline: 'none',
+                    },
+                    pressed: { outline: 'none' },
+                  }}
+                />
+              ))
+            }
+          </Geographies>
+
+          {markers.map(ev => {
+            const cfg = CATEGORY_CONFIG[ev.category] || { color: '#71717a' }
+            const r = markerRadius(ev.impact_score)
+            const isSelected = selectedEvent?.id === ev.id
+            return (
+              <Marker
+                key={ev.id}
+                coordinates={[ev.lng, ev.lat]}
+                onClick={() => onSelectEvent(ev)}
+                onMouseEnter={e => {
+                  const rect = e.currentTarget.closest('svg')?.getBoundingClientRect()
+                  const svgX = e.clientX - (rect?.left ?? 0)
+                  const svgY = e.clientY - (rect?.top ?? 0)
+                  setTooltip({ event: ev, x: svgX, y: svgY })
+                }}
+                onMouseLeave={() => setTooltip({ event: null, x: 0, y: 0 })}
+                style={{ cursor: 'pointer' }}
+              >
+                <circle
+                  r={r}
+                  fill={cfg.color}
+                  fillOpacity={isSelected ? 0.95 : 0.65}
+                  stroke={isSelected ? '#fff' : cfg.color}
+                  strokeWidth={isSelected ? 2 : 0.8}
+                  style={{
+                    filter: isSelected
+                      ? `drop-shadow(0 0 6px ${cfg.color})`
+                      : undefined,
+                    transition: 'all 0.15s ease',
+                  }}
+                />
+              </Marker>
+            )
+          })}
+        </ComposableMap>
+
+        {/* Tooltip */}
+        <MapTooltip {...tooltip} />
+      </div>
+
+      {/* No-coordinates notice */}
+      {markers.length === 0 && events.length > 0 && (
+        <div
+          className="px-3 pb-3 text-xs"
+          style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+        >
+          目前事件無座標資料，地圖標記暫無顯示
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── News Feed panel ───────────────────────────────────────────────────────────
+
+function NewsFeedPanel({ events, selectedEvent, onSelectEvent, categoryFilter }) {
+  const filtered =
+    categoryFilter === null
+      ? events
+      : events.filter(ev => ev.category === categoryFilter)
+
+  return (
+    <div
+      className="rounded-sm border flex flex-col"
+      style={{
+        backgroundColor: 'rgb(var(--card))',
+        borderColor: 'rgb(var(--border))',
+        maxHeight: 480,
+      }}
+    >
+      <div
+        className="px-3 py-2 border-b flex items-center justify-between flex-shrink-0"
+        style={{ borderColor: 'rgb(var(--border))' }}
+      >
+        <span
+          className="text-xs font-medium tracking-widest uppercase"
+          style={{ fontFamily: 'var(--font-mono)', color: 'rgb(var(--muted))' }}
+        >
+          地緣政治事件
+        </span>
+        <span
+          className="text-xs"
+          style={{ fontFamily: 'var(--font-mono)', color: 'rgb(var(--muted))' }}
+        >
+          {filtered.length} 則
+        </span>
+      </div>
+
+      <div className="overflow-y-auto flex-1 divide-y" style={{ divideColor: 'rgb(var(--border))' }}>
+        {filtered.length === 0 && (
+          <div
+            className="flex items-center justify-center py-12 text-xs"
+            style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+          >
+            尚無事件資料
+          </div>
+        )}
+        {filtered.map(ev => (
+          <NewsFeedItem
+            key={ev.id}
+            event={ev}
+            isSelected={selectedEvent?.id === ev.id}
+            onClick={onSelectEvent}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── Main Page ─────────────────────────────────────────────────────────────────
+
 export default function Geopolitical() {
+  const [selectedEvent, setSelectedEvent] = useState(null)
+  const [categoryFilter, setCategoryFilter] = useState(null)
+
+  const { data: events = [], isLoading, error } = useQuery({
+    queryKey: ['geopolitical', 'latest'],
+    queryFn: fetchLatest,
+    staleTime: 15 * 60 * 1000, // 15 minutes
+    retry: 2,
+  })
+
+  const handleSelectEvent = useCallback(ev => {
+    setSelectedEvent(prev => (prev?.id === ev.id ? null : ev))
+  }, [])
+
   return (
     <div className="space-y-4 p-4">
-      <h1
-        className="text-lg font-medium text-th-text mb-4"
-        style={{ fontFamily: 'var(--font-ui)' }}
-      >
-        地緣政治分析
-      </h1>
-      <DataCard title="全球風險地圖" empty="地緣政治模組開發中" />
-      <DataCard title="新聞情緒" empty="即將上線" />
+      {/* Page title */}
+      <div className="flex items-center justify-between">
+        <h1
+          className="text-lg font-medium"
+          style={{ fontFamily: 'var(--font-ui)', color: 'rgb(var(--text))' }}
+        >
+          地緣政治分析
+        </h1>
+        {isLoading && (
+          <div className="flex items-center gap-2">
+            <div
+              className="w-4 h-4 border-2 border-th-border border-t-th-accent rounded-full animate-spin"
+              style={{ borderTopColor: 'rgb(var(--accent))' }}
+            />
+            <span
+              className="text-xs"
+              style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+            >
+              更新中…
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <AlertBadge
+          level="red"
+          message={`資料載入失敗：${error.message || '請稍後重試'}`}
+        />
+      )}
+
+      {/* Mobile: category filter tabs */}
+      <div className="md:hidden">
+        <CategoryFilterTabs active={categoryFilter} onChange={setCategoryFilter} />
+      </div>
+
+      {/* Desktop: 60/40 split layout */}
+      <div className="hidden md:grid gap-4" style={{ gridTemplateColumns: '60% 1fr' }}>
+        {/* Left: World Map */}
+        <div>
+          {isLoading ? (
+            <DataCard title="全球風險地圖" loading />
+          ) : (
+            <WorldMapPanel
+              events={events}
+              selectedEvent={selectedEvent}
+              onSelectEvent={handleSelectEvent}
+            />
+          )}
+        </div>
+
+        {/* Right: News Feed */}
+        <div>
+          {isLoading ? (
+            <DataCard title="地緣政治事件" loading />
+          ) : (
+            <NewsFeedPanel
+              events={events}
+              selectedEvent={selectedEvent}
+              onSelectEvent={handleSelectEvent}
+              categoryFilter={null}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Mobile: full-width news feed only */}
+      <div className="md:hidden">
+        {isLoading ? (
+          <DataCard title="地緣政治事件" loading />
+        ) : (
+          <NewsFeedPanel
+            events={events}
+            selectedEvent={selectedEvent}
+            onSelectEvent={handleSelectEvent}
+            categoryFilter={categoryFilter}
+          />
+        )}
+      </div>
+
+      {/* Bottom: Market Impact Summary */}
+      {!isLoading && events.length > 0 && (
+        <MarketImpactStrip events={events} />
+      )}
+
+      {/* Selected event detail (sidebar card) */}
+      {selectedEvent && (
+        <DataCard
+          title="事件詳情"
+          accentColor={CATEGORY_CONFIG[selectedEvent.category]?.color}
+        >
+          <div className="space-y-3">
+            {/* Title + badges */}
+            <div className="flex items-start justify-between gap-2">
+              <h2
+                className="text-sm font-semibold leading-snug"
+                style={{ fontFamily: 'var(--font-ui)', color: 'rgb(var(--text))' }}
+              >
+                {selectedEvent.title}
+              </h2>
+              <button
+                className="text-xs flex-shrink-0 px-2 py-0.5 rounded-sm"
+                style={{
+                  color: 'rgb(var(--muted))',
+                  border: '1px solid rgb(var(--border))',
+                  fontFamily: 'var(--font-mono)',
+                  background: 'transparent',
+                  cursor: 'pointer',
+                }}
+                onClick={() => setSelectedEvent(null)}
+              >
+                ✕ 關閉
+              </button>
+            </div>
+
+            <div className="flex items-center gap-3 flex-wrap">
+              <CategoryBadge category={selectedEvent.category} />
+              <ImpactBadge score={selectedEvent.impact_score} />
+              <SentimentIndicator
+                sentiment={
+                  selectedEvent.impact_score >= 7
+                    ? 'bearish'
+                    : selectedEvent.impact_score >= 4
+                    ? 'neutral'
+                    : 'bullish'
+                }
+              />
+              <span
+                className="text-xs"
+                style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-mono)' }}
+              >
+                {timeAgo(selectedEvent.event_date)}
+              </span>
+            </div>
+
+            {/* Full summary */}
+            {selectedEvent.summary && (
+              <p
+                className="text-sm leading-relaxed"
+                style={{ color: 'rgb(var(--text))', fontFamily: 'var(--font-ui)' }}
+              >
+                {selectedEvent.summary}
+              </p>
+            )}
+
+            {/* Market impact breakdown */}
+            {selectedEvent.market_impact &&
+              typeof selectedEvent.market_impact === 'object' &&
+              Object.keys(selectedEvent.market_impact).length > 0 && (
+                <div>
+                  <div
+                    className="text-xs mb-2 uppercase tracking-widest"
+                    style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-mono)' }}
+                  >
+                    市場影響
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(selectedEvent.market_impact).map(([sector, val]) => {
+                      const v = parseFloat(val)
+                      const isPos = v >= 0
+                      const c = isPos ? 'rgb(var(--up))' : 'rgb(var(--danger))'
+                      return (
+                        <span
+                          key={sector}
+                          className="text-xs px-2 py-1 rounded-sm"
+                          style={{
+                            backgroundColor: isPos
+                              ? 'rgba(var(--up), 0.1)'
+                              : 'rgba(var(--danger), 0.1)',
+                            color: c,
+                            fontFamily: 'var(--font-mono)',
+                          }}
+                        >
+                          {sector} {isPos ? '▲' : '▼'}
+                          {Math.abs(v).toFixed(1)}%
+                        </span>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
+            {/* Tags */}
+            {Array.isArray(selectedEvent.tags) && selectedEvent.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {selectedEvent.tags.map(tag => (
+                  <span
+                    key={tag}
+                    className="text-xs px-2 py-0.5 rounded-sm"
+                    style={{
+                      backgroundColor: 'rgba(var(--grid), 0.15)',
+                      color: 'rgb(var(--muted))',
+                      fontFamily: 'var(--font-ui)',
+                    }}
+                  >
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Source links */}
+            {(() => {
+              const links = Array.isArray(selectedEvent.source_links)
+                ? selectedEvent.source_links
+                : typeof selectedEvent.source_links === 'string'
+                ? [selectedEvent.source_links]
+                : []
+              if (links.length === 0) return null
+              return (
+                <div className="flex flex-wrap gap-2">
+                  {links.map((link, i) => (
+                    <a
+                      key={i}
+                      href={link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs underline"
+                      style={{ color: 'rgb(var(--accent))', fontFamily: 'var(--font-ui)' }}
+                    >
+                      來源 {i + 1} →
+                    </a>
+                  ))}
+                </div>
+              )
+            })()}
+          </div>
+        </DataCard>
+      )}
     </div>
   )
 }

--- a/frontend/web/src/pages/research/StockResearch.jsx
+++ b/frontend/web/src/pages/research/StockResearch.jsx
@@ -1,20 +1,753 @@
-import React from 'react'
-import { DataCard } from '../../components/ui/DataCard'
+import React, { useState, useCallback } from 'react'
+import { useSearchParams, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts'
 
-/**
- * StockResearch — placeholder for /research/stock
- */
-export default function StockResearch() {
+import { PriceChart } from '../../components/charts/PriceChart'
+import { DataCard } from '../../components/ui/DataCard'
+import { MetricBadge } from '../../components/ui/MetricBadge'
+import { SentimentIndicator } from '../../components/ui/SentimentIndicator'
+
+// ── BattleTheme colour references ─────────────────────────────────────────────
+const C_UP     = 'rgb(var(--up,    34 197 94))'
+const C_DOWN   = 'rgb(var(--down,  239 68 68))'
+const C_ACCENT = 'rgb(var(--accent, 56 189 248))'
+const C_WARN   = 'rgb(var(--warn,  251 146 60))'
+const C_MUTED  = 'rgb(var(--muted, 100 116 139))'
+const C_TEXT   = 'rgb(var(--text,  226 232 240))'
+const C_GOLD   = 'rgb(var(--gold,  161 138 90))'
+
+// ── Rating badge colours ──────────────────────────────────────────────────────
+const RATING_COLOR = { A: C_UP, B: C_ACCENT, C: C_WARN, D: C_DOWN }
+
+// ── API fetchers ──────────────────────────────────────────────────────────────
+
+async function apiFetch(url) {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const json = await res.json()
+  return json?.data ?? json
+}
+
+const fetchWatchlist        = ()       => apiFetch('/api/research/watchlist')
+const fetchStockReport      = (sym)    => apiFetch(`/api/research/stocks/${sym}`)
+const fetchDebate           = (sym)    => apiFetch(`/api/research/debate/${sym}`)
+const fetchPortfolioSummary = ()       => apiFetch('/api/portfolio/summary')
+const fetchPositionDetail   = (sym)    => apiFetch(`/api/portfolio/position-detail/${encodeURIComponent(sym)}`)
+const fetchStockHistory     = (sym)    => apiFetch(`/api/research/stocks/${sym}/history`)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmt(n, decimals = 2) {
+  if (n === null || n === undefined) return '—'
+  return Number(n).toFixed(decimals)
+}
+
+function fmtPct(n) {
+  if (n === null || n === undefined) return '—'
+  return `${Number(n * 100).toFixed(2)}%`
+}
+
+function fmtN(n) {
+  if (n === null || n === undefined) return '—'
+  return new Intl.NumberFormat('zh-TW').format(n)
+}
+
+// AI Score = confidence * 10, capped 0-10
+function aiScore(confidence) {
+  if (confidence === null || confidence === undefined) return '—'
+  return (Math.min(10, Math.max(0, Number(confidence) * 10))).toFixed(1)
+}
+
+// Recommendation sentiment mapping
+function recToSentiment(rec) {
+  if (!rec) return 'neutral'
+  const r = rec.toLowerCase()
+  if (r.includes('buy') || r.includes('long') || r.includes('看多') || r.includes('多')) return 'bullish'
+  if (r.includes('sell') || r.includes('short') || r.includes('看空') || r.includes('空')) return 'bearish'
+  return 'neutral'
+}
+
+// Build radar data from llm_synthesis_json
+function buildRadarData(synthesis) {
+  if (!synthesis) {
+    return [
+      { subject: '技術面', fullMark: 10, value: 0 },
+      { subject: '法人面', fullMark: 10, value: 0 },
+      { subject: '基本面', fullMark: 10, value: 0 },
+      { subject: '事件面', fullMark: 10, value: 0 },
+    ]
+  }
+  return [
+    { subject: '技術面', fullMark: 10, value: Number(synthesis.technical_score  ?? synthesis.technical  ?? 0) },
+    { subject: '法人面', fullMark: 10, value: Number(synthesis.institutional_score ?? synthesis.institutional ?? 0) },
+    { subject: '基本面', fullMark: 10, value: Number(synthesis.fundamental_score ?? synthesis.fundamental ?? 0) },
+    { subject: '事件面', fullMark: 10, value: Number(synthesis.event_score       ?? synthesis.event       ?? 0) },
+  ]
+}
+
+// Extract OHLCV array from position-detail response
+function extractOhlcv(detail) {
+  if (!detail) return []
+  // Various shapes the backend might return
+  const raw = detail.ohlcv ?? detail.kline ?? detail.candles ?? detail.price_history ?? []
+  if (!Array.isArray(raw)) return []
+  return raw.map((d) => ({
+    time:   d.time  ?? d.date ?? d.trade_date,
+    open:   Number(d.open),
+    high:   Number(d.high),
+    low:    Number(d.low),
+    close:  Number(d.close),
+    volume: Number(d.volume ?? 0),
+  })).filter((d) => d.time)
+}
+
+// Find the holding for this symbol in portfolio summary
+function findHolding(summary, symbol) {
+  if (!summary) return null
+  const positions = summary.positions ?? summary.holdings ?? []
+  return positions.find(
+    (p) => (p.symbol ?? p.ticker ?? '').toUpperCase() === symbol.toUpperCase()
+  ) ?? null
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function RatingBadge({ rating }) {
+  const color = RATING_COLOR[rating?.toUpperCase()] ?? C_MUTED
   return (
-    <div className="space-y-4">
-      <h1
-        className="text-lg font-medium text-th-text mb-4"
-        style={{ fontFamily: 'var(--font-ui)' }}
-      >
-        個股分析
-      </h1>
-      <DataCard title="K 線圖" empty="請輸入股票代碼開始分析" />
-      <DataCard title="財務指標" empty="即將上線" />
+    <span
+      className="inline-flex items-center justify-center w-7 h-7 rounded-sm text-sm font-bold border"
+      style={{
+        fontFamily: 'var(--font-mono)',
+        color,
+        borderColor: color,
+        backgroundColor: `${color}1a`,
+        textShadow: `0 0 8px ${color}`,
+      }}
+    >
+      {rating?.toUpperCase() ?? '?'}
+    </span>
+  )
+}
+
+function AiScoreBadge({ confidence }) {
+  const score = confidence !== null && confidence !== undefined
+    ? (Math.min(10, Math.max(0, Number(confidence) * 10))).toFixed(1)
+    : null
+  const color = score === null ? C_MUTED
+    : Number(score) >= 7 ? C_UP
+    : Number(score) >= 5 ? C_WARN
+    : C_DOWN
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-sm text-xs font-bold border"
+      style={{
+        fontFamily: 'var(--font-data)',
+        color,
+        borderColor: color,
+        backgroundColor: `${color}1a`,
+      }}
+    >
+      <span style={{ fontSize: '9px', opacity: 0.7, fontFamily: 'var(--font-mono)' }}>AI</span>
+      {score ?? '—'}
+    </span>
+  )
+}
+
+function ConfidenceBar({ value, color }) {
+  const pct = Math.min(100, Math.max(0, Number(value ?? 0) * 100))
+  return (
+    <div className="w-full h-1.5 rounded-full overflow-hidden" style={{ backgroundColor: `${color}33` }}>
+      <div
+        className="h-full rounded-full transition-all duration-500"
+        style={{ width: `${pct}%`, backgroundColor: color }}
+      />
+    </div>
+  )
+}
+
+// ── Portfolio cross-reference block ──────────────────────────────────────────
+
+function PortfolioCrossRef({ symbol, summary }) {
+  const holding = findHolding(summary, symbol)
+  if (!holding) return null
+
+  const qty       = holding.quantity    ?? holding.shares ?? 0
+  const avgCost   = holding.avg_cost    ?? holding.cost_basis ?? holding.average_cost ?? 0
+  const mktValue  = holding.market_value ?? (qty * (holding.last_price ?? 0))
+  const unrealPnl = holding.unrealized_pnl ?? holding.unrealized_gain ?? (mktValue - qty * avgCost)
+  const pnlPct    = holding.unrealized_pnl_pct ?? (avgCost > 0 ? (unrealPnl / (qty * avgCost)) : 0)
+  const weight    = holding.weight ?? holding.portfolio_weight ?? null
+
+  const pnlColor = unrealPnl >= 0 ? C_UP : C_DOWN
+
+  return (
+    <DataCard
+      title="投資組合持倉"
+      accentColor={C_GOLD}
+      className="mb-4"
+    >
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex flex-col">
+          <span className="text-xs text-th-muted" style={{ fontFamily: 'var(--font-ui)', fontSize: '10px' }}>
+            持倉
+          </span>
+          <span className="text-sm" style={{ fontFamily: 'var(--font-data)', color: C_TEXT }}>
+            {fmtN(qty)} 股 @ {fmt(avgCost)}
+          </span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-xs text-th-muted" style={{ fontFamily: 'var(--font-ui)', fontSize: '10px' }}>
+            未實現損益
+          </span>
+          <span className="text-sm font-bold tabular-nums" style={{ fontFamily: 'var(--font-data)', color: pnlColor }}>
+            {unrealPnl >= 0 ? '+' : ''}{fmt(unrealPnl)}&nbsp;
+            <span className="text-xs opacity-80">({unrealPnl >= 0 ? '+' : ''}{fmtPct(pnlPct)})</span>
+          </span>
+        </div>
+        {weight !== null && (
+          <div className="flex flex-col">
+            <span className="text-xs text-th-muted" style={{ fontFamily: 'var(--font-ui)', fontSize: '10px' }}>
+              投組佔比
+            </span>
+            <span className="text-sm tabular-nums" style={{ fontFamily: 'var(--font-data)', color: C_ACCENT }}>
+              {fmtPct(weight)}
+            </span>
+          </div>
+        )}
+      </div>
+    </DataCard>
+  )
+}
+
+// ── Radar chart ───────────────────────────────────────────────────────────────
+
+function AiRadar({ synthesis }) {
+  const data = buildRadarData(synthesis)
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <RadarChart cx="50%" cy="50%" outerRadius="72%" data={data}>
+        <PolarGrid stroke={`${C_MUTED}44`} />
+        <PolarAngleAxis
+          dataKey="subject"
+          tick={{ fill: C_MUTED, fontSize: 11, fontFamily: 'var(--font-ui)' }}
+        />
+        <PolarRadiusAxis
+          angle={30}
+          domain={[0, 10]}
+          tick={{ fill: C_MUTED, fontSize: 9 }}
+          axisLine={false}
+          tickCount={3}
+        />
+        <Radar
+          name="AI Score"
+          dataKey="value"
+          stroke={C_ACCENT}
+          fill={C_ACCENT}
+          fillOpacity={0.18}
+          dot={{ fill: C_ACCENT, r: 3 }}
+        />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: 'rgb(var(--card, 13 19 30))',
+            border: `1px solid ${C_MUTED}44`,
+            borderRadius: '2px',
+            fontFamily: 'var(--font-data)',
+            fontSize: '11px',
+            color: C_TEXT,
+          }}
+        />
+      </RadarChart>
+    </ResponsiveContainer>
+  )
+}
+
+// ── Fundamentals panel ────────────────────────────────────────────────────────
+
+function FundamentalsPanel({ report }) {
+  const pe       = report?.pe_ratio
+  const pb       = report?.pb_ratio
+  const eps      = report?.eps
+  const divYield = report?.dividend_yield
+  const revYoY   = report?.monthly_revenue_yoy
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <MetricBadge label="P/E"           value={pe       !== undefined ? fmt(pe, 1)     : null} format="raw" />
+      <MetricBadge label="P/B"           value={pb       !== undefined ? fmt(pb, 2)     : null} format="raw" />
+      <MetricBadge label="EPS (TTM)"     value={eps      !== undefined ? fmt(eps, 2)    : null} format="raw" />
+      <MetricBadge label="殖利率"        value={divYield !== undefined ? fmtPct(divYield) : null} format="raw" />
+      <MetricBadge label="月營收 YoY"   value={revYoY   !== undefined ? fmtPct(revYoY)  : null}
+        trend={revYoY > 0 ? 'up' : revYoY < 0 ? 'down' : 'flat'} format="raw" />
+      <MetricBadge label="最新收盤"      value={report?.latest_close !== undefined ? fmt(report.latest_close) : null} format="raw" />
+    </div>
+  )
+}
+
+// ── Bull vs Bear Debate ───────────────────────────────────────────────────────
+
+function DebateSide({ side, data, isLeft }) {
+  if (!data) return null
+  const color = isLeft ? C_UP : C_DOWN
+  const thesis     = data.thesis     ?? data.summary    ?? data.argument   ?? ''
+  const catalysts  = data.catalysts  ?? data.risks      ?? data.points     ?? []
+  const confidence = data.confidence ?? null
+
+  return (
+    <div
+      className="flex-1 min-w-0 rounded-sm border p-3 space-y-2"
+      style={{ borderColor: color, backgroundColor: `${color}0d` }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className="text-xs font-bold tracking-widest uppercase"
+          style={{ fontFamily: 'var(--font-mono)', color }}
+        >
+          {isLeft ? '多方' : '空方'}
+        </span>
+        {confidence !== null && (
+          <span className="text-xs tabular-nums" style={{ fontFamily: 'var(--font-data)', color }}>
+            {fmtPct(confidence)}
+          </span>
+        )}
+      </div>
+
+      {thesis && (
+        <p className="text-xs leading-relaxed" style={{ fontFamily: 'var(--font-ui)', color: C_TEXT }}>
+          {thesis}
+        </p>
+      )}
+
+      {Array.isArray(catalysts) && catalysts.length > 0 && (
+        <ul className="space-y-1">
+          {catalysts.slice(0, 3).map((c, i) => (
+            <li key={i} className="flex items-start gap-1.5 text-xs" style={{ fontFamily: 'var(--font-ui)', color: C_MUTED }}>
+              <span style={{ color, flexShrink: 0, marginTop: '1px' }}>{isLeft ? '▲' : '▼'}</span>
+              <span>{typeof c === 'string' ? c : c.text ?? c.point ?? JSON.stringify(c)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {confidence !== null && (
+        <ConfidenceBar value={confidence} color={color} />
+      )}
+    </div>
+  )
+}
+
+function ArbiterPanel({ arbiter, recommendation, confidence }) {
+  if (!arbiter && !recommendation) return null
+  const verdict = arbiter?.verdict ?? arbiter?.summary ?? arbiter?.decision ?? recommendation ?? ''
+  const rationale = arbiter?.rationale ?? arbiter?.reasoning ?? ''
+  const sentiment = recToSentiment(verdict || recommendation)
+  const conf = arbiter?.confidence ?? confidence ?? null
+  const color = sentiment === 'bullish' ? C_UP : sentiment === 'bearish' ? C_DOWN : C_WARN
+
+  return (
+    <div
+      className="rounded-sm border p-3 space-y-2 mt-3"
+      style={{ borderColor: `${C_ACCENT}55`, backgroundColor: `${C_ACCENT}08` }}
+    >
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <span
+          className="text-xs font-bold tracking-widest uppercase"
+          style={{ fontFamily: 'var(--font-mono)', color: C_ACCENT }}
+        >
+          仲裁裁決
+        </span>
+        <SentimentIndicator sentiment={sentiment} />
+      </div>
+
+      {verdict && (
+        <p className="text-xs font-medium" style={{ fontFamily: 'var(--font-ui)', color }}>
+          {verdict}
+        </p>
+      )}
+
+      {rationale && (
+        <p className="text-xs leading-relaxed" style={{ fontFamily: 'var(--font-ui)', color: C_MUTED }}>
+          {rationale}
+        </p>
+      )}
+
+      {conf !== null && (
+        <div className="space-y-1">
+          <div className="flex justify-between text-xs" style={{ fontFamily: 'var(--font-data)', color: C_MUTED }}>
+            <span>信心度</span>
+            <span>{fmtPct(conf)}</span>
+          </div>
+          <ConfidenceBar value={conf} color={color} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── AI Synthesis block ────────────────────────────────────────────────────────
+
+function AiSynthesisPanel({ report, historyFirst }) {
+  const synthesis  = report?.llm_synthesis_json ?? {}
+  const entry      = report?.entry_price
+  const stopLoss   = report?.stop_loss
+  const target     = report?.target_price
+  const rationale  = synthesis.rationale ?? synthesis.summary ?? report?.report_markdown ?? ''
+  const prevConf   = historyFirst?.confidence
+  const currConf   = report?.confidence
+
+  const hasRisk    = stopLoss !== null && stopLoss !== undefined
+  const hasTarget  = target   !== null && target   !== undefined
+
+  return (
+    <div className="space-y-3">
+      {/* Price targets row */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="flex flex-col gap-1 rounded-sm border p-2" style={{ borderColor: `${C_ACCENT}44` }}>
+          <span className="text-xs" style={{ fontFamily: 'var(--font-mono)', color: C_MUTED, fontSize: '10px' }}>
+            進場價
+          </span>
+          <span className="text-base tabular-nums font-bold" style={{ fontFamily: 'var(--font-data)', color: C_ACCENT }}>
+            {entry !== null && entry !== undefined ? fmt(entry) : '—'}
+          </span>
+        </div>
+        <div className="flex flex-col gap-1 rounded-sm border p-2" style={{ borderColor: `${C_DOWN}44` }}>
+          <span className="text-xs" style={{ fontFamily: 'var(--font-mono)', color: C_MUTED, fontSize: '10px' }}>
+            停損價
+          </span>
+          <span className="text-base tabular-nums font-bold" style={{ fontFamily: 'var(--font-data)', color: C_DOWN }}>
+            {hasRisk ? fmt(stopLoss) : '—'}
+          </span>
+        </div>
+        <div className="flex flex-col gap-1 rounded-sm border p-2" style={{ borderColor: `${C_UP}44` }}>
+          <span className="text-xs" style={{ fontFamily: 'var(--font-mono)', color: C_MUTED, fontSize: '10px' }}>
+            目標價
+          </span>
+          <span className="text-base tabular-nums font-bold" style={{ fontFamily: 'var(--font-data)', color: C_UP }}>
+            {hasTarget ? fmt(target) : '—'}
+          </span>
+        </div>
+      </div>
+
+      {/* Score delta */}
+      {prevConf !== undefined && currConf !== undefined && (
+        <div className="flex items-center gap-3 text-xs" style={{ fontFamily: 'var(--font-data)' }}>
+          <span style={{ color: C_MUTED }}>評分變化</span>
+          <span style={{ color: C_MUTED }}>{aiScore(prevConf)}</span>
+          <span style={{ color: C_MUTED }}>→</span>
+          <span style={{ color: Number(currConf) >= Number(prevConf) ? C_UP : C_DOWN }}>
+            {aiScore(currConf)}
+          </span>
+          <span style={{ color: Number(currConf) >= Number(prevConf) ? C_UP : C_DOWN }}>
+            {Number(currConf) >= Number(prevConf) ? '▲' : '▼'}
+          </span>
+        </div>
+      )}
+
+      {/* Rationale */}
+      {rationale && (
+        <p className="text-xs leading-relaxed" style={{ fontFamily: 'var(--font-ui)', color: C_MUTED }}>
+          {String(rationale).slice(0, 500)}
+          {String(rationale).length > 500 && '…'}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ── Symbol Selector ───────────────────────────────────────────────────────────
+
+function SymbolSelector({ currentSymbol, watchlist, onSelect }) {
+  const symbols = Array.isArray(watchlist)
+    ? watchlist
+    : (watchlist?.stocks ?? watchlist?.symbols ?? [])
+
+  const options = symbols.map((s) =>
+    typeof s === 'string' ? { symbol: s, name: '' } : s
+  )
+
+  return (
+    <select
+      value={currentSymbol}
+      onChange={(e) => onSelect(e.target.value)}
+      className="h-8 px-2 rounded-sm border text-xs focus:outline-none focus:ring-1"
+      style={{
+        fontFamily: 'var(--font-data)',
+        backgroundColor: 'rgb(var(--card, 13 19 30))',
+        borderColor: 'rgb(var(--border, 51 65 85))',
+        color: C_TEXT,
+        minWidth: '120px',
+      }}
+    >
+      {currentSymbol && !options.find((o) => o.symbol === currentSymbol) && (
+        <option value={currentSymbol}>{currentSymbol}</option>
+      )}
+      {options.map((o) => (
+        <option key={o.symbol} value={o.symbol}>
+          {o.symbol}{o.name ? ` - ${o.name}` : ''}
+        </option>
+      ))}
+      {options.length === 0 && (
+        <option value="" disabled>（無自選股）</option>
+      )}
+    </select>
+  )
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function StockResearch() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const symbolParam = (searchParams.get('symbol') ?? '').toUpperCase()
+  const [symbol, setSymbol] = useState(symbolParam || '')
+
+  const navigate = useNavigate()
+
+  const handleSelect = useCallback((sym) => {
+    if (!sym) return
+    const upper = sym.toUpperCase()
+    setSymbol(upper)
+    setSearchParams({ symbol: upper }, { replace: true })
+  }, [setSearchParams])
+
+  // ── Queries ─────────────────────────────────────────────────────────────────
+  const { data: watchlist } = useQuery({
+    queryKey: ['research', 'watchlist'],
+    queryFn: fetchWatchlist,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  })
+
+  const { data: report, isLoading: reportLoading, error: reportError } = useQuery({
+    queryKey: ['research', 'stock', symbol],
+    queryFn: () => fetchStockReport(symbol),
+    enabled: !!symbol,
+    staleTime: 2 * 60 * 1000,
+    retry: 1,
+  })
+
+  const { data: debate, isLoading: debateLoading, error: debateError } = useQuery({
+    queryKey: ['research', 'debate', symbol],
+    queryFn: () => fetchDebate(symbol),
+    enabled: !!symbol,
+    staleTime: 2 * 60 * 1000,
+    retry: 1,
+  })
+
+  const { data: portfolioSummary } = useQuery({
+    queryKey: ['portfolio', 'summary'],
+    queryFn: fetchPortfolioSummary,
+    staleTime: 60 * 1000,
+    retry: 1,
+  })
+
+  const { data: positionDetail, isLoading: klineLoading } = useQuery({
+    queryKey: ['portfolio', 'position-detail', symbol],
+    queryFn: () => fetchPositionDetail(symbol),
+    enabled: !!symbol,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  })
+
+  const { data: history } = useQuery({
+    queryKey: ['research', 'stock-history', symbol],
+    queryFn: () => fetchStockHistory(symbol),
+    enabled: !!symbol,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  })
+
+  // ── Derived data ─────────────────────────────────────────────────────────────
+  const ohlcv = extractOhlcv(positionDetail)
+  const synthesis = report?.llm_synthesis_json ?? {}
+  const radarData = buildRadarData(synthesis)
+
+  // Previous report for score comparison (history[1] if history is an array)
+  const historyList = Array.isArray(history) ? history : (history?.reports ?? [])
+  const historyFirst = historyList?.[1] ?? null // index 0 = current, 1 = previous
+
+  const debateData = debate ?? {}
+  const bullThesis   = debateData.bull_thesis_json
+  const bearThesis   = debateData.bear_thesis_json
+  const arbiter      = debateData.arbiter_decision_json
+  const recommendation = debateData.recommendation
+
+  const stockName = report?.name ?? report?.company_name ?? report?.stock_name ?? ''
+  const confidence = report?.confidence
+  const rating     = report?.rating
+
+  // ── Render ───────────────────────────────────────────────────────────────────
+  return (
+    <div className="space-y-4 px-0 sm:px-1">
+
+      {/* ── Top bar ── */}
+      <div className="flex flex-wrap items-center gap-3 pb-2 border-b border-th-border">
+        {/* Symbol selector */}
+        <SymbolSelector
+          currentSymbol={symbol}
+          watchlist={watchlist}
+          onSelect={handleSelect}
+        />
+
+        {/* Current stock info */}
+        {symbol && (
+          <div className="flex items-center gap-2 flex-wrap">
+            <span
+              className="text-xl font-bold tracking-wide"
+              style={{ fontFamily: 'var(--font-data)', color: C_ACCENT }}
+            >
+              {symbol}
+            </span>
+            {stockName && (
+              <span
+                className="text-sm"
+                style={{ fontFamily: 'var(--font-ui)', color: C_MUTED }}
+              >
+                {stockName}
+              </span>
+            )}
+            {confidence !== undefined && confidence !== null && (
+              <AiScoreBadge confidence={confidence} />
+            )}
+            {rating && <RatingBadge rating={rating} />}
+          </div>
+        )}
+
+        {/* Fallback prompt */}
+        {!symbol && (
+          <span
+            className="text-sm"
+            style={{ fontFamily: 'var(--font-ui)', color: C_MUTED }}
+          >
+            請選擇或輸入股票代碼開始分析
+          </span>
+        )}
+      </div>
+
+      {/* ── Portfolio cross-reference ── */}
+      {symbol && portfolioSummary && (
+        <PortfolioCrossRef symbol={symbol} summary={portfolioSummary} />
+      )}
+
+      {/* ── K-line hero (full width) ── */}
+      {symbol && (
+        <DataCard
+          title={`K 線圖  ${symbol}`}
+          loading={klineLoading}
+          empty={!klineLoading && ohlcv.length === 0 ? '尚無 K 線資料' : undefined}
+          accentColor={C_ACCENT}
+        >
+          {ohlcv.length > 0 && (
+            <div className="-mx-3 -mb-3">
+              <PriceChart data={ohlcv} symbol={symbol} height={360} />
+            </div>
+          )}
+        </DataCard>
+      )}
+
+      {/* ── Radar + Fundamentals (side by side) ── */}
+      {symbol && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+          {/* AI Scoring Radar */}
+          <DataCard
+            title="AI 評分雷達"
+            loading={reportLoading}
+            error={reportError}
+            accentColor={C_ACCENT}
+          >
+            <div className="space-y-2">
+              <AiRadar synthesis={synthesis} />
+              {/* Dimension breakdown */}
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1 pt-1">
+                {radarData.map((d) => (
+                  <div key={d.subject} className="flex items-center justify-between text-xs">
+                    <span style={{ fontFamily: 'var(--font-ui)', color: C_MUTED }}>{d.subject}</span>
+                    <span style={{ fontFamily: 'var(--font-data)', color: C_ACCENT }}>
+                      {d.value > 0 ? d.value.toFixed(1) : '—'}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <div className="flex items-center gap-2 text-xs pt-1 border-t border-th-border">
+                <span style={{ fontFamily: 'var(--font-ui)', color: C_MUTED }}>綜合評分</span>
+                <span style={{ fontFamily: 'var(--font-data)', color: C_ACCENT, fontSize: '14px', fontWeight: 'bold' }}>
+                  {aiScore(confidence)}
+                </span>
+                {rating && <RatingBadge rating={rating} />}
+              </div>
+            </div>
+          </DataCard>
+
+          {/* Fundamental metrics */}
+          <DataCard
+            title="基本面指標"
+            loading={reportLoading}
+            error={reportError}
+            accentColor={C_GOLD}
+          >
+            <FundamentalsPanel report={report} />
+          </DataCard>
+        </div>
+      )}
+
+      {/* ── Bull vs Bear Debate (full width) ── */}
+      {symbol && (
+        <DataCard
+          title="多空辯論"
+          loading={debateLoading}
+          error={debateError}
+          accentColor={C_WARN}
+          empty={!debateLoading && !debateError && !bullThesis && !bearThesis ? '尚無辯論資料' : undefined}
+        >
+          {(bullThesis || bearThesis) && (
+            <div className="space-y-3">
+              {/* Two sides */}
+              <div className="flex flex-col sm:flex-row gap-3">
+                <DebateSide side="bull" data={bullThesis} isLeft={true} />
+                <DebateSide side="bear" data={bearThesis} isLeft={false} />
+              </div>
+              {/* Arbiter */}
+              <ArbiterPanel
+                arbiter={arbiter}
+                recommendation={recommendation}
+                confidence={debateData.confidence}
+              />
+            </div>
+          )}
+        </DataCard>
+      )}
+
+      {/* ── AI Synthesis ── */}
+      {symbol && (
+        <DataCard
+          title="AI 綜合研判"
+          loading={reportLoading}
+          error={reportError}
+          empty={!reportLoading && !reportError && !report ? '尚無研究報告' : undefined}
+          accentColor={C_ACCENT}
+        >
+          {report && (
+            <AiSynthesisPanel report={report} historyFirst={historyFirst} />
+          )}
+        </DataCard>
+      )}
+
+      {/* Empty state — no symbol selected */}
+      {!symbol && (
+        <DataCard
+          title="個股分析"
+          empty="請從上方選擇股票代碼，或在 URL 加上 ?symbol=2382"
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Full rewrite of `StockResearch.jsx` placeholder at `/research/stock?symbol=XXXX`
- Symbol selector dropdown (fetches from `/api/research/watchlist`), displays large symbol + name + AI Score badge (confidence×10) + Rating badge (A/B/C/D)
- Portfolio cross-reference block if stock is held: quantity, avg cost, unrealized P&L (amount + %), portfolio weight %
- Full-width K-line hero using existing `PriceChart` component (lightweight-charts, MA5/MA20/MA60) — data from `/api/portfolio/position-detail/{symbol}`
- AI Scoring Radar (Recharts `RadarChart`) — 4 dimensions (技術面/法人面/基本面/事件面) from `llm_synthesis_json`, with score breakdown grid
- Fundamentals panel: P/E, P/B, EPS, Dividend Yield, Monthly Revenue YoY, Latest Close using `MetricBadge`
- Bull vs Bear Debate panel — green-bordered bull side, red-bordered bear side, central arbiter verdict with `SentimentIndicator` and confidence bar; data from `/api/research/debate/{symbol}`
- AI Synthesis block — entry/stop-loss/target price tiles, score change delta (prev → current), rationale text
- All API calls via `@tanstack/react-query`; uses `DataCard`, `MetricBadge`, `SentimentIndicator`, BattleTheme CSS variables
- Asymmetric layout: K-line hero full width → Radar + Fundamentals side-by-side → Debate full width → Synthesis full width; single column on mobile

## Test plan

- [ ] Build passes: `npm run build` in `frontend/web` (verified: ✓ built in 2.28s, no errors)
- [ ] Navigate to `/research/stock?symbol=2382` — top bar shows symbol + AI Score + Rating
- [ ] Confirm portfolio block appears if symbol is in holdings, hidden otherwise
- [ ] K-line hero renders candles + MA overlays when OHLCV data is available
- [ ] Radar chart reflects dimension scores from `llm_synthesis_json`
- [ ] Fundamentals grid shows P/E, P/B, EPS etc (or `—` when unavailable)
- [ ] Debate panel shows bull/bear sides and arbiter verdict
- [ ] AI Synthesis shows price targets and score delta row
- [ ] Empty state shown when no symbol selected

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)