### PR TITLE
feat(page): geopolitical dashboard — world map + news feed

### DIFF
--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -15,8 +15,10 @@
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.22.3",
+        "react-simple-maps": "^3.0.0",
         "recharts": "^2.7.2",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "topojson-client": "^3.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.0",
@@ -2489,6 +2491,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -2506,6 +2524,30 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/d3-geo/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-geo/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
@@ -2543,6 +2585,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -2587,6 +2635,77 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
+      },
+      "peerDependencies": {
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-transition/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition/node_modules/d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition/node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-transition/node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-zoom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
+    "node_modules/d3-zoom/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-zoom/node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
       }
     },
     "node_modules/data-urls": {
@@ -5556,6 +5675,23 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-simple-maps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-3.0.0.tgz",
+      "integrity": "sha512-vKNFrvpPG8Vyfdjnz5Ne1N56rZlDfHXv5THNXOVZMqbX1rWZA48zQuYT03mx6PAKanqarJu/PDLgshIZAfHHqw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "^2.0.2",
+        "d3-selection": "^2.0.0",
+        "d3-zoom": "^2.0.0",
+        "topojson-client": "^3.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.7.2",
+        "react": "^16.8.0 || 17.x || 18.x",
+        "react-dom": "^16.8.0 || 17.x || 18.x"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -6385,6 +6521,26 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -19,8 +19,10 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.22.3",
+    "react-simple-maps": "^3.0.0",
     "recharts": "^2.7.2",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.0",

--- a/frontend/web/src/pages/Geopolitical.jsx
+++ b/frontend/web/src/pages/Geopolitical.jsx
@@ -1,20 +1,781 @@
-import React from 'react'
-import { DataCard } from '../components/ui/DataCard'
-
 /**
- * Geopolitical — placeholder for /geopolitical
+ * Geopolitical.jsx — Geopolitical Dashboard
+ *
+ * Desktop layout: 60/40 split — World Map (left) + News Feed (right)
+ * Mobile (<768px): hide map, show news feed + market impact + category filter
+ *
+ * Data sources:
+ *   GET /api/geopolitical/latest  — latest 20 events (React Query, staleTime 15 min)
+ *   GET /api/geopolitical/events  — paginated event list
  */
+
+import React, { useState, useCallback } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  ComposableMap,
+  Geographies,
+  Geography,
+  Marker,
+} from 'react-simple-maps'
+import { DataCard } from '../components/ui/DataCard'
+import { SentimentIndicator } from '../components/ui/SentimentIndicator'
+import { AlertBadge } from '../components/ui/AlertBadge'
+import { getApiBase } from '../lib/auth'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const GEO_URL =
+  'https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json'
+
+const CATEGORY_CONFIG = {
+  conflict:  { color: '#ef4444', label: '衝突',   dot: '#ef4444' },
+  trade_war: { color: '#f97316', label: '貿易戰', dot: '#f97316' },
+  sanctions: { color: '#eab308', label: '制裁',   dot: '#eab308' },
+  policy:    { color: '#3b82f6', label: '政策',   dot: '#3b82f6' },
+  election:  { color: '#a855f7', label: '選舉',   dot: '#a855f7' },
+}
+
+const ALL_CATEGORIES = ['conflict', 'trade_war', 'sanctions', 'policy', 'election']
+
+// ── API helpers ───────────────────────────────────────────────────────────────
+
+async function fetchLatest() {
+  const base = getApiBase()
+  const res = await fetch(`${base}/api/geopolitical/latest`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const json = await res.json()
+  if (!json.ok) throw new Error('API returned ok=false')
+  return json.data ?? []
+}
+
+// ── Utility helpers ───────────────────────────────────────────────────────────
+
+function timeAgo(dateStr) {
+  if (!dateStr) return ''
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return '剛剛'
+  if (mins < 60) return `${mins} 分鐘前`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs} 小時前`
+  const days = Math.floor(hrs / 24)
+  return `${days} 天前`
+}
+
+function truncate(str, len = 100) {
+  if (!str) return ''
+  return str.length > len ? str.slice(0, len) + '…' : str
+}
+
+function impactColor(score) {
+  if (score >= 8) return '#ef4444'
+  if (score >= 5) return '#f97316'
+  return '#eab308'
+}
+
+/** Derive market impact summary cards from top events */
+function buildMarketImpact(events) {
+  const impacts = []
+  for (const ev of events.slice(0, 10)) {
+    const mi = ev.market_impact
+    if (!mi || typeof mi !== 'object') continue
+    Object.entries(mi).forEach(([sector, val]) => {
+      impacts.push({ sector, val, category: ev.category })
+    })
+  }
+  return impacts.slice(0, 6)
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+/** Category badge — colored dot + label */
+function CategoryBadge({ category }) {
+  const cfg = CATEGORY_CONFIG[category] || { dot: '#71717a', label: category }
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className="inline-block w-2 h-2 rounded-full flex-shrink-0"
+        style={{ backgroundColor: cfg.dot }}
+      />
+      <span
+        className="text-xs"
+        style={{ color: cfg.dot, fontFamily: 'var(--font-ui)' }}
+      >
+        {cfg.label}
+      </span>
+    </span>
+  )
+}
+
+/** Impact score badge */
+function ImpactBadge({ score }) {
+  if (score == null) return null
+  const color = impactColor(score)
+  return (
+    <span
+      className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-xs font-mono"
+      style={{
+        backgroundColor: `${color}22`,
+        color,
+        border: `1px solid ${color}55`,
+      }}
+    >
+      {score}
+    </span>
+  )
+}
+
+/** Tooltip overlay for map markers */
+function MapTooltip({ event, x, y }) {
+  if (!event) return null
+  return (
+    <div
+      className="absolute z-50 pointer-events-none"
+      style={{ left: x + 10, top: y - 10 }}
+    >
+      <div
+        className="rounded-sm shadow-lg px-3 py-2 text-xs max-w-[200px]"
+        style={{
+          backgroundColor: 'rgb(var(--card))',
+          border: '1px solid rgb(var(--border))',
+          fontFamily: 'var(--font-ui)',
+          color: 'rgb(var(--text))',
+        }}
+      >
+        <div className="font-medium mb-1 leading-snug">{event.title}</div>
+        <div className="flex items-center gap-2">
+          <CategoryBadge category={event.category} />
+          <ImpactBadge score={event.impact_score} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Single news feed item */
+function NewsFeedItem({ event, isSelected, onClick }) {
+  const [expanded, setExpanded] = useState(false)
+  const cfg = CATEGORY_CONFIG[event.category] || { dot: '#71717a' }
+
+  function handleClick() {
+    onClick(event)
+    setExpanded(prev => !prev)
+  }
+
+  const links = Array.isArray(event.source_links)
+    ? event.source_links
+    : typeof event.source_links === 'string'
+    ? [event.source_links]
+    : []
+
+  return (
+    <div
+      className="cursor-pointer rounded-sm transition-colors"
+      style={{
+        borderLeft: `2px solid ${isSelected ? cfg.dot : 'transparent'}`,
+        backgroundColor: isSelected ? `${cfg.dot}11` : 'transparent',
+        paddingLeft: 8,
+        paddingRight: 8,
+        paddingTop: 8,
+        paddingBottom: 8,
+      }}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={e => e.key === 'Enter' && handleClick()}
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-2 mb-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <CategoryBadge category={event.category} />
+          <ImpactBadge score={event.impact_score} />
+        </div>
+        <span
+          className="text-xs text-th-muted flex-shrink-0"
+          style={{ fontFamily: 'var(--font-mono)', color: 'rgb(var(--muted))' }}
+        >
+          {timeAgo(event.event_date)}
+        </span>
+      </div>
+
+      {/* Title */}
+      <div
+        className="text-sm font-medium leading-snug mb-1"
+        style={{ fontFamily: 'var(--font-ui)', color: 'rgb(var(--text))' }}
+      >
+        {event.title}
+      </div>
+
+      {/* Summary — truncated or full */}
+      <div
+        className="text-xs leading-relaxed"
+        style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+      >
+        {expanded ? event.summary : truncate(event.summary, 100)}
+      </div>
+
+      {/* Source links when expanded */}
+      {expanded && links.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {links.map((link, i) => (
+            <a
+              key={i}
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs underline"
+              style={{ color: 'rgb(var(--accent))' }}
+              onClick={e => e.stopPropagation()}
+            >
+              來源 {i + 1}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Market impact summary card strip */
+function MarketImpactStrip({ events }) {
+  const impacts = buildMarketImpact(events)
+  if (impacts.length === 0) return null
+
+  return (
+    <div
+      className="rounded-sm border p-3"
+      style={{
+        backgroundColor: 'rgb(var(--card))',
+        borderColor: 'rgb(var(--border))',
+      }}
+    >
+      <div
+        className="text-xs font-medium tracking-widest uppercase mb-3"
+        style={{
+          fontFamily: 'var(--font-mono)',
+          color: 'rgb(var(--muted))',
+        }}
+      >
+        市場影響概況
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {impacts.map((item, i) => {
+          const val = parseFloat(item.val)
+          const isPositive = val >= 0
+          const color = isPositive ? 'rgb(var(--up))' : 'rgb(var(--danger))'
+          return (
+            <div
+              key={i}
+              className="px-3 py-2 rounded-sm text-xs flex items-center gap-2"
+              style={{
+                backgroundColor: isPositive
+                  ? 'rgba(var(--up), 0.08)'
+                  : 'rgba(var(--danger), 0.08)',
+                border: `1px solid ${isPositive ? 'rgba(var(--up),0.2)' : 'rgba(var(--danger),0.2)'}`,
+                fontFamily: 'var(--font-ui)',
+                color: 'rgb(var(--text))',
+              }}
+            >
+              <span>最受影響板塊: {item.sector}</span>
+              <span style={{ color, fontFamily: 'var(--font-mono)' }}>
+                {isPositive ? '▲' : '▼'}
+                {Math.abs(val).toFixed(1)}%
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/** Category filter tabs (mobile) */
+function CategoryFilterTabs({ active, onChange }) {
+  return (
+    <div className="flex overflow-x-auto gap-1 pb-1">
+      <button
+        className="px-3 py-1.5 rounded-sm text-xs flex-shrink-0 transition-colors"
+        style={{
+          fontFamily: 'var(--font-ui)',
+          backgroundColor: active === null ? 'rgb(var(--accent))' : 'rgb(var(--card))',
+          color: active === null ? '#000' : 'rgb(var(--muted))',
+          border: '1px solid rgb(var(--border))',
+        }}
+        onClick={() => onChange(null)}
+      >
+        全部
+      </button>
+      {ALL_CATEGORIES.map(cat => {
+        const cfg = CATEGORY_CONFIG[cat]
+        const isActive = active === cat
+        return (
+          <button
+            key={cat}
+            className="px-3 py-1.5 rounded-sm text-xs flex-shrink-0 transition-colors"
+            style={{
+              fontFamily: 'var(--font-ui)',
+              backgroundColor: isActive ? cfg.dot : 'rgb(var(--card))',
+              color: isActive ? '#fff' : 'rgb(var(--muted))',
+              border: `1px solid ${isActive ? cfg.dot : 'rgb(var(--border))'}`,
+            }}
+            onClick={() => onChange(cat)}
+          >
+            {cfg.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── World Map panel ───────────────────────────────────────────────────────────
+
+function WorldMapPanel({ events, selectedEvent, onSelectEvent }) {
+  const [tooltip, setTooltip] = useState({ event: null, x: 0, y: 0 })
+
+  // Only events with coordinates
+  const markers = events.filter(
+    ev => ev.lat != null && ev.lng != null
+  )
+
+  function markerRadius(score) {
+    const s = Number(score) || 3
+    return Math.max(4, Math.min(16, s * 1.4))
+  }
+
+  return (
+    <div
+      className="rounded-sm border overflow-hidden relative"
+      style={{
+        backgroundColor: 'rgb(var(--card))',
+        borderColor: 'rgb(var(--border))',
+        minHeight: 340,
+      }}
+    >
+      {/* Panel header */}
+      <div
+        className="px-3 py-2 border-b flex items-center justify-between"
+        style={{ borderColor: 'rgb(var(--border))' }}
+      >
+        <span
+          className="text-xs font-medium tracking-widest uppercase"
+          style={{ fontFamily: 'var(--font-mono)', color: 'rgb(var(--muted))' }}
+        >
+          全球風險地圖
+        </span>
+        <div className="flex items-center gap-3">
+          {ALL_CATEGORIES.map(cat => (
+            <span key={cat} className="flex items-center gap-1">
+              <span
+                className="inline-block w-2 h-2 rounded-full"
+                style={{ backgroundColor: CATEGORY_CONFIG[cat].dot }}
+              />
+              <span
+                className="text-xs"
+                style={{
+                  color: 'rgb(var(--muted))',
+                  fontFamily: 'var(--font-ui)',
+                  fontSize: 10,
+                }}
+              >
+                {CATEGORY_CONFIG[cat].label}
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Map */}
+      <div className="relative">
+        <ComposableMap
+          projectionConfig={{ scale: 130, center: [10, 10] }}
+          style={{ width: '100%', height: 'auto' }}
+        >
+          <Geographies geography={GEO_URL}>
+            {({ geographies }) =>
+              geographies.map(geo => (
+                <Geography
+                  key={geo.rsmKey}
+                  geography={geo}
+                  style={{
+                    default: {
+                      fill: 'rgba(var(--grid), 0.15)',
+                      stroke: 'rgb(var(--border))',
+                      strokeWidth: 0.4,
+                      outline: 'none',
+                    },
+                    hover: {
+                      fill: 'rgba(var(--grid), 0.25)',
+                      stroke: 'rgb(var(--border))',
+                      strokeWidth: 0.4,
+                      outline: 'none',
+                    },
+                    pressed: { outline: 'none' },
+                  }}
+                />
+              ))
+            }
+          </Geographies>
+
+          {markers.map(ev => {
+            const cfg = CATEGORY_CONFIG[ev.category] || { color: '#71717a' }
+            const r = markerRadius(ev.impact_score)
+            const isSelected = selectedEvent?.id === ev.id
+            return (
+              <Marker
+                key={ev.id}
+                coordinates={[ev.lng, ev.lat]}
+                onClick={() => onSelectEvent(ev)}
+                onMouseEnter={e => {
+                  const rect = e.currentTarget.closest('svg')?.getBoundingClientRect()
+                  const svgX = e.clientX - (rect?.left ?? 0)
+                  const svgY = e.clientY - (rect?.top ?? 0)
+                  setTooltip({ event: ev, x: svgX, y: svgY })
+                }}
+                onMouseLeave={() => setTooltip({ event: null, x: 0, y: 0 })}
+                style={{ cursor: 'pointer' }}
+              >
+                <circle
+                  r={r}
+                  fill={cfg.color}
+                  fillOpacity={isSelected ? 0.95 : 0.65}
+                  stroke={isSelected ? '#fff' : cfg.color}
+                  strokeWidth={isSelected ? 2 : 0.8}
+                  style={{
+                    filter: isSelected
+                      ? `drop-shadow(0 0 6px ${cfg.color})`
+                      : undefined,
+                    transition: 'all 0.15s ease',
+                  }}
+                />
+              </Marker>
+            )
+          })}
+        </ComposableMap>
+
+        {/* Tooltip */}
+        <MapTooltip {...tooltip} />
+      </div>
+
+      {/* No-coordinates notice */}
+      {markers.length === 0 && events.length > 0 && (
+        <div
+          className="px-3 pb-3 text-xs"
+          style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+        >
+          目前事件無座標資料，地圖標記暫無顯示
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── News Feed panel ───────────────────────────────────────────────────────────
+
+function NewsFeedPanel({ events, selectedEvent, onSelectEvent, categoryFilter }) {
+  const filtered =
+    categoryFilter === null
+      ? events
+      : events.filter(ev => ev.category === categoryFilter)
+
+  return (
+    <div
+      className="rounded-sm border flex flex-col"
+      style={{
+        backgroundColor: 'rgb(var(--card))',
+        borderColor: 'rgb(var(--border))',
+        maxHeight: 480,
+      }}
+    >
+      <div
+        className="px-3 py-2 border-b flex items-center justify-between flex-shrink-0"
+        style={{ borderColor: 'rgb(var(--border))' }}
+      >
+        <span
+          className="text-xs font-medium tracking-widest uppercase"
+          style={{ fontFamily: 'var(--font-mono)', color: 'rgb(var(--muted))' }}
+        >
+          地緣政治事件
+        </span>
+        <span
+          className="text-xs"
+          style={{ fontFamily: 'var(--font-mono)', color: 'rgb(var(--muted))' }}
+        >
+          {filtered.length} 則
+        </span>
+      </div>
+
+      <div className="overflow-y-auto flex-1 divide-y" style={{ divideColor: 'rgb(var(--border))' }}>
+        {filtered.length === 0 && (
+          <div
+            className="flex items-center justify-center py-12 text-xs"
+            style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+          >
+            尚無事件資料
+          </div>
+        )}
+        {filtered.map(ev => (
+          <NewsFeedItem
+            key={ev.id}
+            event={ev}
+            isSelected={selectedEvent?.id === ev.id}
+            onClick={onSelectEvent}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── Main Page ─────────────────────────────────────────────────────────────────
+
 export default function Geopolitical() {
+  const [selectedEvent, setSelectedEvent] = useState(null)
+  const [categoryFilter, setCategoryFilter] = useState(null)
+
+  const { data: events = [], isLoading, error } = useQuery({
+    queryKey: ['geopolitical', 'latest'],
+    queryFn: fetchLatest,
+    staleTime: 15 * 60 * 1000, // 15 minutes
+    retry: 2,
+  })
+
+  const handleSelectEvent = useCallback(ev => {
+    setSelectedEvent(prev => (prev?.id === ev.id ? null : ev))
+  }, [])
+
   return (
     <div className="space-y-4 p-4">
-      <h1
-        className="text-lg font-medium text-th-text mb-4"
-        style={{ fontFamily: 'var(--font-ui)' }}
-      >
-        地緣政治分析
-      </h1>
-      <DataCard title="全球風險地圖" empty="地緣政治模組開發中" />
-      <DataCard title="新聞情緒" empty="即將上線" />
+      {/* Page title */}
+      <div className="flex items-center justify-between">
+        <h1
+          className="text-lg font-medium"
+          style={{ fontFamily: 'var(--font-ui)', color: 'rgb(var(--text))' }}
+        >
+          地緣政治分析
+        </h1>
+        {isLoading && (
+          <div className="flex items-center gap-2">
+            <div
+              className="w-4 h-4 border-2 border-th-border border-t-th-accent rounded-full animate-spin"
+              style={{ borderTopColor: 'rgb(var(--accent))' }}
+            />
+            <span
+              className="text-xs"
+              style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+            >
+              更新中…
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <AlertBadge
+          level="red"
+          message={`資料載入失敗：${error.message || '請稍後重試'}`}
+        />
+      )}
+
+      {/* Mobile: category filter tabs */}
+      <div className="md:hidden">
+        <CategoryFilterTabs active={categoryFilter} onChange={setCategoryFilter} />
+      </div>
+
+      {/* Desktop: 60/40 split layout */}
+      <div className="hidden md:grid gap-4" style={{ gridTemplateColumns: '60% 1fr' }}>
+        {/* Left: World Map */}
+        <div>
+          {isLoading ? (
+            <DataCard title="全球風險地圖" loading />
+          ) : (
+            <WorldMapPanel
+              events={events}
+              selectedEvent={selectedEvent}
+              onSelectEvent={handleSelectEvent}
+            />
+          )}
+        </div>
+
+        {/* Right: News Feed */}
+        <div>
+          {isLoading ? (
+            <DataCard title="地緣政治事件" loading />
+          ) : (
+            <NewsFeedPanel
+              events={events}
+              selectedEvent={selectedEvent}
+              onSelectEvent={handleSelectEvent}
+              categoryFilter={null}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Mobile: full-width news feed only */}
+      <div className="md:hidden">
+        {isLoading ? (
+          <DataCard title="地緣政治事件" loading />
+        ) : (
+          <NewsFeedPanel
+            events={events}
+            selectedEvent={selectedEvent}
+            onSelectEvent={handleSelectEvent}
+            categoryFilter={categoryFilter}
+          />
+        )}
+      </div>
+
+      {/* Bottom: Market Impact Summary */}
+      {!isLoading && events.length > 0 && (
+        <MarketImpactStrip events={events} />
+      )}
+
+      {/* Selected event detail (sidebar card) */}
+      {selectedEvent && (
+        <DataCard
+          title="事件詳情"
+          accentColor={CATEGORY_CONFIG[selectedEvent.category]?.color}
+        >
+          <div className="space-y-3">
+            {/* Title + badges */}
+            <div className="flex items-start justify-between gap-2">
+              <h2
+                className="text-sm font-semibold leading-snug"
+                style={{ fontFamily: 'var(--font-ui)', color: 'rgb(var(--text))' }}
+              >
+                {selectedEvent.title}
+              </h2>
+              <button
+                className="text-xs flex-shrink-0 px-2 py-0.5 rounded-sm"
+                style={{
+                  color: 'rgb(var(--muted))',
+                  border: '1px solid rgb(var(--border))',
+                  fontFamily: 'var(--font-mono)',
+                  background: 'transparent',
+                  cursor: 'pointer',
+                }}
+                onClick={() => setSelectedEvent(null)}
+              >
+                ✕ 關閉
+              </button>
+            </div>
+
+            <div className="flex items-center gap-3 flex-wrap">
+              <CategoryBadge category={selectedEvent.category} />
+              <ImpactBadge score={selectedEvent.impact_score} />
+              <SentimentIndicator
+                sentiment={
+                  selectedEvent.impact_score >= 7
+                    ? 'bearish'
+                    : selectedEvent.impact_score >= 4
+                    ? 'neutral'
+                    : 'bullish'
+                }
+              />
+              <span
+                className="text-xs"
+                style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-mono)' }}
+              >
+                {timeAgo(selectedEvent.event_date)}
+              </span>
+            </div>
+
+            {/* Full summary */}
+            {selectedEvent.summary && (
+              <p
+                className="text-sm leading-relaxed"
+                style={{ color: 'rgb(var(--text))', fontFamily: 'var(--font-ui)' }}
+              >
+                {selectedEvent.summary}
+              </p>
+            )}
+
+            {/* Market impact breakdown */}
+            {selectedEvent.market_impact &&
+              typeof selectedEvent.market_impact === 'object' &&
+              Object.keys(selectedEvent.market_impact).length > 0 && (
+                <div>
+                  <div
+                    className="text-xs mb-2 uppercase tracking-widest"
+                    style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-mono)' }}
+                  >
+                    市場影響
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(selectedEvent.market_impact).map(([sector, val]) => {
+                      const v = parseFloat(val)
+                      const isPos = v >= 0
+                      const c = isPos ? 'rgb(var(--up))' : 'rgb(var(--danger))'
+                      return (
+                        <span
+                          key={sector}
+                          className="text-xs px-2 py-1 rounded-sm"
+                          style={{
+                            backgroundColor: isPos
+                              ? 'rgba(var(--up), 0.1)'
+                              : 'rgba(var(--danger), 0.1)',
+                            color: c,
+                            fontFamily: 'var(--font-mono)',
+                          }}
+                        >
+                          {sector} {isPos ? '▲' : '▼'}
+                          {Math.abs(v).toFixed(1)}%
+                        </span>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
+            {/* Tags */}
+            {Array.isArray(selectedEvent.tags) && selectedEvent.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {selectedEvent.tags.map(tag => (
+                  <span
+                    key={tag}
+                    className="text-xs px-2 py-0.5 rounded-sm"
+                    style={{
+                      backgroundColor: 'rgba(var(--grid), 0.15)',
+                      color: 'rgb(var(--muted))',
+                      fontFamily: 'var(--font-ui)',
+                    }}
+                  >
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Source links */}
+            {(() => {
+              const links = Array.isArray(selectedEvent.source_links)
+                ? selectedEvent.source_links
+                : typeof selectedEvent.source_links === 'string'
+                ? [selectedEvent.source_links]
+                : []
+              if (links.length === 0) return null
+              return (
+                <div className="flex flex-wrap gap-2">
+                  {links.map((link, i) => (
+                    <a
+                      key={i}
+                      href={link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs underline"
+                      style={{ color: 'rgb(var(--accent))', fontFamily: 'var(--font-ui)' }}
+                    >
+                      來源 {i + 1} →
+                    </a>
+                  ))}
+                </div>
+              )
+            })()}
+          </div>
+        </DataCard>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Implements Issue #567: replaces the placeholder `/geopolitical` page with a full-featured geopolitical analysis dashboard
- Desktop: 60/40 split — `react-simple-maps` ComposableMap (left) with category-coloured, impact-sized event markers + hover tooltip; scrollable news feed (right) via React Query (`staleTime` 15 min)
- Mobile: map hidden, full-width news feed with horizontal category filter tabs (衝突 / 貿易戰 / 制裁 / 政策 / 選舉)
- Bottom: market impact sector cards extracted from `market_impact` JSON field ("最受影響板塊: 能源 ▲3.2%")
- Clicking any marker or feed item opens an inline detail card with full summary, SentimentIndicator, market impact badges, tags, and source links

Closes #567

## Test plan

- [ ] `npm run build` passes (verified — Geopolitical chunk 115 kB gzip 39 kB)
- [ ] Desktop: world map renders with CDN TopoJSON; markers appear when events have `lat`/`lng`; hover shows tooltip; click selects event + highlights feed item
- [ ] Desktop: news feed scrollable; category badge, impact score, truncated summary, time ago; click expands full summary + source links
- [ ] Mobile (<768px): map not rendered; category filter tabs filter feed; market impact strip visible
- [ ] Error state: AlertBadge shown on API failure
- [ ] Loading state: DataCard spinner shown during fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)