### PR TITLE
feat(page): 戰情總覽 dashboard — alerts, portfolio, market pulse (Closes #561)

### DIFF
--- a/frontend/web/src/App.jsx
+++ b/frontend/web/src/App.jsx
@@ -75,7 +75,7 @@ export default function App() {
             </RequireAuth>
           }
         >
-          <Route path="/" element={<Navigate to="/portfolio" replace />} />
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route
             path="/portfolio"
             element={
@@ -206,7 +206,7 @@ export default function App() {
         {/* Catch-all */}
         <Route
           path="*"
-          element={isAuthenticated() ? <Navigate to="/portfolio" replace /> : <Navigate to="/login" replace />}
+          element={isAuthenticated() ? <Navigate to="/dashboard" replace /> : <Navigate to="/login" replace />}
         />
       </Routes>
     </QueryClientProvider>

--- a/frontend/web/src/pages/Dashboard.jsx
+++ b/frontend/web/src/pages/Dashboard.jsx
@@ -1,227 +1,573 @@
-import React, { useMemo, useState, useEffect } from 'react'
+import React, { useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
-import KpiCard from '../components/KpiCard'
-import PmStatusCard from '../components/PmStatusCard'
-import AllocationDonut from '../components/charts/AllocationDonut'
-import {
-  buildAllocationData,
-  buildMockEquitySeries,
-  calcPortfolioKpis,
-  fetchPortfolioPositions,
-  mockPositions
-} from '../lib/portfolio'
-import { formatCurrency, formatNumber, formatPercent } from '../lib/format'
-import { getToken, getApiBase } from '../lib/auth'
+import { useQuery } from '@tanstack/react-query'
 
-function Panel({ title, right, children }) {
+import { DataCard } from '../components/ui/DataCard'
+import { MetricBadge } from '../components/ui/MetricBadge'
+import { AlertBadge } from '../components/ui/AlertBadge'
+import { SentimentIndicator } from '../components/ui/SentimentIndicator'
+import { authFetch, getApiBase } from '../lib/auth'
+
+// ── Fetchers ──────────────────────────────────────────────────────────────────
+
+async function fetchIndices() {
+  const res = await authFetch(`${getApiBase()}/api/indices/latest`)
+  if (!res.ok) throw new Error(`指數載入失敗 (${res.status})`)
+  return res.json()
+}
+
+async function fetchPortfolioSummary() {
+  const res = await authFetch(`${getApiBase()}/api/portfolio/summary`)
+  if (!res.ok) throw new Error(`投組摘要載入失敗 (${res.status})`)
+  return res.json()
+}
+
+async function fetchLatestAnalysis() {
+  const res = await authFetch(`${getApiBase()}/api/analysis/latest`)
+  if (!res.ok) throw new Error(`分析快照載入失敗 (${res.status})`)
+  return res.json()
+}
+
+// ── Mock action queue (structure ready for real data) ────────────────────────
+
+const MOCK_ACTION_QUEUE = [
+  {
+    id: 'aq-1',
+    type: 'stop_loss',
+    symbol: '華邦電',
+    ticker: '4532',
+    message: '華邦電距停損線 3%，建議執行停損',
+    level: 'red',
+    primaryLabel: '執行停損',
+    secondaryLabel: '忽略',
+  },
+  {
+    id: 'aq-2',
+    type: 'ai_suggest',
+    symbol: '廣達',
+    ticker: '2382',
+    message: 'AI 建議加碼廣達：籌碼集中度上升，本週外資淨買超',
+    level: 'yellow',
+    primaryLabel: '查看分析',
+    secondaryLabel: '稍後',
+  },
+]
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function pnlTrend(value) {
+  if (value == null) return 'flat'
+  return value > 0 ? 'up' : value < 0 ? 'down' : 'flat'
+}
+
+function formatPct(val) {
+  if (val == null) return null
+  return `${val > 0 ? '+' : ''}${Number(val).toFixed(2)}%`
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function SectionHeading({ children }) {
   return (
-    <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))/0.25] shadow-panel">
-      <div className="flex items-center justify-between border-b border-[rgb(var(--border))] px-4 py-3">
-        <div className="text-sm font-semibold">{title}</div>
-        {right ? <div className="text-xs text-[rgb(var(--muted))]">{right}</div> : null}
-      </div>
-      <div className="p-4">{children}</div>
-    </section>
+    <h2
+      className="text-xs font-semibold uppercase tracking-widest text-th-muted mb-2"
+      style={{ fontFamily: 'var(--font-mono)' }}
+    >
+      {children}
+    </h2>
   )
 }
 
-export default function DashboardPage() {
-  const [positions, setPositions] = useState([])
-  const [source, setSource] = useState('api')
-  const [preferApi, setPreferApi] = useState(true)
-  const [error, setError] = useState(null)
-  const [loading, setLoading] = useState(false)
-  const [analysisSnap, setAnalysisSnap] = useState(null)
+/** KPI row item — wraps MetricBadge in a themed tile */
+function KpiTile({ label, value, trend, format, subtext, accentColor }) {
+  return (
+    <div
+      className="flex flex-col gap-1 px-4 py-3 rounded-sm border border-th-border border-l-2 bg-th-card shadow-panel"
+      style={{ borderLeftColor: accentColor || 'rgb(var(--accent))' }}
+    >
+      <span
+        className="text-[10px] tracking-widest uppercase text-th-muted"
+        style={{ fontFamily: 'var(--font-mono)' }}
+      >
+        {label}
+      </span>
+      <MetricBadge value={value} trend={trend} format={format} />
+      {subtext && (
+        <span
+          className="text-[10px] text-th-muted truncate mt-0.5"
+          style={{ fontFamily: 'var(--font-ui)' }}
+        >
+          {subtext}
+        </span>
+      )}
+    </div>
+  )
+}
 
-  const equitySeries = useMemo(() => buildMockEquitySeries({ days: 30, startEquity: 100000 }), [])
+/** Gainers / losers row */
+function MoverRow({ symbol, name, changePct, isGainer }) {
+  const color = isGainer ? 'rgb(var(--up))' : 'rgb(var(--down))'
+  const arrow = isGainer ? '▲' : '▼'
+  return (
+    <div className="flex items-center justify-between py-1.5 border-b border-th-border last:border-0">
+      <div className="flex flex-col min-w-0">
+        <span
+          className="text-xs font-medium truncate"
+          style={{ color: 'rgb(var(--text))', fontFamily: 'var(--font-ui)' }}
+        >
+          {name || symbol}
+        </span>
+        <span
+          className="text-[10px] text-th-muted"
+          style={{ fontFamily: 'var(--font-mono)' }}
+        >
+          {symbol}
+        </span>
+      </div>
+      <span
+        className="text-sm tabular-nums flex-shrink-0 ml-3"
+        style={{ color, fontFamily: 'var(--font-data)' }}
+      >
+        {arrow} {Math.abs(changePct).toFixed(2)}%
+      </span>
+    </div>
+  )
+}
 
-  async function load(nextPreferApi = preferApi) {
-    setLoading(true)
-    setError(null)
-
-    if (!nextPreferApi) {
-      setPositions(mockPositions)
-      setSource('mock')
-      setLoading(false)
-      return
-    }
-
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 1500)
-
-    try {
-      const data = await fetchPortfolioPositions({ signal: controller.signal })
-      setPositions(data)
-      setSource('api')
-    } catch (e) {
-      setPositions([])
-      setSource('error')
-      setError(String(e?.message || e))
-    } finally {
-      clearTimeout(timeout)
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    load(true)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  useEffect(() => {
-    fetch(`${getApiBase()}/api/analysis/latest`, {
-      headers: { Authorization: `Bearer ${getToken()}` }
-    })
-      .then(r => r.ok ? r.json() : null)
-      .then(data => data && setAnalysisSnap(data))
-      .catch(() => {})
-  }, [])
-
-  const allocation = useMemo(() => buildAllocationData(positions), [positions])
-  const kpis = useMemo(() => calcPortfolioKpis(positions, { equitySeries }), [positions, equitySeries])
-
-  const dailyTone = kpis.dailyPnl >= 0 ? 'good' : 'bad'
-  const cumulativeTone = kpis.cumulativePnl >= 0 ? 'good' : 'bad'
-
-  const total = kpis.total
+/** Unrealized P&L bar */
+function PnlBar({ totalPnl, totalCost }) {
+  const pct = totalCost > 0 ? (totalPnl / totalCost) * 100 : 0
+  const clampedPct = Math.min(Math.abs(pct), 100)
+  const positive = pct >= 0
+  const barColor = positive ? 'rgb(var(--up))' : 'rgb(var(--down))'
 
   return (
-    <div className="space-y-6">
-      {/* Daily PM approval status — must be checked every morning before market open */}
-      <PmStatusCard />
-
-      {analysisSnap && (
-        <Link to="/analysis" className="block rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))/0.25] px-4 py-3 hover:bg-[rgb(var(--surface))/0.4] transition-colors">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-semibold text-[rgb(var(--muted))]">
-              盤後分析 · {analysisSnap.trade_date}
-            </span>
-            <span className="text-xs text-emerald-400">查看 →</span>
-          </div>
-          <p className="mt-1 text-sm truncate">
-            {analysisSnap.strategy?.summary || '分析完成'}
-          </p>
-        </Link>
-      )}
-
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <div className="text-sm font-semibold">儀表板總覽 (Dashboard)</div>
-          <div className="mt-1 text-xs text-[rgb(var(--muted))]">
-            Data source:{' '}
-            <span
-              className={
-                source === 'api'
-                  ? 'rounded-md bg-emerald-500/10 px-2 py-0.5 text-emerald-600 dark:text-emerald-300 ring-1 ring-emerald-500/20'
-                  : 'rounded-md bg-[rgb(var(--surface))/0.45] px-2 py-0.5 text-[rgb(var(--text))] ring-1 ring-[rgb(var(--border))]'
-              }
-            >
-              {source.toUpperCase()}
-            </span>
-            {error ? <span className="ml-2 text-rose-600 dark:text-rose-300">(fallback: {error})</span> : null}
-          </div>
-
-          {/* Prefer API checkbox removed per user request */}
-        </div>
-
-        <button
-          type="button"
-          onClick={() => load(preferApi)}
-          disabled={loading}
-          className="w-full sm:w-auto rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))/0.35] px-4 py-2 text-sm text-[rgb(var(--text))] shadow-panel transition hover:bg-[rgb(var(--surface))/0.5] disabled:opacity-50"
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <span
+          className="text-[10px] uppercase tracking-widest text-th-muted"
+          style={{ fontFamily: 'var(--font-mono)' }}
         >
-          {loading ? '讀取中…' : '重新整理'}
+          未實現損益
+        </span>
+        <span
+          className="text-sm tabular-nums font-semibold"
+          style={{ color: barColor, fontFamily: 'var(--font-data)' }}
+        >
+          {positive ? '+' : ''}
+          {new Intl.NumberFormat('zh-TW', {
+            style: 'currency',
+            currency: 'TWD',
+            minimumFractionDigits: 0,
+          }).format(totalPnl)}
+          <span className="text-xs ml-1">
+            ({positive ? '+' : ''}{pct.toFixed(2)}%)
+          </span>
+        </span>
+      </div>
+      <div className="w-full h-1.5 rounded-full bg-th-border overflow-hidden">
+        <div
+          className="h-full rounded-full transition-all duration-500"
+          style={{ width: `${clampedPct}%`, backgroundColor: barColor }}
+        />
+      </div>
+    </div>
+  )
+}
+
+/** Single action queue item with two buttons */
+function ActionItem({ item, onPrimary, onSecondary, dismissed }) {
+  if (dismissed) return null
+  return (
+    <div className="flex items-start gap-3 px-3 py-2.5 rounded-sm border border-th-border bg-th-card">
+      <div className="flex-1 min-w-0">
+        <span
+          className="text-xs text-th-muted block mb-0.5"
+          style={{ fontFamily: 'var(--font-mono)' }}
+        >
+          [{item.ticker}] {item.symbol}
+        </span>
+        <span
+          className="text-xs"
+          style={{ color: 'rgb(var(--text))', fontFamily: 'var(--font-ui)' }}
+        >
+          {item.message}
+        </span>
+      </div>
+      <div className="flex gap-2 flex-shrink-0 mt-0.5">
+        <button
+          onClick={onPrimary}
+          className="text-xs px-2 py-0.5 rounded-sm border transition-opacity hover:opacity-80"
+          style={{
+            color: item.level === 'red' ? 'rgb(var(--danger))' : 'rgb(var(--accent))',
+            borderColor: item.level === 'red' ? 'rgb(var(--danger))' : 'rgb(var(--accent))',
+            fontFamily: 'var(--font-mono)',
+          }}
+        >
+          {item.primaryLabel}
+        </button>
+        <button
+          onClick={onSecondary}
+          className="text-xs px-2 py-0.5 rounded-sm border border-th-border text-th-muted transition-opacity hover:opacity-80"
+          style={{ fontFamily: 'var(--font-mono)' }}
+        >
+          {item.secondaryLabel}
         </button>
       </div>
+    </div>
+  )
+}
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <KpiCard title="總資產" value={formatCurrency(kpis.total)} subtext="Σ (qty × lastPrice)" />
-        <KpiCard title="日損益" value={formatCurrency(kpis.dailyPnl)} subtext="Mock equity curve" tone={dailyTone} />
-        <KpiCard title="累計損益" value={formatCurrency(kpis.cumulativePnl)} subtext="Mock equity curve" tone={cumulativeTone} />
-        <KpiCard
-          title="夏普比率"
-          value={kpis.sharpe == null ? '-' : formatNumber(kpis.sharpe, { maximumFractionDigits: 2 })}
-          subtext="(mock) annualized"
-          tone={kpis.sharpe != null && kpis.sharpe >= 1 ? 'good' : 'neutral'}
+// ── Main Page ─────────────────────────────────────────────────────────────────
+
+export default function DashboardPage() {
+  const [dismissedActions, setDismissedActions] = useState(new Set())
+
+  const dismissAction = useCallback((id) => {
+    setDismissedActions((prev) => new Set([...prev, id]))
+  }, [])
+
+  // React Query fetches
+  const indicesQ = useQuery({
+    queryKey: ['indices-latest'],
+    queryFn: fetchIndices,
+    staleTime: 60_000,
+    retry: 1,
+  })
+
+  const portfolioQ = useQuery({
+    queryKey: ['portfolio-summary'],
+    queryFn: fetchPortfolioSummary,
+    staleTime: 60_000,
+    retry: 1,
+  })
+
+  const analysisQ = useQuery({
+    queryKey: ['analysis-latest'],
+    queryFn: fetchLatestAnalysis,
+    staleTime: 5 * 60_000,
+    retry: 1,
+  })
+
+  // Derived values from API data (with safe fallbacks)
+  const indices = indicesQ.data || {}
+  const portfolio = portfolioQ.data || {}
+  const analysis = analysisQ.data || null
+
+  const totalValue = portfolio.total_value ?? null
+  const dailyChangePct = portfolio.daily_change_pct ?? null
+  const unrealizedPnl = portfolio.unrealized_pnl ?? null
+  const totalCost = portfolio.total_cost ?? 1
+
+  const vixLevel = indices.vix ?? null
+  const vixTrend = indices.vix_trend ?? null
+  const taixChange = indices.taiex_change_pct ?? null
+
+  // Derive alert-level counts from portfolio risk data
+  const riskAlerts = portfolio.alerts || []
+  const redAlerts = riskAlerts.filter((a) => a.level === 'red')
+  const yellowAlerts = riskAlerts.filter((a) => a.level === 'yellow')
+
+  // Derive gainers / losers from portfolio positions
+  const positions = portfolio.positions || []
+  const sorted = [...positions].sort(
+    (a, b) => (b.change_pct ?? 0) - (a.change_pct ?? 0)
+  )
+  const gainers = sorted.filter((p) => (p.change_pct ?? 0) > 0).slice(0, 3)
+  const losers = sorted
+    .filter((p) => (p.change_pct ?? 0) < 0)
+    .reverse()
+    .slice(0, 3)
+
+  // Analysis sentiment
+  const sentiment = analysis?.strategy?.sentiment ?? 'neutral'
+  const analysisSummary = analysis?.strategy?.summary ?? null
+  const analysisDate = analysis?.trade_date ?? null
+
+  // Active alerts count KPI (API alerts + mock action queue)
+  const activeAlertsCount =
+    redAlerts.length + yellowAlerts.length + MOCK_ACTION_QUEUE.length
+
+  // VIX sentiment mapping
+  const vixSentiment =
+    vixLevel == null ? 'neutral' : vixLevel > 25 ? 'bearish' : vixLevel < 15 ? 'bullish' : 'neutral'
+
+  return (
+    <div className="space-y-5">
+      {/* ── KPI Row ──────────────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <KpiTile
+          label="投組總值"
+          value={totalValue}
+          format="currency"
+          trend={pnlTrend(dailyChangePct)}
+          subtext={dailyChangePct != null ? `今日 ${formatPct(dailyChangePct)}` : '—'}
+          accentColor="rgb(var(--accent))"
         />
-        <KpiCard title="風險評級" value="B+" subtext="Medium risk" />
-        <KpiCard title="API 配額" value="87%" subtext="87/100 requests" />
-        <KpiCard title="持倉數" value={positions.length} subtext="active positions" />
-        <KpiCard title="總槓桿" value="1.2x" subtext="Low leverage" />
+        <KpiTile
+          label="VIX 波動指數"
+          value={vixLevel}
+          format="number"
+          trend={vixTrend === 'up' ? 'up' : vixTrend === 'down' ? 'down' : undefined}
+          subtext={<SentimentIndicator sentiment={vixSentiment} />}
+          accentColor={vixLevel != null && vixLevel > 25 ? 'rgb(var(--danger))' : 'rgb(var(--warn))'}
+        />
+        <KpiTile
+          label="加權指數 (TAIEX)"
+          value={taixChange != null ? formatPct(taixChange) : null}
+          format="raw"
+          trend={pnlTrend(taixChange)}
+          subtext="今日漲跌幅"
+          accentColor={
+            taixChange == null
+              ? 'rgb(var(--accent))'
+              : taixChange >= 0
+              ? 'rgb(var(--up))'
+              : 'rgb(var(--down))'
+          }
+        />
+        <KpiTile
+          label="活躍警報"
+          value={activeAlertsCount}
+          format="number"
+          trend={activeAlertsCount > 0 ? 'down' : 'flat'}
+          subtext={`${redAlerts.length} 緊急 · ${yellowAlerts.length} 警告`}
+          accentColor={
+            redAlerts.length > 0 ? 'rgb(var(--danger))' : 'rgb(var(--warn))'
+          }
+        />
       </div>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <Panel title="持倉總覽" right={`${positions.length} positions`}>
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-left text-sm">
-              <thead className="text-xs uppercase tracking-wider text-[rgb(var(--muted))]">
-                <tr>
-                  <th className="px-4 py-3">代碼</th>
-                  <th className="px-4 py-3">成本</th>
-                  <th className="px-4 py-3">現價</th>
-                  <th className="px-4 py-3">數量</th>
-                  <th className="px-4 py-3">未實現損益</th>
-                  <th className="px-4 py-3">持倉比例</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[rgb(var(--border))]">
-                {positions.slice(0, 5).map((p) => {
-                  const qty = Number(p.qty || 0)
-                  const last = Number(p.lastPrice || 0)
-                  const avg = Number(p.avgCost)
-                  const mv = qty * last
-                  const weight = total > 0 ? mv / total : 0
-                  const unreal = Number.isFinite(avg) ? (last - avg) * qty : null
-
-                  const pnlTone =
-                    unreal == null
-                      ? 'text-[rgb(var(--muted))]'
-                      : unreal >= 0
-                        ? 'text-emerald-600 dark:text-emerald-300'
-                        : 'text-rose-600 dark:text-rose-300'
-
-                  return (
-                    <tr key={p.symbol} className="hover:bg-[rgb(var(--surface))/0.35]">
-                      <td className="px-4 py-3 font-medium text-[rgb(var(--text))]">{p.symbol}</td>
-                      <td className="px-4 py-3 text-[rgb(var(--text))]">{Number.isFinite(avg) ? formatCurrency(avg) : '-'}</td>
-                      <td className="px-4 py-3 text-[rgb(var(--text))]">{formatCurrency(last)}</td>
-                      <td className="px-4 py-3 text-[rgb(var(--text))]">{formatNumber(qty, { maximumFractionDigits: 4 })}</td>
-                      <td className={`px-4 py-3 ${pnlTone}`}>{unreal == null ? '-' : formatCurrency(unreal)}</td>
-                      <td className="px-4 py-3 text-[rgb(var(--text))]">{formatPercent(weight)}</td>
-                    </tr>
-                  )
-                })}
-
-                {positions.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className="px-4 py-10 text-center text-[rgb(var(--muted))]">
-                      No positions.
-                    </td>
-                  </tr>
-                ) : null}
-              </tbody>
-            </table>
+      {/* ── Alert Section (Priority 1) ────────────────────────────────────── */}
+      {(redAlerts.length > 0 || yellowAlerts.length > 0) && (
+        <section>
+          <SectionHeading>警報中心</SectionHeading>
+          <div className="space-y-2">
+            {redAlerts.map((a, i) => (
+              <AlertBadge
+                key={`red-${i}`}
+                level="red"
+                message={a.message}
+                actionLabel={a.action_label}
+                onAction={a.on_action}
+              />
+            ))}
+            {yellowAlerts.map((a, i) => (
+              <AlertBadge
+                key={`yellow-${i}`}
+                level="yellow"
+                message={a.message}
+                actionLabel={a.action_label}
+                onAction={a.on_action}
+              />
+            ))}
           </div>
-          {positions.length > 5 && (
-            <div className="mt-4 text-center">
-              <Link to="/portfolio" className="text-xs text-[rgb(var(--muted))] hover:text-[rgb(var(--text))]">
-                View all {positions.length} positions →
-              </Link>
-            </div>
-          )}
-        </Panel>
+        </section>
+      )}
 
-        <Panel title="板塊分佈" right={allocation.length ? `${allocation.length} symbols` : 'No data'}>
-          {allocation.length ? (
-            <AllocationDonut data={allocation} />
-          ) : (
-            <div className="py-16 text-center text-sm text-[rgb(var(--muted))]">No allocation data.</div>
-          )}
-        </Panel>
+      {/* ── Portfolio + Market — asymmetric grid (3:2) ────────────────────── */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-5">
+        {/* Portfolio Summary — 3/5 width on desktop */}
+        <div className="lg:col-span-3 space-y-3">
+          <SectionHeading>投組摘要</SectionHeading>
+
+          {/* P&L summary bar */}
+          <DataCard
+            loading={portfolioQ.isLoading}
+            error={portfolioQ.isError ? portfolioQ.error?.message : null}
+            accentColor="rgb(var(--accent))"
+          >
+            {unrealizedPnl != null ? (
+              <PnlBar totalPnl={unrealizedPnl} totalCost={totalCost} />
+            ) : (
+              <p className="text-xs text-th-muted" style={{ fontFamily: 'var(--font-ui)' }}>
+                未實現損益資料尚未載入
+              </p>
+            )}
+          </DataCard>
+
+          {/* Gainers / Losers */}
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <DataCard
+              title="今日漲幅前三"
+              loading={portfolioQ.isLoading}
+              error={portfolioQ.isError ? portfolioQ.error?.message : null}
+              empty={gainers.length === 0 && !portfolioQ.isLoading ? '今日無上漲持倉' : false}
+              accentColor="rgb(var(--up))"
+            >
+              <div className="divide-y divide-th-border">
+                {gainers.map((p) => (
+                  <MoverRow
+                    key={p.symbol}
+                    symbol={p.symbol}
+                    name={p.name}
+                    changePct={p.change_pct}
+                    isGainer
+                  />
+                ))}
+              </div>
+            </DataCard>
+
+            <DataCard
+              title="今日跌幅前三"
+              loading={portfolioQ.isLoading}
+              error={portfolioQ.isError ? portfolioQ.error?.message : null}
+              empty={losers.length === 0 && !portfolioQ.isLoading ? '今日無下跌持倉' : false}
+              accentColor="rgb(var(--down))"
+            >
+              <div className="divide-y divide-th-border">
+                {losers.map((p) => (
+                  <MoverRow
+                    key={p.symbol}
+                    symbol={p.symbol}
+                    name={p.name}
+                    changePct={p.change_pct}
+                    isGainer={false}
+                  />
+                ))}
+              </div>
+            </DataCard>
+          </div>
+
+          <div className="text-right">
+            <Link
+              to="/portfolio"
+              className="text-xs text-th-muted hover:text-th-text transition-colors"
+              style={{ fontFamily: 'var(--font-ui)' }}
+            >
+              查看完整持倉 →
+            </Link>
+          </div>
+        </div>
+
+        {/* Market Pulse — 2/5 width on desktop */}
+        <div className="lg:col-span-2 space-y-3">
+          <SectionHeading>市場脈動</SectionHeading>
+
+          {/* Latest analysis snapshot */}
+          <DataCard
+            title="盤後分析摘要"
+            loading={analysisQ.isLoading}
+            error={analysisQ.isError ? analysisQ.error?.message : null}
+            empty={!analysis && !analysisQ.isLoading ? '尚無分析資料' : false}
+            accentColor="rgb(var(--accent))"
+          >
+            {analysis && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <SentimentIndicator sentiment={sentiment} />
+                  <span
+                    className="text-[10px] text-th-muted"
+                    style={{ fontFamily: 'var(--font-mono)' }}
+                  >
+                    {analysisDate}
+                  </span>
+                </div>
+                {analysisSummary && (
+                  <p
+                    className="text-xs leading-relaxed text-th-text line-clamp-4 mt-1"
+                    style={{ fontFamily: 'var(--font-ui)' }}
+                  >
+                    {analysisSummary}
+                  </p>
+                )}
+                <div className="pt-1">
+                  <Link
+                    to="/analysis"
+                    className="text-xs text-th-muted hover:text-th-text transition-colors"
+                    style={{ fontFamily: 'var(--font-ui)' }}
+                  >
+                    完整報告 →
+                  </Link>
+                </div>
+              </div>
+            )}
+          </DataCard>
+
+          {/* Key indices snapshot */}
+          <DataCard
+            title="關鍵指數"
+            loading={indicesQ.isLoading}
+            error={indicesQ.isError ? indicesQ.error?.message : null}
+            empty={!indicesQ.data && !indicesQ.isLoading ? '指數資料未載入' : false}
+            accentColor="rgb(var(--warn))"
+          >
+            <div className="space-y-2.5">
+              {[
+                { key: 'taiex', label: 'TAIEX', val: indices.taiex, changePct: taixChange },
+                { key: 'nasdaq', label: 'NASDAQ', val: indices.nasdaq, changePct: indices.nasdaq_change_pct },
+                { key: 'sp500', label: 'S&P 500', val: indices.sp500, changePct: indices.sp500_change_pct },
+                { key: 'sox', label: 'SOX', val: indices.sox, changePct: indices.sox_change_pct },
+              ].map(({ key, label, val, changePct }) => (
+                <div key={key} className="flex items-center justify-between">
+                  <span
+                    className="text-[10px] uppercase tracking-wider text-th-muted"
+                    style={{ fontFamily: 'var(--font-mono)' }}
+                  >
+                    {label}
+                  </span>
+                  <div className="flex items-baseline gap-2">
+                    {val != null ? (
+                      <span
+                        className="text-xs tabular-nums"
+                        style={{ fontFamily: 'var(--font-data)', color: 'rgb(var(--text))' }}
+                      >
+                        {new Intl.NumberFormat('zh-TW').format(Math.round(val))}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-th-muted">—</span>
+                    )}
+                    {changePct != null && (
+                      <span
+                        className="text-[10px] tabular-nums"
+                        style={{
+                          fontFamily: 'var(--font-data)',
+                          color: changePct >= 0 ? 'rgb(var(--up))' : 'rgb(var(--down))',
+                        }}
+                      >
+                        {formatPct(changePct)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </DataCard>
+        </div>
       </div>
 
+      {/* ── Action Queue ─────────────────────────────────────────────────────── */}
+      <section>
+        <SectionHeading>待辦行動</SectionHeading>
+        <div className="space-y-2">
+          {MOCK_ACTION_QUEUE.map((item) => (
+            <ActionItem
+              key={item.id}
+              item={item}
+              dismissed={dismissedActions.has(item.id)}
+              onPrimary={() => {
+                if (item.type === 'ai_suggest') {
+                  window.location.href = '/analysis'
+                }
+                // stop_loss: real impl would send order via API
+              }}
+              onSecondary={() => dismissAction(item.id)}
+            />
+          ))}
+          {MOCK_ACTION_QUEUE.every((i) => dismissedActions.has(i.id)) && (
+            <p
+              className="text-xs text-th-muted py-2 text-center"
+              style={{ fontFamily: 'var(--font-ui)' }}
+            >
+              無待辦行動
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* Accessibility live region */}
       <div className="sr-only" aria-live="polite">
-        {loading ? '讀取儀表板資料中...' : `資料來源：${source}`}
+        {indicesQ.isLoading || portfolioQ.isLoading ? '載入儀表板資料中…' : '資料已更新'}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **KPI row (4 tiles):** 投組總值 + 今日漲跌 %、VIX + SentimentIndicator、TAIEX 今日漲跌幅、活躍警報數
- **Alert section (priority 1):** AlertBadge 渲染 portfolio.alerts 的 red/yellow 項目，全寬顯示
- **Portfolio summary (priority 2):** 未實現損益進度條、今日漲/跌幅前三 (DataCard + MoverRow)，連結至 /portfolio
- **Market pulse (priority 3):** 盤後分析摘要 + SentimentIndicator + 日期；關鍵指數快照 (TAIEX/NASDAQ/SP500/SOX)
- **Action queue:** Mock 華邦電停損 + 廣達 AI 建議，支援 dismiss 功能，結構已預備接入真實資料
- **非等寬格線：** 桌面 3:2 (lg:col-span-3 / lg:col-span-2)，行動裝置垂直堆疊
- **React Query：** /api/indices/latest、/api/portfolio/summary、/api/analysis/latest
- **App.jsx：** 預設重導向由 /portfolio 改為 /dashboard

## Test plan

- [ ] 前端測試通過（60 個既有失敗為 Analysis/Strategy 測試的 pre-existing 問題，與本 PR 無關）
- [ ] 瀏覽 / 自動跳轉 /dashboard
- [ ] API 正常時顯示真實 KPI；API 失敗時各 DataCard 顯示錯誤狀態
- [ ] 點擊「忽略」/「稍後」可 dismiss 行動佇列項目
- [ ] 行動裝置寬度下投組/市場區塊垂直堆疊

Closes #561

🤖 Generated with Claude Code