### PR TITLE
feat(globe): 3D globe upgrade for Geopolitical page (Issue #586)

### DIFF
--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -13,6 +13,7 @@
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-globe.gl": "^2.37.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.22.3",
         "react-simple-maps": "^3.0.0",
@@ -1668,6 +1669,55 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.4.tgz",
+      "integrity": "sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.4.tgz",
+      "integrity": "sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.4.tgz",
+      "integrity": "sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -1824,6 +1874,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2028,6 +2084,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/agent-base": {
@@ -2703,6 +2768,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-dispatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
@@ -2746,6 +2823,33 @@
         "d3-array": "^2.5.0"
       }
     },
+    "node_modules/d3-geo-voronoi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-voronoi/-/d3-geo-voronoi-2.1.0.tgz",
+      "integrity": "sha512-kqE4yYuOjPbKdBXG0xztCacPwkVSK2REF1opSNrnqqtXJmNcM++UbwQ8SxvwP6IQTj9RvIjjK4qeiVsEfj0Z2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-delaunay": "6",
+        "d3-geo": "3",
+        "d3-tricontour": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-voronoi/node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-geo/node_modules/d3-array": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
@@ -2773,6 +2877,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
     "node_modules/d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
@@ -2793,6 +2903,19 @@
         "d3-interpolate": "1.2.0 - 3",
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -2892,6 +3015,19 @@
       "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/d3-tricontour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-tricontour/-/d3-tricontour-1.1.0.tgz",
+      "integrity": "sha512-G7gHKj89n2owmkGb6WX6ixcnQ0Kf/0wpa9VIh9DGdbHu8wdrlaHU4ir3/bFNERl8N8nn4G7e7qbtBG8N9caihQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-delaunay": "6",
+        "d3-scale": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-zoom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
@@ -2918,6 +3054,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/data-bind-mapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/data-bind-mapper/-/data-bind-mapper-1.0.3.tgz",
+      "integrity": "sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/data-urls": {
@@ -3056,6 +3204,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3133,6 +3290,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -3396,6 +3559,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3424,6 +3601,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/frame-ticker": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/frame-ticker/-/frame-ticker-1.0.3.tgz",
+      "integrity": "sha512-E0X2u2JIvbEMrqEg5+4BpTqaD22OwojJI63K7MdKHdncjtAhGRbCR8nJCr2vwEt9NWBPCPcu70X9smPviEBy8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "simplesignal": "^2.1.6"
       }
     },
     "node_modules/fsevents": {
@@ -3533,6 +3719,23 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globe.gl": {
+      "version": "2.45.1",
+      "resolved": "https://registry.npmjs.org/globe.gl/-/globe.gl-2.45.1.tgz",
+      "integrity": "sha512-OTNU+0RxM/b8xHdHdrarJWHmobzgGEkBep1nYVdsQ1WIb+DRzngNtFe52mI2ndfRSiwHs/fRQKJSTAkDoduhiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "kapsule": "^1.16",
+        "three": ">=0.154 <1",
+        "three-globe": "^2.45",
+        "three-render-objects": "^1.40"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3554,6 +3757,17 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/h3-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.4.0.tgz",
+      "integrity": "sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=3",
+        "yarn": ">=1.3.0"
       }
     },
     "node_modules/has-bigints": {
@@ -3753,6 +3967,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/inline-style-parser": {
@@ -4175,6 +4398,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jest-axe": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
@@ -4345,6 +4577,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/lightweight-charts": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.1.0.tgz",
@@ -4378,6 +4622,12 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -5687,6 +5937,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5860,6 +6131,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -5965,11 +6246,43 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-globe.gl": {
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/react-globe.gl/-/react-globe.gl-2.37.0.tgz",
+      "integrity": "sha512-nN1FDOJBhFvWfKrOY0SnkDuA8wk9FSTBN0HFfAdTqqcFM5R+OXBIxK0BM6t8n3oNVYpEJVxEzjYFwLyk4BC7Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "globe.gl": "^2.45",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6293,6 +6606,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -6555,6 +6874,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/simplesignal": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/simplesignal/-/simplesignal-2.1.7.tgz",
+      "integrity": "sha512-PEo2qWpUke7IMhlqiBxrulIFvhJRLkl1ih52Rwa+bPjzhJepcd4GIjn2RiQmFSx3dQvsEAgF0/lXMwMN7vODaA==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -6844,6 +7169,129 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "license": "MIT"
+    },
+    "node_modules/three-conic-polygon-geometry": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/three-conic-polygon-geometry/-/three-conic-polygon-geometry-2.1.2.tgz",
+      "integrity": "sha512-NaP3RWLJIyPGI+zyaZwd0Yj6rkoxm4FJHqAX1Enb4L64oNYLCn4bz1ESgOEYavgcUwCNYINu1AgEoUBJr1wZcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.2",
+        "d3-array": "1 - 3",
+        "d3-geo": "1 - 3",
+        "d3-geo-voronoi": "2",
+        "d3-scale": "1 - 4",
+        "delaunator": "5",
+        "earcut": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.72.0"
+      }
+    },
+    "node_modules/three-geojson-geometry": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/three-geojson-geometry/-/three-geojson-geometry-2.1.1.tgz",
+      "integrity": "sha512-dC7bF3ri1goDcihYhzACHOBQqu7YNNazYLa2bSydVIiJUb3jDFojKSy+gNj2pMkqZNSVjssSmdY9zlmnhEpr1w==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "earcut": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.72.0"
+      }
+    },
+    "node_modules/three-globe": {
+      "version": "2.45.1",
+      "resolved": "https://registry.npmjs.org/three-globe/-/three-globe-2.45.1.tgz",
+      "integrity": "sha512-82idHCkN8YOn+I93I6Tv9KtIb67Cgc3JFOLxvk0hL3iFhzIproT+XsreoI56ofYB3dSvD4FxZnk8jj6JjajrsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "d3-array": "3",
+        "d3-color": "3",
+        "d3-geo": "3",
+        "d3-interpolate": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "data-bind-mapper": "1",
+        "frame-ticker": "1",
+        "h3-js": "4",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "three-conic-polygon-geometry": "2",
+        "three-geojson-geometry": "2",
+        "three-slippy-map-globe": "1",
+        "tinycolor2": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.154"
+      }
+    },
+    "node_modules/three-globe/node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/three-render-objects": {
+      "version": "1.40.5",
+      "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.40.5.tgz",
+      "integrity": "sha512-iA+rYdal0tkond37YeXIvEMAxUFGxw1wU6+ce/GsuiOUKL+8zaxFXY7PTVft0F+Km50mbmtKQ24b2FdwSG3p3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "float-tooltip": "^1.7",
+        "kapsule": "^1.16",
+        "polished": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.168"
+      }
+    },
+    "node_modules/three-slippy-map-globe": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/three-slippy-map-globe/-/three-slippy-map-globe-1.0.5.tgz",
+      "integrity": "sha512-e5ZUKclpflaX+0Nc9CQko3vYq4VLrjHiyMQsVpdtE4ztxpw/T9+LHzcxBgp7pvkTfo51UQV2BII+DZCclJOPHg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "1 - 3",
+        "d3-octree": "^1.1",
+        "d3-scale": "1 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.154"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -6855,6 +7303,12 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -7047,6 +7501,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "5.5.0",

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -17,6 +17,7 @@
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-globe.gl": "^2.37.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.22.3",
     "react-simple-maps": "^3.0.0",

--- a/frontend/web/src/components/GlobeView.jsx
+++ b/frontend/web/src/components/GlobeView.jsx
@@ -1,0 +1,250 @@
+/**
+ * GlobeView.jsx — 3D Globe component for Geopolitical Dashboard
+ *
+ * Uses react-globe.gl for WebGL-based 3D globe rendering.
+ * Lazy-loaded via React.lazy for code splitting.
+ *
+ * Props:
+ *   events         — array of geopolitical events { lat, lng, impact_score, category, title, id }
+ *   selectedEvent  — currently selected event object or null
+ *   onSelectEvent  — callback(event) when a marker is clicked
+ */
+
+import React, { useRef, useEffect, useCallback } from 'react'
+import Globe from 'react-globe.gl'
+
+// ── Category color map ─────────────────────────────────────────────────────────
+
+const CATEGORY_COLOR = {
+  conflict:  '#ef4444',
+  trade_war: '#f97316',
+  sanctions: '#eab308',
+  policy:    '#3b82f6',
+  election:  '#a855f7',
+}
+
+function getCategoryColor(category) {
+  return CATEGORY_COLOR[category] ?? '#71717a'
+}
+
+// ── GlobeView ──────────────────────────────────────────────────────────────────
+
+function GlobeView({ events = [], selectedEvent, onSelectEvent }) {
+  const globeRef = useRef(null)
+  const interactedRef = useRef(false)
+
+  // Only render markers with valid coordinates
+  const markers = events.filter(ev => ev.lat != null && ev.lng != null)
+
+  // Convert events to globe point data
+  const pointsData = markers.map(ev => ({
+    lat: ev.lat,
+    lng: ev.lng,
+    size: Math.max(0.3, Math.min(1.5, (Number(ev.impact_score) || 3) * 0.15)),
+    color: getCategoryColor(ev.category),
+    event: ev,
+  }))
+
+  // Auto-rotate — stop on user interaction
+  useEffect(() => {
+    const globe = globeRef.current
+    if (!globe) return
+
+    const controls = globe.controls()
+    if (!controls) return
+
+    controls.autoRotate = true
+    controls.autoRotateSpeed = 0.4
+
+    function handleInteraction() {
+      if (!interactedRef.current) {
+        interactedRef.current = true
+        controls.autoRotate = false
+      }
+    }
+
+    const domEl = globe.renderer()?.domElement
+    if (domEl) {
+      domEl.addEventListener('pointerdown', handleInteraction, { once: true })
+    }
+
+    return () => {
+      if (domEl) {
+        domEl.removeEventListener('pointerdown', handleInteraction)
+      }
+    }
+  }, [])
+
+  // Re-enable auto-rotate 3 s after last interaction ends
+  useEffect(() => {
+    const globe = globeRef.current
+    if (!globe) return
+
+    const controls = globe.controls()
+    if (!controls) return
+
+    let timer
+    const domEl = globe.renderer()?.domElement
+
+    function onPointerUp() {
+      clearTimeout(timer)
+      timer = setTimeout(() => {
+        controls.autoRotate = true
+        interactedRef.current = false
+      }, 3000)
+    }
+
+    if (domEl) {
+      domEl.addEventListener('pointerup', onPointerUp)
+    }
+
+    return () => {
+      clearTimeout(timer)
+      if (domEl) {
+        domEl.removeEventListener('pointerup', onPointerUp)
+      }
+    }
+  }, [])
+
+  // Focus camera on selected event
+  useEffect(() => {
+    const globe = globeRef.current
+    if (!globe || !selectedEvent?.lat || !selectedEvent?.lng) return
+
+    globe.pointOfView(
+      { lat: selectedEvent.lat, lng: selectedEvent.lng, altitude: 1.8 },
+      600
+    )
+  }, [selectedEvent])
+
+  const handlePointClick = useCallback(
+    point => {
+      if (point?.event) onSelectEvent(point.event)
+    },
+    [onSelectEvent]
+  )
+
+  const pointColor = useCallback(point => {
+    if (selectedEvent && point?.event?.id === selectedEvent.id) {
+      return '#ffffff'
+    }
+    return point.color
+  }, [selectedEvent])
+
+  const pointRadius = useCallback(point => {
+    const base = point.size
+    return selectedEvent && point?.event?.id === selectedEvent.id
+      ? base * 1.6
+      : base
+  }, [selectedEvent])
+
+  const pointLabel = useCallback(point => {
+    const ev = point?.event
+    if (!ev) return ''
+    return `
+      <div style="
+        background: rgba(10,10,20,0.88);
+        border: 1px solid ${point.color}88;
+        border-radius: 4px;
+        padding: 6px 10px;
+        font-size: 12px;
+        color: #e5e7eb;
+        max-width: 200px;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        pointer-events: none;
+      ">
+        <div style="font-weight: 600; margin-bottom: 4px; line-height: 1.3;">${ev.title ?? ''}</div>
+        <div style="color: ${point.color}; font-size: 11px;">
+          衝擊指數: ${ev.impact_score ?? '-'}
+        </div>
+      </div>
+    `
+  }, [])
+
+  return (
+    <div
+      className="rounded-sm border overflow-hidden relative"
+      style={{
+        backgroundColor: '#060b18',
+        borderColor: 'rgb(var(--border))',
+        minHeight: 400,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {/* Panel header */}
+      <div
+        className="px-3 py-2 border-b flex items-center justify-between flex-shrink-0"
+        style={{ borderColor: 'rgb(var(--border))' }}
+      >
+        <span
+          className="text-xs font-medium tracking-widest uppercase"
+          style={{ fontFamily: 'var(--font-mono)', color: 'rgb(var(--muted))' }}
+        >
+          全球風險地圖 3D
+        </span>
+        <div className="flex items-center gap-3">
+          {Object.entries(CATEGORY_COLOR).map(([cat, color]) => {
+            const labels = {
+              conflict: '衝突', trade_war: '貿易戰',
+              sanctions: '制裁', policy: '政策', election: '選舉',
+            }
+            return (
+              <span key={cat} className="flex items-center gap-1">
+                <span
+                  className="inline-block w-2 h-2 rounded-full"
+                  style={{ backgroundColor: color }}
+                />
+                <span
+                  style={{
+                    color: 'rgb(var(--muted))',
+                    fontFamily: 'var(--font-ui)',
+                    fontSize: 10,
+                  }}
+                >
+                  {labels[cat]}
+                </span>
+              </span>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Globe */}
+      <div style={{ flex: 1, minHeight: 360 }}>
+        <Globe
+          ref={globeRef}
+          width={undefined}
+          height={360}
+          backgroundColor="#060b18"
+          globeImageUrl="//unpkg.com/three-globe/example/img/earth-night.jpg"
+          bumpImageUrl="//unpkg.com/three-globe/example/img/earth-topology.png"
+          atmosphereColor="#1e3a5f"
+          atmosphereAltitude={0.15}
+          pointsData={pointsData}
+          pointLat="lat"
+          pointLng="lng"
+          pointColor={pointColor}
+          pointRadius={pointRadius}
+          pointAltitude={0.01}
+          pointResolution={6}
+          pointLabel={pointLabel}
+          onPointClick={handlePointClick}
+          pointsMerge={false}
+        />
+      </div>
+
+      {/* No coordinates notice */}
+      {markers.length === 0 && events.length > 0 && (
+        <div
+          className="px-3 pb-3 text-xs"
+          style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+        >
+          目前事件無座標資料，地圖標記暫無顯示
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default GlobeView

--- a/frontend/web/src/pages/Geopolitical.jsx
+++ b/frontend/web/src/pages/Geopolitical.jsx
@@ -9,7 +9,7 @@
  *   GET /api/geopolitical/events  — paginated event list
  */
 
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, lazy, Suspense } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
   ComposableMap,
@@ -21,6 +21,19 @@ import { DataCard } from '../components/ui/DataCard'
 import { SentimentIndicator } from '../components/ui/SentimentIndicator'
 import { AlertBadge } from '../components/ui/AlertBadge'
 import { authFetch, getApiBase } from '../lib/auth'
+
+// ── Lazy-loaded 3D Globe (code splitting) ─────────────────────────────────────
+const GlobeView = lazy(() => import('../components/GlobeView'))
+
+// ── WebGL / mobile detection ──────────────────────────────────────────────────
+
+function hasWebGL() {
+  try { return !!document.createElement('canvas').getContext('webgl') } catch { return false }
+}
+
+function isMobile() {
+  return window.matchMedia('(pointer: coarse)').matches || window.innerWidth < 768
+}
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -557,11 +570,63 @@ function NewsFeedPanel({ events, selectedEvent, onSelectEvent, categoryFilter })
   )
 }
 
+// ── 2D/3D toggle button ───────────────────────────────────────────────────────
+
+function MapViewToggle({ use3D, onChange, disabled }) {
+  return (
+    <div
+      className="inline-flex rounded-sm overflow-hidden"
+      style={{ border: '1px solid rgb(var(--border))' }}
+      role="group"
+      aria-label="地圖檢視切換"
+    >
+      {['2D', '3D'].map(mode => {
+        const isActive = mode === '3D' ? use3D : !use3D
+        return (
+          <button
+            key={mode}
+            disabled={disabled && mode === '3D'}
+            onClick={() => onChange(mode === '3D')}
+            className="px-3 py-1 text-xs transition-colors"
+            style={{
+              fontFamily: 'var(--font-mono)',
+              backgroundColor: isActive ? 'rgb(var(--accent))' : 'rgb(var(--card))',
+              color: isActive ? '#000' : disabled && mode === '3D' ? 'rgb(var(--muted))' : 'rgb(var(--muted))',
+              cursor: disabled && mode === '3D' ? 'not-allowed' : 'pointer',
+              borderRight: mode === '2D' ? '1px solid rgb(var(--border))' : 'none',
+              opacity: disabled && mode === '3D' ? 0.4 : 1,
+            }}
+            title={disabled && mode === '3D' ? '此裝置不支援 WebGL 3D 地圖' : undefined}
+          >
+            {mode}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 // ── Main Page ─────────────────────────────────────────────────────────────────
 
 export default function Geopolitical() {
   const [selectedEvent, setSelectedEvent] = useState(null)
   const [categoryFilter, setCategoryFilter] = useState(null)
+
+  // 3D toggle — persist in sessionStorage; auto-disable if WebGL or mobile unavailable
+  const webglAvailable = hasWebGL() && !isMobile()
+  const [use3D, setUse3D] = useState(() => {
+    if (!webglAvailable) return false
+    try {
+      return sessionStorage.getItem('geo_map_3d') !== 'false'
+    } catch {
+      return true
+    }
+  })
+
+  const handleToggle3D = useCallback(value => {
+    setUse3D(value)
+    try { sessionStorage.setItem('geo_map_3d', String(value)) } catch {}
+  }, [])
 
   const { data: events = [], isLoading, error } = useQuery({
     queryKey: ['geopolitical', 'latest'],
@@ -574,6 +639,9 @@ export default function Geopolitical() {
     setSelectedEvent(prev => (prev?.id === ev.id ? null : ev))
   }, [])
 
+  // Decide which map to render on desktop
+  const showGlobe = use3D && webglAvailable
+
   return (
     <div className="space-y-4 p-4">
       {/* Page title */}
@@ -584,20 +652,30 @@ export default function Geopolitical() {
         >
           地緣政治分析
         </h1>
-        {isLoading && (
-          <div className="flex items-center gap-2">
-            <div
-              className="w-4 h-4 border-2 border-th-border border-t-th-accent rounded-full animate-spin"
-              style={{ borderTopColor: 'rgb(var(--accent))' }}
+        <div className="flex items-center gap-3">
+          {/* 2D/3D toggle — only visible on desktop */}
+          <div className="hidden md:block">
+            <MapViewToggle
+              use3D={use3D}
+              onChange={handleToggle3D}
+              disabled={!webglAvailable}
             />
-            <span
-              className="text-xs"
-              style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
-            >
-              更新中…
-            </span>
           </div>
-        )}
+          {isLoading && (
+            <div className="flex items-center gap-2">
+              <div
+                className="w-4 h-4 border-2 border-th-border border-t-th-accent rounded-full animate-spin"
+                style={{ borderTopColor: 'rgb(var(--accent))' }}
+              />
+              <span
+                className="text-xs"
+                style={{ color: 'rgb(var(--muted))', fontFamily: 'var(--font-ui)' }}
+              >
+                更新中…
+              </span>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Error banner */}
@@ -615,10 +693,34 @@ export default function Geopolitical() {
 
       {/* Desktop: 60/40 split layout */}
       <div className="hidden md:grid gap-4" style={{ gridTemplateColumns: '60% 1fr' }}>
-        {/* Left: World Map */}
+        {/* Left: World Map (2D) or Globe (3D) */}
         <div>
           {isLoading ? (
             <DataCard title="全球風險地圖" loading />
+          ) : showGlobe ? (
+            <Suspense
+              fallback={
+                <div
+                  className="rounded-sm border flex items-center justify-center"
+                  style={{
+                    backgroundColor: 'rgb(var(--card))',
+                    borderColor: 'rgb(var(--border))',
+                    minHeight: 400,
+                    color: 'rgb(var(--muted))',
+                    fontFamily: 'var(--font-ui)',
+                    fontSize: 13,
+                  }}
+                >
+                  載入 3D 地球儀…
+                </div>
+              }
+            >
+              <GlobeView
+                events={events}
+                selectedEvent={selectedEvent}
+                onSelectEvent={handleSelectEvent}
+              />
+            </Suspense>
           ) : (
             <WorldMapPanel
               events={events}
@@ -643,7 +745,7 @@ export default function Geopolitical() {
         </div>
       </div>
 
-      {/* Mobile: full-width news feed only */}
+      {/* Mobile: full-width news feed only (always 2D, no globe on mobile) */}
       <div className="md:hidden">
         {isLoading ? (
           <DataCard title="地緣政治事件" loading />


### PR DESCRIPTION
## Summary

- Add `react-globe.gl` 3D globe component (`GlobeView.jsx`) with dark earth texture, auto-rotate, and hexagonal markers
- Markers sized by `impact_score`, colored by category (conflict=red, trade_war=orange, sanctions=yellow, policy=blue, election=purple)
- Click marker → `onSelectEvent`; camera pans to selected event
- Auto-rotate resumes 3 s after user stops interacting
- Add `hasWebGL()` + `isMobile()` detection; 3D only renders on desktop with WebGL support
- Add 2D/3D toggle button in page header (persisted in `sessionStorage`)
- `GlobeView` wrapped in `React.lazy` + `<Suspense>` for code splitting — GlobeView chunk is isolated from main bundle
- `WorldMapPanel` (2D) retained as fallback

Closes #586

## Test plan

- [ ] Desktop with WebGL: toggle shows 2D | **3D**, globe renders, markers clickable, auto-rotate works
- [ ] Desktop without WebGL (e.g. headless): 3D button disabled, 2D map shown
- [ ] Mobile viewport (< 768px or coarse pointer): 3D button hidden, only news feed shown
- [ ] `sessionStorage` key `geo_map_3d` persists preference across page reload
- [ ] `npm run build` passes with no errors; GlobeView chunk split confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)