### PR TITLE
feat(advanced): AI backtesting + SSE indices + calendar + PDF export

### DIFF
--- a/frontend/backend/app/api/research.py
+++ b/frontend/backend/app/api/research.py
@@ -287,6 +287,89 @@ def get_debate(
     return api_response(data, source="sqlite")
 
 
+@router.get("/backtest")
+@cached(ttl=600, maxsize=4)
+def get_backtest_stats():
+    """GET /api/research/backtest — aggregate AI score backtest statistics.
+
+    Returns win_rate and avg_return per rating (A/B/C/D) plus overall accuracy.
+    Results are cached for 10 minutes.
+    """
+    try:
+        from app.db.research_db import RESEARCH_DB_PATH, connect_research, init_research_db  # noqa: PLC0415
+        init_research_db(RESEARCH_DB_PATH)
+        research_conn = connect_research(RESEARCH_DB_PATH)
+    except Exception as exc:
+        log.error("backtest: cannot open research.db: %s", exc)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+
+    try:
+        rows = research_conn.execute(
+            """
+            SELECT rating,
+                   COUNT(*) AS cnt,
+                   AVG(return_20d) AS avg_ret_20d,
+                   AVG(return_5d)  AS avg_ret_5d,
+                   AVG(return_10d) AS avg_ret_10d,
+                   SUM(CASE WHEN return_20d > 0 THEN 1 ELSE 0 END) AS wins,
+                   SUM(hit_target)   AS total_hits_target,
+                   SUM(hit_stoploss) AS total_hits_stoploss
+            FROM ai_score_backtest
+            WHERE return_20d IS NOT NULL
+            GROUP BY rating
+            ORDER BY rating
+            """
+        ).fetchall()
+
+        by_rating: Dict[str, Any] = {}
+        total_cnt  = 0
+        total_wins = 0
+
+        for row in rows:
+            rating   = row["rating"] or "?"
+            cnt      = row["cnt"]
+            wins     = row["wins"] or 0
+            win_rate = round(wins / cnt, 4) if cnt > 0 else 0.0
+            by_rating[rating] = {
+                "count":              cnt,
+                "win_rate":           win_rate,
+                "avg_return_5d":      round(row["avg_ret_5d"],   4) if row["avg_ret_5d"]   is not None else None,
+                "avg_return_10d":     round(row["avg_ret_10d"],  4) if row["avg_ret_10d"]  is not None else None,
+                "avg_return_20d":     round(row["avg_ret_20d"],  4) if row["avg_ret_20d"]  is not None else None,
+                "total_hit_target":   row["total_hits_target"]   or 0,
+                "total_hit_stoploss": row["total_hits_stoploss"] or 0,
+            }
+            total_cnt  += cnt
+            total_wins += wins
+
+        overall_win_rate = round(total_wins / total_cnt, 4) if total_cnt > 0 else 0.0
+        all_row = research_conn.execute(
+            "SELECT AVG(return_20d) FROM ai_score_backtest WHERE return_20d IS NOT NULL"
+        ).fetchone()
+        overall_avg_ret = round(all_row[0], 4) if all_row and all_row[0] is not None else None
+
+        total_row = research_conn.execute(
+            "SELECT COUNT(*) FROM ai_score_backtest"
+        ).fetchone()
+        total_records = total_row[0] if total_row else 0
+
+    except Exception as exc:
+        log.error("backtest stats query failed: %s", exc, exc_info=True)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+    finally:
+        research_conn.close()
+
+    data: Dict[str, Any] = {
+        "by_rating": by_rating,
+        "overall": {
+            "total_count":    total_cnt,
+            "win_rate":       overall_win_rate,
+            "avg_return_20d": overall_avg_ret,
+        },
+    }
+    return api_response(data, total=total_records, source="research.db/ai_score_backtest")
+
+
 @router.get("/watchlist")
 @cached(ttl=300, maxsize=4)
 def get_watchlist():

--- a/frontend/backend/app/api/stream.py
+++ b/frontend/backend/app/api/stream.py
@@ -301,3 +301,120 @@ async def stream_health(request: Request):
 
     return EventSourceResponse(health_gen())
 
+
+# ─── SSE /api/stream/market-ticks ────────────────────────────────────────────
+# Module 2D: Real-time market index SSE endpoint.
+# Fetches indices in-process every 30 s and pushes `market_tick` events.
+
+MARKET_TICK_INTERVAL_SEC = max(10, _env_int("MARKET_TICK_INTERVAL_SEC", 30))
+
+# Separate semaphore: max 10 concurrent market-tick SSE clients.
+_market_sema = asyncio.Semaphore(10)
+
+
+def _fetch_market_indices() -> list[dict]:
+    """Fetch latest index rows from research.db market_indices table.
+
+    Returns a list of dicts suitable for JSON serialisation.
+    Falls back to [] on any error so the SSE stream stays alive.
+    """
+    try:
+        from app.db.research_db import RESEARCH_DB_PATH, connect_research, init_research_db  # noqa: PLC0415
+        init_research_db(RESEARCH_DB_PATH)
+        conn = connect_research(RESEARCH_DB_PATH)
+        try:
+            rows = conn.execute(
+                """
+                SELECT m.symbol, m.name, m.close_price, m.change_pct, m.trade_date
+                FROM market_indices m
+                INNER JOIN (
+                    SELECT symbol, MAX(trade_date) AS max_date
+                    FROM market_indices
+                    GROUP BY symbol
+                ) latest ON m.symbol = latest.symbol AND m.trade_date = latest.max_date
+                ORDER BY m.symbol
+                """
+            ).fetchall()
+            return [
+                {
+                    "symbol":      r["symbol"],
+                    "name":        r["name"],
+                    "close_price": r["close_price"],
+                    "change_pct":  r["change_pct"],
+                    "trade_date":  r["trade_date"],
+                }
+                for r in rows
+            ]
+        finally:
+            conn.close()
+    except Exception as exc:
+        import logging as _log
+        _log.getLogger(__name__).warning("market_indices fetch failed: %s", exc)
+        return []
+
+
+@router.get("/market-ticks")
+async def stream_market_ticks(request: Request):
+    """GET /api/stream/market-ticks — SSE, Module 2D.
+
+    Pushes a ``market_tick`` event every MARKET_TICK_INTERVAL_SEC seconds
+    (default 30 s) with the latest global index snapshot from research.db.
+
+    Safety:
+    - separate semaphore (_market_sema, max 10 clients)
+    - in-process fetch, no cross-process IPC
+    - read-only research.db access
+    """
+    try:
+        await asyncio.wait_for(_market_sema.acquire(), timeout=0.1)
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=429, detail="Market-tick SSE capacity reached")
+
+    async def market_gen() -> AsyncGenerator[Dict[str, str], None]:
+        last_heartbeat = 0.0
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+
+                now = time.time()
+                if now - last_heartbeat >= SSE_HEARTBEAT_SEC:
+                    last_heartbeat = now
+                    yield {
+                        "event": "heartbeat",
+                        "data": json.dumps(
+                            {"ts": int(now * 1000), "type": "heartbeat"},
+                            ensure_ascii=False,
+                        ),
+                    }
+
+                try:
+                    indices = await asyncio.to_thread(_fetch_market_indices)
+                    yield {
+                        "event": "market_tick",
+                        "data": json.dumps(
+                            {
+                                "ts":      int(time.time() * 1000),
+                                "indices": indices,
+                            },
+                            ensure_ascii=False,
+                        ),
+                    }
+                except Exception as exc:
+                    yield {
+                        "event": "market_tick",
+                        "data": json.dumps(
+                            {
+                                "ts":    int(time.time() * 1000),
+                                "error": str(exc),
+                            },
+                            ensure_ascii=False,
+                        ),
+                    }
+
+                await asyncio.sleep(MARKET_TICK_INTERVAL_SEC)
+        finally:
+            _market_sema.release()
+
+    return EventSourceResponse(market_gen())
+

--- a/frontend/backend/app/db/research_db.py
+++ b/frontend/backend/app/db/research_db.py
@@ -208,6 +208,26 @@ _DDL_STATEMENTS = [
     """,
 
     # ------------------------------------------------------------------
+    # ai_score_backtest: compare historical AI ratings with actual returns (Module 2D).
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS ai_score_backtest (
+        symbol          TEXT    NOT NULL,
+        report_date     TEXT    NOT NULL,
+        rating          TEXT,
+        confidence      REAL,
+        entry_price     REAL,
+        return_5d       REAL,
+        return_10d      REAL,
+        return_20d      REAL,
+        hit_target      INTEGER DEFAULT 0,
+        hit_stoploss    INTEGER DEFAULT 0,
+        created_at      INTEGER NOT NULL,
+        UNIQUE (symbol, report_date)
+    )
+    """,
+
+    # ------------------------------------------------------------------
     # Indices for common query patterns.
     # ------------------------------------------------------------------
     "CREATE INDEX IF NOT EXISTS idx_sector_data_date      ON sector_data (trade_date DESC)",
@@ -224,6 +244,9 @@ _DDL_STATEMENTS = [
     "CREATE INDEX IF NOT EXISTS idx_macro_indicator       ON macro_indicators (indicator_id, date DESC)",
     "CREATE INDEX IF NOT EXISTS idx_sector_data_date      ON sector_data (trade_date DESC)",
     "CREATE INDEX IF NOT EXISTS idx_sector_mapping_code   ON sector_mapping (sector_code)",
+    "CREATE INDEX IF NOT EXISTS idx_backtest_symbol       ON ai_score_backtest (symbol)",
+    "CREATE INDEX IF NOT EXISTS idx_backtest_date         ON ai_score_backtest (report_date DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_backtest_rating       ON ai_score_backtest (rating)",
 ]
 
 

--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -9,10 +9,13 @@
       "version": "4.7.19",
       "dependencies": {
         "@tanstack/react-query": "^5.96.1",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^4.2.1",
         "lightweight-charts": "^5.1.0",
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-globe.gl": "^2.37.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.22.3",
         "react-simple-maps": "^3.0.0",
@@ -1668,6 +1671,55 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.4.tgz",
+      "integrity": "sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.4.tgz",
+      "integrity": "sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.4.tgz",
+      "integrity": "sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -1825,6 +1877,12 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -1849,11 +1907,24 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
@@ -1881,6 +1952,13 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2028,6 +2106,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/agent-base": {
@@ -2201,6 +2288,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -2364,6 +2460,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2642,6 +2758,27 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -2703,6 +2840,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-dispatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
@@ -2746,6 +2895,33 @@
         "d3-array": "^2.5.0"
       }
     },
+    "node_modules/d3-geo-voronoi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-voronoi/-/d3-geo-voronoi-2.1.0.tgz",
+      "integrity": "sha512-kqE4yYuOjPbKdBXG0xztCacPwkVSK2REF1opSNrnqqtXJmNcM++UbwQ8SxvwP6IQTj9RvIjjK4qeiVsEfj0Z2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-delaunay": "6",
+        "d3-geo": "3",
+        "d3-tricontour": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-voronoi/node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-geo/node_modules/d3-array": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
@@ -2773,6 +2949,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
     "node_modules/d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
@@ -2793,6 +2975,19 @@
         "d3-interpolate": "1.2.0 - 3",
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -2892,6 +3087,19 @@
       "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/d3-tricontour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-tricontour/-/d3-tricontour-1.1.0.tgz",
+      "integrity": "sha512-G7gHKj89n2owmkGb6WX6ixcnQ0Kf/0wpa9VIh9DGdbHu8wdrlaHU4ir3/bFNERl8N8nn4G7e7qbtBG8N9caihQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-delaunay": "6",
+        "d3-scale": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-zoom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
@@ -2918,6 +3126,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/data-bind-mapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/data-bind-mapper/-/data-bind-mapper-1.0.3.tgz",
+      "integrity": "sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/data-urls": {
@@ -3056,6 +3276,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3119,6 +3348,16 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3133,6 +3372,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -3373,6 +3618,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3382,6 +3638,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3394,6 +3656,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/for-each": {
@@ -3424,6 +3700,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/frame-ticker": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/frame-ticker/-/frame-ticker-1.0.3.tgz",
+      "integrity": "sha512-E0X2u2JIvbEMrqEg5+4BpTqaD22OwojJI63K7MdKHdncjtAhGRbCR8nJCr2vwEt9NWBPCPcu70X9smPviEBy8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "simplesignal": "^2.1.6"
       }
     },
     "node_modules/fsevents": {
@@ -3533,6 +3818,23 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globe.gl": {
+      "version": "2.45.1",
+      "resolved": "https://registry.npmjs.org/globe.gl/-/globe.gl-2.45.1.tgz",
+      "integrity": "sha512-OTNU+0RxM/b8xHdHdrarJWHmobzgGEkBep1nYVdsQ1WIb+DRzngNtFe52mI2ndfRSiwHs/fRQKJSTAkDoduhiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "kapsule": "^1.16",
+        "three": ">=0.154 <1",
+        "three-globe": "^2.45",
+        "three-render-objects": "^1.40"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3554,6 +3856,17 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/h3-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.4.0.tgz",
+      "integrity": "sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=3",
+        "yarn": ">=1.3.0"
       }
     },
     "node_modules/has-bigints": {
@@ -3704,6 +4017,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3755,6 +4081,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -3784,6 +4119,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -4175,6 +4516,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jest-axe": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
@@ -4345,6 +4695,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/lightweight-charts": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.1.0.tgz",
@@ -4378,6 +4757,12 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -5578,6 +5963,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -5647,6 +6038,13 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5685,6 +6083,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5860,6 +6279,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -5940,6 +6369,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -5965,11 +6404,43 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-globe.gl": {
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/react-globe.gl/-/react-globe.gl-2.37.0.tgz",
+      "integrity": "sha512-nN1FDOJBhFvWfKrOY0SnkDuA8wk9FSTBN0HFfAdTqqcFM5R+OXBIxK0BM6t8n3oNVYpEJVxEzjYFwLyk4BC7Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "globe.gl": "^2.45",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6157,6 +6628,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6292,6 +6770,22 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -6556,6 +7050,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simplesignal": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/simplesignal/-/simplesignal-2.1.7.tgz",
+      "integrity": "sha512-PEo2qWpUke7IMhlqiBxrulIFvhJRLkl1ih52Rwa+bPjzhJepcd4GIjn2RiQmFSx3dQvsEAgF0/lXMwMN7vODaA==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6582,6 +7082,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -6763,6 +7273,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -6821,6 +7341,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -6844,6 +7373,129 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "license": "MIT"
+    },
+    "node_modules/three-conic-polygon-geometry": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/three-conic-polygon-geometry/-/three-conic-polygon-geometry-2.1.2.tgz",
+      "integrity": "sha512-NaP3RWLJIyPGI+zyaZwd0Yj6rkoxm4FJHqAX1Enb4L64oNYLCn4bz1ESgOEYavgcUwCNYINu1AgEoUBJr1wZcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.2",
+        "d3-array": "1 - 3",
+        "d3-geo": "1 - 3",
+        "d3-geo-voronoi": "2",
+        "d3-scale": "1 - 4",
+        "delaunator": "5",
+        "earcut": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.72.0"
+      }
+    },
+    "node_modules/three-geojson-geometry": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/three-geojson-geometry/-/three-geojson-geometry-2.1.1.tgz",
+      "integrity": "sha512-dC7bF3ri1goDcihYhzACHOBQqu7YNNazYLa2bSydVIiJUb3jDFojKSy+gNj2pMkqZNSVjssSmdY9zlmnhEpr1w==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "earcut": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.72.0"
+      }
+    },
+    "node_modules/three-globe": {
+      "version": "2.45.1",
+      "resolved": "https://registry.npmjs.org/three-globe/-/three-globe-2.45.1.tgz",
+      "integrity": "sha512-82idHCkN8YOn+I93I6Tv9KtIb67Cgc3JFOLxvk0hL3iFhzIproT+XsreoI56ofYB3dSvD4FxZnk8jj6JjajrsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "d3-array": "3",
+        "d3-color": "3",
+        "d3-geo": "3",
+        "d3-interpolate": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "data-bind-mapper": "1",
+        "frame-ticker": "1",
+        "h3-js": "4",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "three-conic-polygon-geometry": "2",
+        "three-geojson-geometry": "2",
+        "three-slippy-map-globe": "1",
+        "tinycolor2": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.154"
+      }
+    },
+    "node_modules/three-globe/node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/three-render-objects": {
+      "version": "1.40.5",
+      "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.40.5.tgz",
+      "integrity": "sha512-iA+rYdal0tkond37YeXIvEMAxUFGxw1wU6+ce/GsuiOUKL+8zaxFXY7PTVft0F+Km50mbmtKQ24b2FdwSG3p3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "float-tooltip": "^1.7",
+        "kapsule": "^1.16",
+        "polished": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.168"
+      }
+    },
+    "node_modules/three-slippy-map-globe": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/three-slippy-map-globe/-/three-slippy-map-globe-1.0.5.tgz",
+      "integrity": "sha512-e5ZUKclpflaX+0Nc9CQko3vYq4VLrjHiyMQsVpdtE4ztxpw/T9+LHzcxBgp7pvkTfo51UQV2BII+DZCclJOPHg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "1 - 3",
+        "d3-octree": "^1.1",
+        "d3-scale": "1 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.154"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -6855,6 +7507,12 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -7048,6 +7706,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-fest": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
@@ -7198,6 +7862,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.96.1",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^4.2.1",
     "lightweight-charts": "^5.1.0",
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",

--- a/frontend/web/src/components/EconomicCalendar.jsx
+++ b/frontend/web/src/components/EconomicCalendar.jsx
@@ -1,0 +1,296 @@
+/**
+ * EconomicCalendar.jsx — Upcoming economic events from /api/macro/calendar.
+ *
+ * Used in MacroAnalysis (Analysis page) and Dashboard page.
+ *
+ * Props:
+ *   maxItems   — max events to display (default: 8)
+ *   className  — extra CSS classes for the outer wrapper
+ */
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { authFetch, getApiBase } from '../lib/auth'
+
+// ---------------------------------------------------------------------------
+// API
+// ---------------------------------------------------------------------------
+
+async function fetchCalendar() {
+  const res = await authFetch(`${getApiBase()}/api/macro/calendar`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const json = await res.json()
+  return Array.isArray(json?.data) ? json.data : []
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const IMPORTANCE_COLORS = {
+  critical: { bg: 'rgba(220,38,38,0.12)', text: 'rgb(239,68,68)',  border: 'rgba(220,38,38,0.4)' },
+  high:     { bg: 'rgba(202,138,4,0.12)', text: 'rgb(234,179,8)',  border: 'rgba(202,138,4,0.4)' },
+  medium:   { bg: 'rgba(99,102,241,0.10)',text: 'rgb(129,140,248)',border: 'rgba(99,102,241,0.3)' },
+  low:      { bg: 'rgba(100,116,139,0.10)',text:'rgb(148,163,184)',border: 'rgba(100,116,139,0.2)' },
+}
+
+const COUNTRY_FLAGS = {
+  US: '🇺🇸',
+  TW: '🇹🇼',
+  EU: '🇪🇺',
+  JP: '🇯🇵',
+  CN: '🇨🇳',
+  GB: '🇬🇧',
+}
+
+function ImportanceBadge({ importance }) {
+  const level = importance || 'low'
+  const colors = IMPORTANCE_COLORS[level] || IMPORTANCE_COLORS.low
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        background: colors.bg,
+        color: colors.text,
+        border: `1px solid ${colors.border}`,
+        borderRadius: '2px',
+        fontFamily: 'var(--font-mono)',
+        fontSize: '0.6rem',
+        letterSpacing: '0.08em',
+        padding: '1px 5px',
+        whiteSpace: 'nowrap',
+        textTransform: 'uppercase',
+        flexShrink: 0,
+      }}
+    >
+      {level}
+    </span>
+  )
+}
+
+function getWeekBounds() {
+  const today = new Date()
+  const dayOfWeek = today.getDay()        // 0=Sun, 6=Sat
+  const startOfWeek = new Date(today)
+  startOfWeek.setDate(today.getDate() - dayOfWeek)
+  const endOfWeek = new Date(startOfWeek)
+  endOfWeek.setDate(startOfWeek.getDate() + 6)
+  return {
+    start: startOfWeek.toISOString().slice(0, 10),
+    end:   endOfWeek.toISOString().slice(0, 10),
+  }
+}
+
+function classifyDate(dateStr) {
+  const todayStr = new Date().toISOString().slice(0, 10)
+  if (dateStr === todayStr) return 'today'
+  const { start, end } = getWeekBounds()
+  if (dateStr >= start && dateStr <= end) return 'this_week'
+  return 'future'
+}
+
+// ---------------------------------------------------------------------------
+// Single event row
+// ---------------------------------------------------------------------------
+
+function EventRow({ event }) {
+  const dateClass = classifyDate(event.date)
+  const flag      = COUNTRY_FLAGS[event.country] || '🌐'
+  const isToday   = dateClass === 'today'
+  const isWeek    = dateClass === 'this_week'
+
+  const rowBg = isToday
+    ? 'rgba(var(--accent-raw, 34 197 94), 0.06)'
+    : 'transparent'
+
+  const dateFontColor = isToday
+    ? 'rgb(var(--accent))'
+    : isWeek
+    ? 'rgb(var(--text))'
+    : 'rgb(var(--muted))'
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        padding: '0.35rem 0.6rem',
+        background: rowBg,
+        borderRadius: '2px',
+        borderLeft: isToday
+          ? '2px solid rgb(var(--accent))'
+          : isWeek
+          ? '2px solid rgba(var(--accent-raw, 34 197 94), 0.3)'
+          : '2px solid transparent',
+        transition: 'background 0.1s ease',
+      }}
+    >
+      {/* Date */}
+      <span
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: '0.7rem',
+          color: dateFontColor,
+          whiteSpace: 'nowrap',
+          minWidth: '5rem',
+          fontWeight: isToday ? 700 : 400,
+        }}
+      >
+        {isToday ? '▶ 今日' : event.date}
+      </span>
+
+      {/* Flag */}
+      <span style={{ fontSize: '0.85rem', flexShrink: 0 }} title={event.country}>
+        {flag}
+      </span>
+
+      {/* Event name */}
+      <span
+        style={{
+          fontFamily: 'var(--font-ui)',
+          fontSize: '0.78rem',
+          color: 'rgb(var(--text))',
+          flex: 1,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+        title={event.event}
+      >
+        {event.event}
+      </span>
+
+      {/* Importance badge */}
+      <ImportanceBadge importance={event.importance} />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+function CalendarSkeleton({ rows = 5 }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          style={{
+            height: '1.6rem',
+            borderRadius: '2px',
+            background: 'rgb(var(--border))',
+            opacity: 0.3 + (i % 3) * 0.1,
+            animation: 'pulse 1.4s ease-in-out infinite',
+            animationDelay: `${i * 0.1}s`,
+          }}
+        />
+      ))}
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 0.25; }
+          50%       { opacity: 0.5; }
+        }
+      `}</style>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// EconomicCalendar
+// ---------------------------------------------------------------------------
+
+export default function EconomicCalendar({ maxItems = 8, className = '' }) {
+  const { data: events = [], isLoading, isError } = useQuery({
+    queryKey: ['economic-calendar'],
+    queryFn: fetchCalendar,
+    staleTime: 30 * 60 * 1000,    // 30 min — calendar changes infrequently
+    refetchInterval: 60 * 60 * 1000, // 1 hour
+    retry: 1,
+  })
+
+  const visibleEvents = events.slice(0, maxItems)
+
+  return (
+    <div
+      className={className}
+      style={{
+        background: 'rgb(var(--card))',
+        border: '1px solid rgb(var(--border))',
+        borderRadius: '2px',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0.5rem 0.75rem',
+          borderBottom: '1px solid rgb(var(--border))',
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--font-ui)',
+            fontSize: '0.78rem',
+            fontWeight: 600,
+            color: 'rgb(var(--text))',
+            letterSpacing: '0.02em',
+          }}
+        >
+          經濟日曆
+        </span>
+        {events.length > 0 && (
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.65rem',
+              color: 'rgb(var(--muted))',
+            }}
+          >
+            近期 {visibleEvents.length} 筆
+          </span>
+        )}
+      </div>
+
+      {/* Body */}
+      <div style={{ padding: '0.4rem 0.2rem' }}>
+        {isLoading && <CalendarSkeleton rows={4} />}
+
+        {isError && !isLoading && (
+          <p
+            style={{
+              fontFamily: 'var(--font-ui)',
+              fontSize: '0.78rem',
+              color: 'rgb(var(--danger, 239 68 68))',
+              padding: '0.5rem 0.6rem',
+              margin: 0,
+            }}
+          >
+            無法載入經濟日曆
+          </p>
+        )}
+
+        {!isLoading && !isError && visibleEvents.length === 0 && (
+          <p
+            style={{
+              fontFamily: 'var(--font-ui)',
+              fontSize: '0.78rem',
+              color: 'rgb(var(--muted))',
+              padding: '0.5rem 0.6rem',
+              margin: 0,
+            }}
+          >
+            近期無重大經濟事件
+          </p>
+        )}
+
+        {!isLoading && !isError && visibleEvents.map((evt, idx) => (
+          <EventRow key={`${evt.date}-${idx}`} event={evt} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/web/src/components/GlobalTicker.jsx
+++ b/frontend/web/src/components/GlobalTicker.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef, useEffect, useState, useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 // ---------------------------------------------------------------------------
@@ -20,6 +20,77 @@ async function fetchLatestIndices() {
   const json = await res.json()
   // Unwrap unified envelope
   return Array.isArray(json?.data) ? json.data : []
+}
+
+// ---------------------------------------------------------------------------
+// SSE hook — tries EventSource first, falls back to polling
+// ---------------------------------------------------------------------------
+
+/**
+ * useMarketTickSSE — subscribe to /api/stream/market-ticks.
+ *
+ * Returns { rows, sseActive } where:
+ *   rows       — latest index array (may be empty until first tick)
+ *   sseActive  — true while SSE connection is open
+ *
+ * Automatically falls back to polling via react-query if EventSource
+ * is not supported or the connection fails.
+ */
+function useMarketTickSSE({ enabled = true } = {}) {
+  const [sseRows, setSseRows]       = useState(null)   // null = no SSE data yet
+  const [sseActive, setSseActive]   = useState(false)
+  const [sseFailed, setSseFailed]   = useState(false)
+  const esRef                       = useRef(null)
+
+  // Start SSE connection
+  useEffect(() => {
+    if (!enabled || typeof EventSource === 'undefined') {
+      setSseFailed(true)
+      return
+    }
+
+    const token = localStorage.getItem('auth_token') || ''
+    // EventSource doesn't support custom headers; pass token as query param
+    const url = `${API_BASE}/api/stream/market-ticks${token ? `?token=${encodeURIComponent(token)}` : ''}`
+
+    let es
+    try {
+      es = new EventSource(url)
+      esRef.current = es
+    } catch {
+      setSseFailed(true)
+      return
+    }
+
+    es.onopen = () => {
+      setSseActive(true)
+      setSseFailed(false)
+    }
+
+    es.addEventListener('market_tick', (evt) => {
+      try {
+        const payload = JSON.parse(evt.data)
+        if (Array.isArray(payload?.indices) && payload.indices.length > 0) {
+          setSseRows(payload.indices)
+        }
+      } catch {
+        // ignore malformed frames
+      }
+    })
+
+    es.onerror = () => {
+      setSseActive(false)
+      setSseFailed(true)
+      es.close()
+    }
+
+    return () => {
+      setSseActive(false)
+      es.close()
+    }
+  }, [enabled])
+
+  return { sseRows, sseActive, sseFailed }
 }
 
 // ---------------------------------------------------------------------------
@@ -172,13 +243,24 @@ function TickerSkeleton() {
 export default function GlobalTicker({ className = '', pauseOnHover = true }) {
   const trackRef = useRef(null)
 
-  const { data: rows = [], isLoading, isError } = useQuery({
+  // Try SSE first, fall back to polling
+  const { sseRows, sseActive, sseFailed } = useMarketTickSSE({ enabled: true })
+
+  // Polling fallback — active when SSE has failed or has no data yet
+  const pollEnabled = sseFailed || sseRows === null
+  const { data: pollRows = [], isLoading: pollLoading, isError: pollError } = useQuery({
     queryKey: ['market-indices-latest'],
     queryFn: fetchLatestIndices,
-    staleTime: 60 * 1000,        // 60 s — matches backend cache TTL
-    refetchInterval: 60 * 1000,  // auto-refresh every 60 s
+    staleTime: 60 * 1000,
+    refetchInterval: pollEnabled ? 60 * 1000 : false,
     retry: 1,
+    enabled: pollEnabled,
   })
+
+  // Prefer SSE data; fall back to poll data
+  const rows      = (sseRows && sseRows.length > 0) ? sseRows : pollRows
+  const isLoading = sseRows === null && pollLoading && !sseActive
+  const isError   = sseRows === null && pollError && sseFailed
 
   // Pause/resume scroll animation on hover (CSS var trick)
   useEffect(() => {

--- a/frontend/web/src/pages/Analysis.jsx
+++ b/frontend/web/src/pages/Analysis.jsx
@@ -18,6 +18,7 @@ import { FileText, ChevronDown, ChevronRight } from 'lucide-react'
 import LoadingSpinner from '../components/LoadingSpinner'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
+import EconomicCalendar from '../components/EconomicCalendar'
 
 /* ── Sentiment Badge ──────────────────────────────────────── */
 function SentimentBadge({ sentiment }) {
@@ -587,6 +588,11 @@ export default function AnalysisPage() {
               )}
             </div>
           </div>
+
+          {/* ══════════════════════════════════════════════════════════
+              Economic Calendar (Module 2D)
+              ══════════════════════════════════════════════════════════ */}
+          <EconomicCalendar maxItems={10} />
 
           {/* ══════════════════════════════════════════════════════════
               BOTTOM: Institutional Flow Heatmap

--- a/frontend/web/src/pages/Dashboard.jsx
+++ b/frontend/web/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import { MetricBadge } from '../components/ui/MetricBadge'
 import { AlertBadge } from '../components/ui/AlertBadge'
 import { SentimentIndicator } from '../components/ui/SentimentIndicator'
 import { authFetch, getApiBase } from '../lib/auth'
+import EconomicCalendar from '../components/EconomicCalendar'
 
 // ── Fetchers ──────────────────────────────────────────────────────────────────
 
@@ -578,6 +579,11 @@ export default function DashboardPage() {
           </DataCard>
         </div>
       </div>
+
+      {/* ── Economic Calendar (Module 2D) ─────────────────────────────────────── */}
+      <section>
+        <EconomicCalendar maxItems={6} />
+      </section>
 
       {/* ── Action Queue ─────────────────────────────────────────────────────── */}
       <section>

--- a/frontend/web/src/pages/Reports.jsx
+++ b/frontend/web/src/pages/Reports.jsx
@@ -272,7 +272,107 @@ function MarkdownBody({ body }) {
   )
 }
 
+// ── PDF Export ────────────────────────────────────────────────────────────────
+
+/**
+ * exportReportPdf — dynamically imports html2canvas + jspdf and renders the
+ * provided DOM element across multiple pages.
+ *
+ * Dynamic import is ONLY triggered on click, never at module load.
+ */
+async function exportReportPdf(element, filename = 'report.pdf') {
+  // Dynamic import — bundler will code-split these heavy libs
+  const [{ default: html2canvas }, { default: jsPDF }] = await Promise.all([
+    import('html2canvas'),
+    import('jspdf'),
+  ])
+
+  const canvas = await html2canvas(element, {
+    scale: 2,
+    useCORS: true,
+    backgroundColor: '#0f1117',
+    logging: false,
+  })
+
+  const imgData   = canvas.toDataURL('image/png')
+  const imgWidth  = canvas.width
+  const imgHeight = canvas.height
+
+  const pdf       = new jsPDF({ orientation: 'portrait', unit: 'px', format: 'a4' })
+  const pageWidth = pdf.internal.pageSize.getWidth()
+  const pageHeight= pdf.internal.pageSize.getHeight()
+
+  // Scale image to page width
+  const scaledWidth  = pageWidth
+  const scaledHeight = (imgHeight * pageWidth) / imgWidth
+
+  let yOffset = 0
+
+  // Multi-page: split by page height in a while loop
+  while (yOffset < scaledHeight) {
+    if (yOffset > 0) pdf.addPage()
+    pdf.addImage(
+      imgData,
+      'PNG',
+      0,
+      -yOffset,
+      scaledWidth,
+      scaledHeight,
+    )
+    yOffset += pageHeight
+  }
+
+  pdf.save(filename)
+}
+
+function ExportPdfButton({ report, contentRef }) {
+  const [exporting, setExporting] = React.useState(false)
+
+  const handleExport = async (e) => {
+    e.stopPropagation()   // don't toggle card expand/collapse
+    if (exporting || !contentRef?.current) return
+    setExporting(true)
+    try {
+      const filename = `report-${report.report_date || report.id}-${report.report_type || 'ai'}.pdf`
+      await exportReportPdf(contentRef.current, filename)
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[PDF export]', err)
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleExport}
+      disabled={exporting}
+      title="匯出 PDF"
+      style={{
+        fontFamily: 'var(--font-mono)',
+        fontSize: '0.65rem',
+        letterSpacing: '0.05em',
+        padding: '2px 7px',
+        background: 'transparent',
+        border: '1px solid rgb(var(--border))',
+        borderRadius: '2px',
+        color: exporting ? 'rgb(var(--muted))' : 'rgb(var(--text))',
+        cursor: exporting ? 'not-allowed' : 'pointer',
+        whiteSpace: 'nowrap',
+        transition: 'border-color 0.15s ease, color 0.15s ease',
+        flexShrink: 0,
+      }}
+      onMouseEnter={e => { if (!exporting) e.currentTarget.style.borderColor = 'rgb(var(--accent))' }}
+      onMouseLeave={e => { e.currentTarget.style.borderColor = 'rgb(var(--border))' }}
+    >
+      {exporting ? '產生中…' : '↓ PDF'}
+    </button>
+  )
+}
+
 function ReportCard({ report, isExpanded, onToggle }) {
+  const cardRef = React.useRef(null)
+
   const { data: detail, isLoading: detailLoading } = useQuery({
     queryKey: ['report-detail', report.id],
     queryFn: () => fetchReportDetail(report.id),
@@ -287,6 +387,7 @@ function ReportCard({ report, isExpanded, onToggle }) {
 
   return (
     <div
+      ref={cardRef}
       style={{
         background: 'rgb(var(--card))',
         border: '1px solid rgb(var(--border))',
@@ -311,7 +412,7 @@ function ReportCard({ report, isExpanded, onToggle }) {
           gap: '0.35rem',
         }}
       >
-        {/* Top row: title + date */}
+        {/* Top row: title + date + PDF export */}
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', justifyContent: 'space-between' }}>
           <span
             style={{
@@ -325,17 +426,20 @@ function ReportCard({ report, isExpanded, onToggle }) {
           >
             {report.title}
           </span>
-          <span
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: '0.72rem',
-              color: 'rgb(var(--muted))',
-              whiteSpace: 'nowrap',
-              paddingTop: '2px',
-            }}
-          >
-            {dateStr}
-          </span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', flexShrink: 0 }}>
+            <ExportPdfButton report={report} contentRef={cardRef} />
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.72rem',
+                color: 'rgb(var(--muted))',
+                whiteSpace: 'nowrap',
+                paddingTop: '2px',
+              }}
+            >
+              {dateStr}
+            </span>
+          </div>
         </div>
 
         {/* Badge row */}

--- a/src/openclaw/agent_orchestrator.py
+++ b/src/openclaw/agent_orchestrator.py
@@ -53,6 +53,11 @@ def _is_wednesday_twn(now_twn: Optional[datetime] = None) -> bool:
     return t.weekday() == 2
 
 
+def _is_sunday_twn(now_twn: Optional[datetime] = None) -> bool:
+    t = now_twn or datetime.now(tz=_TZ_TWN)
+    return t.weekday() == 6
+
+
 # ── 事件偵測 ──────────────────────────────────────────────────────────────────
 
 _LAST_STRATEGY_COMMITEE_TRIGGER: Optional[datetime] = None
@@ -245,6 +250,13 @@ async def run_orchestrator() -> None:
                     if _should_run_now("03:00", now_twn):
                         asyncio.create_task(
                             _run_agent("RedTeamAgent", run_redteam_agent))
+
+                # 每週日 22:00 TWN → AI Score Backtester（Module 2D）
+                if _is_sunday_twn(now_twn):
+                    if _should_run_now("22:00", now_twn):
+                        from openclaw.ai_score_backtester import run_backtester  # noqa: PLC0415
+                        asyncio.create_task(
+                            _run_agent("AIScoreBacktester", run_backtester))
 
                 # ── 事件任務 ──────────────────────────────────────────────────
                 today_str = now_twn.strftime("%Y-%m-%d")

--- a/src/openclaw/ai_score_backtester.py
+++ b/src/openclaw/ai_score_backtester.py
@@ -1,0 +1,362 @@
+"""ai_score_backtester.py — AI Score Backtesting Engine (Module 2D).
+
+Compare historical AI ratings from stock_research_reports with actual
+returns from eod_prices. For each report compute return after 5, 10,
+and 20 trading days, check target/stop-loss hits, and store results in
+ai_score_backtest table (research.db).
+
+Entry point: run_backtester()
+Schedule: Sunday 22:00 TWN (in agent_orchestrator.py)
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+_TZ_TWN = timezone(timedelta(hours=8))
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _get_trades_db_path() -> str:
+    """Resolve trades.db path (source of stock_research_reports + eod_prices)."""
+    import os
+    from openclaw.path_utils import get_repo_root
+    return os.environ.get("DB_PATH", str(get_repo_root() / "data" / "sqlite" / "trades.db"))
+
+
+def _get_research_db() -> sqlite3.Connection:
+    """Open read-write connection to research.db and ensure schema."""
+    from frontend.backend.app.db.research_db import (  # noqa: PLC0415
+        RESEARCH_DB_PATH,
+        connect_research,
+        init_research_db,
+    )
+    init_research_db(RESEARCH_DB_PATH)
+    return connect_research(RESEARCH_DB_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Core computation
+# ---------------------------------------------------------------------------
+
+def _fetch_pending_reports(
+    trades_conn: sqlite3.Connection,
+    research_conn: sqlite3.Connection,
+) -> List[Dict]:
+    """Return reports that have not yet been backtested.
+
+    A report is "ready" if it was created more than 20 trading days ago
+    (conservative: ≥ 28 calendar days) and is not yet in ai_score_backtest.
+    """
+    cutoff = (datetime.now(tz=_TZ_TWN) - timedelta(days=28)).strftime("%Y-%m-%d")
+    already_done = {
+        row[0] + "|" + row[1]
+        for row in research_conn.execute(
+            "SELECT symbol, report_date FROM ai_score_backtest"
+        ).fetchall()
+    }
+
+    rows = trades_conn.execute(
+        """
+        SELECT symbol, trade_date, rating, entry_price, stop_loss, target_price
+        FROM stock_research_reports
+        WHERE trade_date <= ?
+          AND rating IS NOT NULL
+        ORDER BY trade_date DESC
+        """,
+        (cutoff,),
+    ).fetchall()
+
+    pending = []
+    for row in rows:
+        key = row[0] + "|" + row[1]
+        if key not in already_done:
+            pending.append({
+                "symbol":       row[0],
+                "report_date":  row[1],
+                "rating":       row[2],
+                "entry_price":  row[3],
+                "stop_loss":    row[4],
+                "target_price": row[5],
+            })
+    return pending
+
+
+def _fetch_prices_after(
+    trades_conn: sqlite3.Connection,
+    symbol: str,
+    report_date: str,
+    n: int = 25,
+) -> List[Tuple[str, float]]:
+    """Return up to n closing prices after report_date, in chronological order."""
+    rows = trades_conn.execute(
+        """
+        SELECT trade_date, close
+        FROM eod_prices
+        WHERE symbol = ? AND trade_date > ? AND close IS NOT NULL
+        ORDER BY trade_date ASC
+        LIMIT ?
+        """,
+        (symbol, report_date, n),
+    ).fetchall()
+    return [(r[0], float(r[1])) for r in rows]
+
+
+def _compute_return(entry: float, close: float) -> float:
+    """Simple return: (close - entry) / entry * 100 (percent)."""
+    if entry is None or entry == 0:
+        return 0.0
+    return round((close - entry) / entry * 100, 4)
+
+
+def _backtest_report(
+    trades_conn: sqlite3.Connection,
+    report: Dict,
+) -> Optional[Dict]:
+    """Compute backtest metrics for a single report.
+
+    Returns None when there is insufficient price data.
+    """
+    symbol      = report["symbol"]
+    report_date = report["report_date"]
+    entry_price = report.get("entry_price")
+    stop_loss   = report.get("stop_loss")
+    target_price = report.get("target_price")
+
+    prices = _fetch_prices_after(trades_conn, symbol, report_date, n=25)
+    if len(prices) < 5:
+        log.debug("[backtester] %s %s: only %d prices — skipping", symbol, report_date, len(prices))
+        return None
+
+    # If no entry_price, fall back to price on first available day (day 1 close)
+    actual_entry = entry_price if (entry_price and entry_price > 0) else prices[0][1]
+
+    def _price_at(n_days: int) -> Optional[float]:
+        if len(prices) >= n_days:
+            return prices[n_days - 1][1]
+        return None
+
+    p5  = _price_at(5)
+    p10 = _price_at(10)
+    p20 = _price_at(20)
+
+    ret5  = _compute_return(actual_entry, p5)  if p5  else None
+    ret10 = _compute_return(actual_entry, p10) if p10 else None
+    ret20 = _compute_return(actual_entry, p20) if p20 else None
+
+    # Check hit_target / hit_stoploss across entire observation window
+    hit_target   = 0
+    hit_stoploss = 0
+    for _, close in prices[:20]:
+        if target_price and close >= target_price:
+            hit_target = 1
+        if stop_loss and close <= stop_loss:
+            hit_stoploss = 1
+
+    # Derive confidence from llm_synthesis_json if available
+    try:
+        synth_row = trades_conn.execute(
+            "SELECT llm_synthesis_json FROM stock_research_reports "
+            "WHERE symbol=? AND trade_date=?",
+            (symbol, report_date),
+        ).fetchone()
+        if synth_row and synth_row[0]:
+            import json
+            synth = json.loads(synth_row[0])
+            confidence = float(synth.get("confidence", 0.0))
+        else:
+            confidence = 0.0
+    except Exception:
+        confidence = 0.0
+
+    return {
+        "symbol":       symbol,
+        "report_date":  report_date,
+        "rating":       report["rating"],
+        "confidence":   confidence,
+        "entry_price":  actual_entry,
+        "return_5d":    ret5,
+        "return_10d":   ret10,
+        "return_20d":   ret20,
+        "hit_target":   hit_target,
+        "hit_stoploss": hit_stoploss,
+        "created_at":   int(time.time()),
+    }
+
+
+def _upsert_backtest(research_conn: sqlite3.Connection, result: Dict) -> None:
+    """Insert or replace a backtest row."""
+    research_conn.execute(
+        """
+        INSERT OR REPLACE INTO ai_score_backtest
+            (symbol, report_date, rating, confidence, entry_price,
+             return_5d, return_10d, return_20d, hit_target, hit_stoploss, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            result["symbol"],
+            result["report_date"],
+            result["rating"],
+            result["confidence"],
+            result["entry_price"],
+            result["return_5d"],
+            result["return_10d"],
+            result["return_20d"],
+            result["hit_target"],
+            result["hit_stoploss"],
+            result["created_at"],
+        ),
+    )
+    research_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Aggregate statistics
+# ---------------------------------------------------------------------------
+
+def compute_aggregate_stats(research_conn: sqlite3.Connection) -> Dict:
+    """Compute win_rate and avg_return aggregated by rating + overall.
+
+    win_rate = fraction of entries where return_20d > 0 (simple definition).
+    """
+    rows = research_conn.execute(
+        """
+        SELECT rating,
+               COUNT(*) AS cnt,
+               AVG(return_20d) AS avg_ret_20d,
+               AVG(return_5d)  AS avg_ret_5d,
+               AVG(return_10d) AS avg_ret_10d,
+               SUM(CASE WHEN return_20d > 0 THEN 1 ELSE 0 END) AS wins,
+               SUM(hit_target)   AS total_hits_target,
+               SUM(hit_stoploss) AS total_hits_stoploss
+        FROM ai_score_backtest
+        WHERE return_20d IS NOT NULL
+        GROUP BY rating
+        ORDER BY rating
+        """
+    ).fetchall()
+
+    by_rating: Dict[str, Dict] = {}
+    total_cnt = 0
+    total_wins = 0
+    total_ret_20d: List[float] = []
+
+    for row in rows:
+        rating   = row[0] or "?"
+        cnt      = row[1]
+        avg_ret  = round(row[2], 4) if row[2] is not None else None
+        avg_ret5 = round(row[4], 4) if row[4] is not None else None
+        avg_ret10 = round(row[3], 4) if row[3] is not None else None
+        wins     = row[5] or 0
+        win_rate = round(wins / cnt, 4) if cnt > 0 else 0.0
+
+        by_rating[rating] = {
+            "count":            cnt,
+            "win_rate":         win_rate,
+            "avg_return_5d":    avg_ret5,
+            "avg_return_10d":   avg_ret10,
+            "avg_return_20d":   avg_ret,
+            "total_hit_target": row[6] or 0,
+            "total_hit_stoploss": row[7] or 0,
+        }
+        total_cnt  += cnt
+        total_wins += wins
+
+    overall_win_rate = round(total_wins / total_cnt, 4) if total_cnt > 0 else 0.0
+
+    # Overall avg return
+    all_row = research_conn.execute(
+        "SELECT AVG(return_20d) FROM ai_score_backtest WHERE return_20d IS NOT NULL"
+    ).fetchone()
+    overall_avg_ret = round(all_row[0], 4) if all_row and all_row[0] is not None else None
+
+    return {
+        "by_rating":        by_rating,
+        "overall": {
+            "total_count":    total_cnt,
+            "win_rate":       overall_win_rate,
+            "avg_return_20d": overall_avg_ret,
+        },
+        "computed_at": datetime.now(tz=_TZ_TWN).isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def run_backtester(trades_db_path: Optional[str] = None) -> Dict:
+    """Run the AI score backtester.
+
+    1. Fetch reports older than 28 calendar days that haven't been backtested.
+    2. Compute 5/10/20d returns and target/stoploss hits.
+    3. Write results to research.db.
+    4. Return aggregate stats.
+
+    Args:
+        trades_db_path: Override path for trades.db (used in tests).
+
+    Returns:
+        Aggregate stats dict (by_rating + overall).
+    """
+    log.info("[ai_score_backtester] Starting backtester run …")
+
+    if trades_db_path is None:
+        trades_db_path = _get_trades_db_path()
+
+    try:
+        trades_conn = sqlite3.connect(trades_db_path, check_same_thread=False)
+        trades_conn.row_factory = sqlite3.Row
+    except Exception as e:
+        log.error("[ai_score_backtester] Cannot open trades.db (%s): %s", trades_db_path, e)
+        raise
+
+    try:
+        research_conn = _get_research_db()
+    except Exception as e:
+        log.error("[ai_score_backtester] Cannot open research.db: %s", e)
+        trades_conn.close()
+        raise
+
+    try:
+        pending = _fetch_pending_reports(trades_conn, research_conn)
+        log.info("[ai_score_backtester] %d reports to backtest", len(pending))
+
+        processed = 0
+        skipped   = 0
+        for report in pending:
+            try:
+                result = _backtest_report(trades_conn, report)
+                if result is None:
+                    skipped += 1
+                    continue
+                _upsert_backtest(research_conn, result)
+                processed += 1
+            except Exception as e:
+                log.warning(
+                    "[ai_score_backtester] Error processing %s/%s: %s",
+                    report["symbol"], report["report_date"], e,
+                )
+                skipped += 1
+
+        log.info(
+            "[ai_score_backtester] Done: processed=%d skipped=%d",
+            processed, skipped,
+        )
+
+        stats = compute_aggregate_stats(research_conn)
+        log.info("[ai_score_backtester] Stats: %s", stats.get("overall"))
+        return stats
+
+    finally:
+        trades_conn.close()
+        research_conn.close()


### PR DESCRIPTION
## Summary

Closes #587 — Module 2D: 4 advanced sub-features

- **AI Score Backtester** (`ai_score_backtester.py`): compares historical AI ratings from `stock_research_reports` with actual returns from `eod_prices` at 5/10/20 trading days; checks target/stoploss hits; stores in `ai_score_backtest` table (research.db). Scheduled Sunday 22:00 TWN. API: `GET /api/research/backtest`
- **SSE Real-time Indices** (`/api/stream/market-ticks`): in-process fetch from research.db every 30s, separate `_market_sema` (10 clients), pushes `market_tick` events. `GlobalTicker.jsx` tries `EventSource` first, falls back to polling on failure.
- **EconomicCalendar** (`EconomicCalendar.jsx`): compact list from `/api/macro/calendar`, importance badges (critical/high/medium/low), country flags, highlights today + this-week. Integrated into Analysis and Dashboard pages.
- **PDF Export** (`Reports.jsx`): "↓ PDF" button per report card, dynamic import of `html2canvas` + `jspdf` only on click (code-split), multi-page while loop, loading state.

## Test plan

- [x] Frontend build passes (`vite build` — 0 errors)
- [x] 1042 Python tests pass
- [x] `ai_score_backtest` DDL added to `research_db.py` with 3 indices
- [x] `_is_sunday_twn()` helper + Sunday 22:00 schedule added to orchestrator
- [x] `GET /api/research/backtest` returns by_rating + overall stats
- [x] `GET /api/stream/market-ticks` SSE endpoint with `_market_sema(10)`
- [x] `GlobalTicker.jsx` SSE → polling fallback logic verified
- [x] `EconomicCalendar.jsx` renders in both Analysis + Dashboard pages
- [x] PDF export uses dynamic import (never top-level), multi-page while loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)