### PR TITLE
fix: Phase 2 final QA findings — 7 items

### DIFF
--- a/frontend/backend/app/api/macro.py
+++ b/frontend/backend/app/api/macro.py
@@ -128,6 +128,21 @@ FIXED_EVENTS = [
         "importance":  "critical",
         "indicator":   None,
     },
+    # ISM Manufacturing PMI (monthly, 1st business day)
+    {"date": "2026-04-01", "event": "ISM Manufacturing PMI", "country": "US", "importance": "high", "recurrence": "monthly_1st_biz_day"},
+    {"date": "2026-05-01", "event": "ISM Manufacturing PMI", "country": "US", "importance": "high", "recurrence": "monthly_1st_biz_day"},
+    {"date": "2026-06-01", "event": "ISM Manufacturing PMI", "country": "US", "importance": "high", "recurrence": "monthly_1st_biz_day"},
+    # Taiwan Monthly Revenue Deadline (every month 10th)
+    {"date": "2026-04-10", "event": "上市櫃月營收公告截止", "country": "TW", "importance": "high", "recurrence": "monthly_10th"},
+    {"date": "2026-05-10", "event": "上市櫃月營收公告截止", "country": "TW", "importance": "high", "recurrence": "monthly_10th"},
+    {"date": "2026-06-10", "event": "上市櫃月營收公告截止", "country": "TW", "importance": "high", "recurrence": "monthly_10th"},
+    # China Manufacturing PMI (monthly, last day or 1st)
+    {"date": "2026-03-31", "event": "中國製造業PMI", "country": "CN", "importance": "high", "recurrence": "monthly_last_day"},
+    {"date": "2026-04-30", "event": "中國製造業PMI", "country": "CN", "importance": "high", "recurrence": "monthly_last_day"},
+    {"date": "2026-05-31", "event": "中國製造業PMI", "country": "CN", "importance": "high", "recurrence": "monthly_last_day"},
+    # Taiwan Ex-dividend Season (June-September marker)
+    {"date": "2026-06-01", "event": "台股除權息旺季開始", "country": "TW", "importance": "medium", "recurrence": "annual"},
+    {"date": "2026-09-30", "event": "台股除權息旺季結束", "country": "TW", "importance": "medium", "recurrence": "annual"},
 ]
 
 

--- a/frontend/backend/app/api/sector.py
+++ b/frontend/backend/app/api/sector.py
@@ -36,9 +36,11 @@ def _research_conn_dep():
         finally:
             conn.close()
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        log.error("research.db connection error: %s", exc)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable") from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"research.db error: {exc}") from exc
+        log.error("research.db connection error: %s", exc)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/web/.env.example
+++ b/frontend/web/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://localhost:8080

--- a/frontend/web/src/components/EconomicCalendar.jsx
+++ b/frontend/web/src/components/EconomicCalendar.jsx
@@ -287,8 +287,8 @@ export default function EconomicCalendar({ maxItems = 8, className = '' }) {
           </p>
         )}
 
-        {!isLoading && !isError && visibleEvents.map((evt, idx) => (
-          <EventRow key={`${evt.date}-${idx}`} event={evt} />
+        {!isLoading && !isError && visibleEvents.map((evt) => (
+          <EventRow key={`${evt.date}-${evt.event}`} event={evt} />
         ))}
       </div>
     </div>

--- a/frontend/web/src/components/GlobalTicker.jsx
+++ b/frontend/web/src/components/GlobalTicker.jsx
@@ -50,7 +50,11 @@ function useMarketTickSSE({ enabled = true } = {}) {
     }
 
     const token = localStorage.getItem('auth_token') || ''
-    // EventSource doesn't support custom headers; pass token as query param
+    // SECURITY NOTE: EventSource API does not support custom headers.
+    // Auth token is passed via URL query parameter as a technical limitation.
+    // Token will appear in server access logs and browser history.
+    // Mitigation: Use short-lived SSE-specific tokens in production.
+    // See: https://github.com/whatwg/html/issues/2177
     const url = `${API_BASE}/api/stream/market-ticks${token ? `?token=${encodeURIComponent(token)}` : ''}`
 
     let es

--- a/frontend/web/src/pages/research/SectorAnalysis.jsx
+++ b/frontend/web/src/pages/research/SectorAnalysis.jsx
@@ -147,7 +147,7 @@ function DetailPanel({ sector, onClose }) {
   const { data: raw, isLoading } = useQuery({
     queryKey: ['sector', 'detail', sector?.sector_code],
     queryFn: () =>
-      authFetch(`/api/sector/${encodeURIComponent(sector.sector_code)}/detail`).then((r) => r.json()),
+      authFetch(`${getApiBase()}/api/sector/${encodeURIComponent(sector.sector_code)}/detail`).then((r) => r.json()),
     enabled: !!sector,
     staleTime: 5 * 60 * 1000,
   })

--- a/src/openclaw/ai_score_backtester.py
+++ b/src/openclaw/ai_score_backtester.py
@@ -59,7 +59,7 @@ def _fetch_pending_reports(
     """
     cutoff = (datetime.now(tz=_TZ_TWN) - timedelta(days=28)).strftime("%Y-%m-%d")
     already_done = {
-        row[0] + "|" + row[1]
+        row["symbol"] + "|" + row["report_date"]
         for row in research_conn.execute(
             "SELECT symbol, report_date FROM ai_score_backtest"
         ).fetchall()
@@ -78,15 +78,15 @@ def _fetch_pending_reports(
 
     pending = []
     for row in rows:
-        key = row[0] + "|" + row[1]
+        key = row["symbol"] + "|" + row["trade_date"]
         if key not in already_done:
             pending.append({
-                "symbol":       row[0],
-                "report_date":  row[1],
-                "rating":       row[2],
-                "entry_price":  row[3],
-                "stop_loss":    row[4],
-                "target_price": row[5],
+                "symbol":       row["symbol"],
+                "report_date":  row["trade_date"],
+                "rating":       row["rating"],
+                "entry_price":  row["entry_price"],
+                "stop_loss":    row["stop_loss"],
+                "target_price": row["target_price"],
             })
     return pending
 
@@ -108,7 +108,7 @@ def _fetch_prices_after(
         """,
         (symbol, report_date, n),
     ).fetchall()
-    return [(r[0], float(r[1])) for r in rows]
+    return [(r["trade_date"], float(r["close"])) for r in rows]
 
 
 def _compute_return(entry: float, close: float) -> float:


### PR DESCRIPTION
## Summary

Fixes all 7 remaining Phase 2 QA findings.

**HIGH (3)**
- `macro.py`: Add 4 missing event types to `FIXED_EVENTS` — ISM Manufacturing PMI (3 months), Taiwan monthly revenue deadline (3 months), China Manufacturing PMI (3 months), Taiwan ex-dividend season start/end
- `SectorAnalysis.jsx`: `DetailPanel` authFetch call was missing `getApiBase()` prefix, causing requests to relative URL instead of configured backend
- `GlobalTicker.jsx`: Add SECURITY NOTE comment documenting SSE token-in-URL limitation, risk, and mitigation path

**MEDIUM (4)**
- `sector.py`: `_research_conn_dep` was leaking raw exception text via `detail=str(exc)` and `detail=f"research.db error: {exc}"` — replaced with generic message + proper logging
- `EconomicCalendar.jsx`: Replace `key={\`${evt.date}-${idx}\`}` (index-based) with `key={\`${evt.date}-${evt.event}\`}` for stable React keys
- `ai_score_backtester.py`: Replace all tuple index access (`row[0]`, `row[1]`, etc.) with named access (`row["symbol"]`, `row["trade_date"]`, `row["close"]`) consistent with existing `row_factory = sqlite3.Row`
- `frontend/web/.env.example`: Create missing example env file with `VITE_API_BASE`

## Test plan

- [x] `cd frontend/web && npm run build` — passes (✓ built in 4.52s)
- [x] All 7 QA items addressed in a single commit

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)