### PR TITLE
fix(llm): unify MiniMax model version to single constant

### DIFF
--- a/frontend/backend/app/api/chat.py
+++ b/frontend/backend/app/api/chat.py
@@ -105,7 +105,8 @@ def _pick_streamer(model_override: str):
     if os.environ.get("ANTHROPIC_API_KEY", "").strip():
         return _stream_claude, "claude-sonnet-4-6"
     if os.environ.get("MINIMAX_API_KEY", "").strip():
-        return _stream_minimax, "MiniMax-M2.5"
+        from openclaw.llm_minimax import _DEFAULT_MODEL
+        return _stream_minimax, _DEFAULT_MODEL
     return None, "none"
 
 

--- a/frontend/backend/app/api/pm.py
+++ b/frontend/backend/app/api/pm.py
@@ -209,7 +209,8 @@ def pm_review():
         context = build_daily_context(conn=None)
 
     # Read model at request time (not module load) so env vars from run.sh are visible
-    model = os.environ.get("PM_LLM_MODEL", "MiniMax-M2.5")
+    from openclaw.llm_minimax import _DEFAULT_MODEL
+    model = os.environ.get("PM_LLM_MODEL", _DEFAULT_MODEL)
     llm_call = _get_llm_call()
     try:
         state = run_daily_pm_review(context=context, llm_call=llm_call, model=model)

--- a/src/openclaw/agents/base.py
+++ b/src/openclaw/agents/base.py
@@ -40,7 +40,7 @@ def call_agent_llm(
     prompt: str,
     model: str = DEFAULT_MODEL,
 ) -> Dict[str, Any]:
-    """呼叫 MiniMax M2.5，回傳解析後的 dict。失敗時回傳 fallback dict。"""
+    """呼叫 MiniMax LLM，回傳解析後的 dict。失敗時回傳 fallback dict。"""
     try:
         return minimax_call(model, prompt)
     except Exception as e:

--- a/src/openclaw/llm_minimax.py
+++ b/src/openclaw/llm_minimax.py
@@ -1,4 +1,4 @@
-"""llm_minimax.py — MiniMax M2.5 LLM adapter（OpenAI-compatible API）。
+"""llm_minimax.py — MiniMax LLM adapter（OpenAI-compatible API）。
 
 LLM 呼叫介面：
     minimax_call(model, prompt) -> dict


### PR DESCRIPTION
## Summary
- 消除 `pm.py` 和 `chat.py` 中硬編碼的 `MiniMax-M2.5` fallback
- 統一引用 `llm_minimax._DEFAULT_MODEL`（`MiniMax-M2.7`），未來升級只需改一處
- 更新 `agents/base.py` 和 `llm_minimax.py` 的過時 docstring

## Test plan
- [x] `tests/test_llm_stability.py` — 9 passed
- [x] `tests/test_screener_llm_fix.py` — passed
- [x] `src/tests/test_agents.py` — passed
- [x] 既有 pm/chat test failures 確認為 pre-existing（與本次修改無關）

Closes #605

🤖 Generated with [Claude Code](https://claude.ai/claude-code)