### PR TITLE
feat: add E2E test journey files (#609)

### DIFF
--- a/docs/test-journeys/01-auth.json
+++ b/docs/test-journeys/01-auth.json
@@ -1,0 +1,200 @@
+{
+  "journey": "authentication-authorization",
+  "version": "1.0.0",
+  "description": "Authentication and authorization flows for ai-trader frontend. Covers login, logout, protected routes, token persistence, and edge cases.",
+  "baseUrl": "http://localhost:3012",
+  "credentials": {
+    "ADMIN": {
+      "username": "admin",
+      "password": "test-password",
+      "role": "ADMIN"
+    }
+  },
+  "setup": {
+    "login": {
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "fill", "selector": "input[name=username]", "value": "{{username}}" },
+        { "action": "fill", "selector": "input[name=password]", "value": "{{password}}" },
+        { "action": "click", "selector": "button[type=submit]" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 }
+      ]
+    }
+  },
+  "testCases": [
+    {
+      "id": "AUTH-01",
+      "name": "Login page renders correctly",
+      "role": "ADMIN",
+      "setup": null,
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "wait", "selector": "form", "timeout": 5000 },
+        { "action": "assert", "check": "element_exists", "selector": "input[name=username]" },
+        { "action": "assert", "check": "element_exists", "selector": "input[name=password]" },
+        { "action": "assert", "check": "element_exists", "selector": "button[type=submit]" },
+        { "action": "assert", "check": "element_visible", "selector": "input[name=username]" },
+        { "action": "assert", "check": "element_visible", "selector": "input[name=password]" },
+        { "action": "screenshot", "name": "auth-01-login-page-renders" }
+      ]
+    },
+    {
+      "id": "AUTH-02",
+      "name": "Login with valid credentials redirects to dashboard",
+      "role": "ADMIN",
+      "setup": null,
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "wait", "selector": "input[name=username]", "timeout": 5000 },
+        { "action": "fill", "selector": "input[name=username]", "value": "admin" },
+        { "action": "fill", "selector": "input[name=password]", "value": "test-password" },
+        { "action": "click", "selector": "button[type=submit]" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/" },
+        { "action": "assert", "check": "url_not_contains", "value": "/login" },
+        { "action": "screenshot", "name": "auth-02-login-success-dashboard" }
+      ]
+    },
+    {
+      "id": "AUTH-03",
+      "name": "Login with invalid credentials shows error message",
+      "role": "ADMIN",
+      "setup": null,
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "wait", "selector": "input[name=username]", "timeout": 5000 },
+        { "action": "fill", "selector": "input[name=username]", "value": "admin" },
+        { "action": "fill", "selector": "input[name=password]", "value": "wrong-password-xyz" },
+        { "action": "click", "selector": "button[type=submit]" },
+        { "action": "wait", "selector": "[data-testid=login-error], .error-message, [role=alert]", "timeout": 5000 },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=login-error], .error-message, [role=alert]" },
+        { "action": "assert", "check": "url_contains", "value": "/login" },
+        { "action": "screenshot", "name": "auth-03-login-invalid-credentials-error" }
+      ]
+    },
+    {
+      "id": "AUTH-04",
+      "name": "Login with empty fields shows validation",
+      "role": "ADMIN",
+      "setup": null,
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "wait", "selector": "button[type=submit]", "timeout": 5000 },
+        { "action": "click", "selector": "button[type=submit]" },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "input[name=username]:invalid",
+            "input[name=password]:invalid",
+            "[data-testid=login-error]",
+            ".error-message",
+            "[role=alert]"
+          ]
+        },
+        { "action": "assert", "check": "url_contains", "value": "/login" },
+        { "action": "screenshot", "name": "auth-04-login-empty-fields-validation" }
+      ]
+    },
+    {
+      "id": "AUTH-05",
+      "name": "Protected route redirects to login when not authenticated",
+      "role": "ADMIN",
+      "setup": null,
+      "steps": [
+        { "action": "clear_storage", "keys": ["token", "auth_token", "accessToken"] },
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "input[name=username], input[name=password]", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/login" },
+        { "action": "screenshot", "name": "auth-05-protected-route-redirects-to-login" }
+      ]
+    },
+    {
+      "id": "AUTH-06",
+      "name": "Logout clears token and redirects to login",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "click",
+          "selector": "[data-testid=logout-button], button[aria-label*=logout i], button[aria-label*=登出]"
+        },
+        { "action": "wait", "selector": "input[name=username]", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/login" },
+        { "action": "assert", "check": "local_storage_key_absent", "key": "token" },
+        { "action": "screenshot", "name": "auth-06-logout-redirects-to-login" }
+      ]
+    },
+    {
+      "id": "AUTH-07",
+      "name": "401 API response triggers redirect to login",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "inject_response",
+          "url_pattern": "/api/*",
+          "status": 401,
+          "body": { "detail": "Unauthorized" }
+        },
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "input[name=username]", "timeout": 6000 },
+        { "action": "assert", "check": "url_contains", "value": "/login" },
+        { "action": "screenshot", "name": "auth-07-401-redirects-to-login" }
+      ]
+    },
+    {
+      "id": "AUTH-08",
+      "name": "Token persists across page reload",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        { "action": "assert", "check": "local_storage_key_exists", "key": "token" },
+        { "action": "reload" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        { "action": "assert", "check": "url_not_contains", "value": "/login" },
+        { "action": "assert", "check": "local_storage_key_exists", "key": "token" },
+        { "action": "screenshot", "name": "auth-08-token-persists-after-reload" }
+      ]
+    },
+    {
+      "id": "AUTH-09",
+      "name": "Login page redirects to dashboard if already authenticated",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        { "action": "assert", "check": "url_not_contains", "value": "/login" },
+        { "action": "screenshot", "name": "auth-09-already-authenticated-skips-login" }
+      ]
+    },
+    {
+      "id": "AUTH-10",
+      "name": "Show/hide password toggle works",
+      "role": "ADMIN",
+      "setup": null,
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "wait", "selector": "input[name=password]", "timeout": 5000 },
+        { "action": "fill", "selector": "input[name=password]", "value": "test-password" },
+        { "action": "assert", "check": "attribute_equals", "selector": "input[name=password]", "attribute": "type", "value": "password" },
+        {
+          "action": "click",
+          "selector": "[data-testid=toggle-password], button[aria-label*=show i], button[aria-label*=顯示], .password-toggle"
+        },
+        { "action": "assert", "check": "attribute_equals", "selector": "input[name=password]", "attribute": "type", "value": "text" },
+        {
+          "action": "click",
+          "selector": "[data-testid=toggle-password], button[aria-label*=hide i], button[aria-label*=隱藏], .password-toggle"
+        },
+        { "action": "assert", "check": "attribute_equals", "selector": "input[name=password]", "attribute": "type", "value": "password" },
+        { "action": "screenshot", "name": "auth-10-show-hide-password-toggle" }
+      ]
+    }
+  ]
+}

--- a/docs/test-journeys/02-portfolio-trades.json
+++ b/docs/test-journeys/02-portfolio-trades.json
@@ -1,0 +1,472 @@
+{
+  "journey": "portfolio-trades",
+  "version": "1.0.0",
+  "description": "Portfolio and Trades page flows for ai-trader frontend. Covers position list, KPI cards, charts, position detail drawer, chip health, trade filtering, sorting, export, and causal chain viewer.",
+  "baseUrl": "http://localhost:3012",
+  "credentials": {
+    "ADMIN": {
+      "username": "admin",
+      "password": "test-password",
+      "role": "ADMIN"
+    }
+  },
+  "setup": {
+    "login": {
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "fill", "selector": "input[name=username]", "value": "{{username}}" },
+        { "action": "fill", "selector": "input[name=password]", "value": "{{password}}" },
+        { "action": "click", "selector": "button[type=submit]" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 }
+      ]
+    }
+  },
+  "testCases": [
+    {
+      "id": "PORT-01",
+      "name": "Portfolio page loads with position list",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=portfolio-page], [data-testid=position-list], .position-list", "timeout": 8000 },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=portfolio-page], [data-testid=position-list], .position-list" },
+        { "action": "assert", "check": "element_count_gte", "selector": "[data-testid=position-row], .position-row, [data-testid=position-card]", "count": 0 },
+        { "action": "screenshot", "name": "port-01-portfolio-position-list" }
+      ]
+    },
+    {
+      "id": "PORT-02",
+      "name": "KPI cards display total value, unrealized P&L, daily P&L, Sharpe",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=kpi-cards], .kpi-card, [data-testid=kpi-total-value]", "timeout": 8000 },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=kpi-total-value]",
+            "[data-testid=kpi-unrealized-pnl]",
+            "[data-testid=kpi-daily-pnl]",
+            "[data-testid=kpi-sharpe]",
+            ".kpi-card"
+          ]
+        },
+        { "action": "screenshot", "name": "port-02-kpi-cards" }
+      ]
+    },
+    {
+      "id": "PORT-03",
+      "name": "Sector allocation chart renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=sector-chart], [data-testid=sector-allocation], .sector-chart, canvas, svg", "timeout": 8000 },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=sector-chart]",
+            "[data-testid=sector-allocation]",
+            ".sector-chart"
+          ]
+        },
+        { "action": "screenshot", "name": "port-03-sector-allocation-chart" }
+      ]
+    },
+    {
+      "id": "PORT-04",
+      "name": "Equity curve chart renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=equity-curve], [data-testid=pnl-chart], .equity-curve, canvas, svg", "timeout": 8000 },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=equity-curve]",
+            "[data-testid=pnl-chart]",
+            ".equity-curve",
+            ".pnl-chart"
+          ]
+        },
+        { "action": "screenshot", "name": "port-04-equity-curve-chart" }
+      ]
+    },
+    {
+      "id": "PORT-05",
+      "name": "Click position row opens detail drawer",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=position-row], .position-row, [data-testid=position-card]", "timeout": 8000 },
+        { "action": "click", "selector": "[data-testid=position-row]:first-child, .position-row:first-child, [data-testid=position-card]:first-child" },
+        { "action": "wait", "selector": "[data-testid=position-detail-drawer], .position-drawer, [data-testid=detail-drawer]", "timeout": 5000 },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=position-detail-drawer], .position-drawer, [data-testid=detail-drawer]" },
+        { "action": "screenshot", "name": "port-05-position-detail-drawer-open" }
+      ]
+    },
+    {
+      "id": "PORT-06",
+      "name": "Position detail drawer shows quote panel",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=position-row], .position-row, [data-testid=position-card]", "timeout": 8000 },
+        { "action": "click", "selector": "[data-testid=position-row]:first-child, .position-row:first-child, [data-testid=position-card]:first-child" },
+        { "action": "wait", "selector": "[data-testid=quote-panel], .quote-panel", "timeout": 5000 },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=quote-panel], .quote-panel" },
+        { "action": "screenshot", "name": "port-06-position-drawer-quote-panel" }
+      ]
+    },
+    {
+      "id": "PORT-07",
+      "name": "Position detail drawer shows K-line chart",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=position-row], .position-row, [data-testid=position-card]", "timeout": 8000 },
+        { "action": "click", "selector": "[data-testid=position-row]:first-child, .position-row:first-child, [data-testid=position-card]:first-child" },
+        { "action": "wait", "selector": "[data-testid=kline-chart], .kline-chart, [data-testid=position-detail-drawer] svg, [data-testid=position-detail-drawer] canvas", "timeout": 8000 },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=kline-chart]",
+            ".kline-chart",
+            "[data-testid=position-detail-drawer] svg"
+          ]
+        },
+        { "action": "screenshot", "name": "port-07-position-drawer-kline-chart" }
+      ]
+    },
+    {
+      "id": "PORT-08",
+      "name": "Lock position button works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=position-row], .position-row, [data-testid=position-card]", "timeout": 8000 },
+        { "action": "click", "selector": "[data-testid=position-row]:first-child, .position-row:first-child, [data-testid=position-card]:first-child" },
+        { "action": "wait", "selector": "[data-testid=lock-position-btn], button[aria-label*=lock i], button[aria-label*=鎖定]", "timeout": 5000 },
+        { "action": "click", "selector": "[data-testid=lock-position-btn], button[aria-label*=lock i], button[aria-label*=鎖定]" },
+        {
+          "action": "wait",
+          "selector": "[data-testid=lock-success], [data-testid=position-locked], .locked-badge, [aria-label*=locked i]",
+          "timeout": 5000
+        },
+        { "action": "screenshot", "name": "port-08-position-locked" }
+      ]
+    },
+    {
+      "id": "PORT-09",
+      "name": "Unlock position button works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=position-row], .position-row, [data-testid=position-card]", "timeout": 8000 },
+        { "action": "click", "selector": "[data-testid=position-row]:first-child, .position-row:first-child, [data-testid=position-card]:first-child" },
+        { "action": "wait", "selector": "[data-testid=unlock-position-btn], [data-testid=lock-position-btn], button[aria-label*=unlock i], button[aria-label*=解鎖]", "timeout": 5000 },
+        {
+          "action": "click",
+          "selector": "[data-testid=unlock-position-btn], button[aria-label*=unlock i], button[aria-label*=解鎖]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=unlock-success], [data-testid=position-unlocked], [data-testid=lock-position-btn]",
+          "timeout": 5000
+        },
+        { "action": "screenshot", "name": "port-09-position-unlocked" }
+      ]
+    },
+    {
+      "id": "PORT-10",
+      "name": "Close position modal appears on button click",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=position-row], .position-row, [data-testid=position-card]", "timeout": 8000 },
+        { "action": "click", "selector": "[data-testid=position-row]:first-child, .position-row:first-child, [data-testid=position-card]:first-child" },
+        { "action": "wait", "selector": "[data-testid=close-position-btn], button[aria-label*=close i], button[aria-label*=平倉]", "timeout": 5000 },
+        { "action": "click", "selector": "[data-testid=close-position-btn], button[aria-label*=close i], button[aria-label*=平倉]" },
+        { "action": "wait", "selector": "[data-testid=close-position-modal], [role=dialog], .modal", "timeout": 5000 },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=close-position-modal], [role=dialog], .modal" },
+        { "action": "screenshot", "name": "port-10-close-position-modal" }
+      ]
+    },
+    {
+      "id": "PORT-11",
+      "name": "Close position confirms and submits",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=position-row], .position-row, [data-testid=position-card]", "timeout": 8000 },
+        { "action": "click", "selector": "[data-testid=position-row]:first-child, .position-row:first-child, [data-testid=position-card]:first-child" },
+        { "action": "wait", "selector": "[data-testid=close-position-btn], button[aria-label*=close i], button[aria-label*=平倉]", "timeout": 5000 },
+        { "action": "click", "selector": "[data-testid=close-position-btn], button[aria-label*=close i], button[aria-label*=平倉]" },
+        { "action": "wait", "selector": "[data-testid=close-position-modal], [role=dialog], .modal", "timeout": 5000 },
+        { "action": "click", "selector": "[data-testid=confirm-close-btn], button[data-testid*=confirm], button[aria-label*=confirm i], button[aria-label*=確認]" },
+        {
+          "action": "wait",
+          "selector": "[data-testid=close-success-toast], [data-testid=close-position-modal]:not([class*=open]), .toast",
+          "timeout": 8000
+        },
+        { "action": "screenshot", "name": "port-11-close-position-submitted" }
+      ]
+    },
+    {
+      "id": "PORT-12",
+      "name": "Chip health score displays correctly",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/portfolio" },
+        { "action": "wait", "selector": "[data-testid=position-row], .position-row, [data-testid=position-card]", "timeout": 8000 },
+        { "action": "click", "selector": "[data-testid=position-row]:first-child, .position-row:first-child, [data-testid=position-card]:first-child" },
+        { "action": "wait", "selector": "[data-testid=chip-health], [data-testid=chip-score], .chip-health, .chip-score", "timeout": 8000 },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=chip-health]",
+            "[data-testid=chip-score]",
+            ".chip-health",
+            ".chip-score"
+          ]
+        },
+        { "action": "screenshot", "name": "port-12-chip-health-score" }
+      ]
+    },
+    {
+      "id": "TRADE-01",
+      "name": "Trades page loads with trade cards",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list, .trade-card", "timeout": 8000 },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list" },
+        { "action": "screenshot", "name": "trade-01-trades-page-loads" }
+      ]
+    },
+    {
+      "id": "TRADE-02",
+      "name": "Date range filter works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list", "timeout": 8000 },
+        {
+          "action": "fill",
+          "selector": "[data-testid=date-from], input[name=date_from], input[type=date]:first-of-type",
+          "value": "2026-03-01"
+        },
+        {
+          "action": "fill",
+          "selector": "[data-testid=date-to], input[name=date_to], input[type=date]:last-of-type",
+          "value": "2026-04-04"
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=apply-filter], button[aria-label*=filter i], button[aria-label*=篩選], button[type=submit]"
+        },
+        { "action": "wait", "selector": "[data-testid=trade-list], .trade-list, [data-testid=trade-card]", "timeout": 5000 },
+        { "action": "screenshot", "name": "trade-02-date-range-filter" }
+      ]
+    },
+    {
+      "id": "TRADE-03",
+      "name": "Symbol filter works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list", "timeout": 8000 },
+        {
+          "action": "fill",
+          "selector": "[data-testid=symbol-filter], input[name=symbol], input[placeholder*=symbol i], input[placeholder*=股票]",
+          "value": "2330"
+        },
+        { "action": "wait", "selector": "[data-testid=trade-list], .trade-list", "timeout": 3000 },
+        { "action": "screenshot", "name": "trade-03-symbol-filter-2330" }
+      ]
+    },
+    {
+      "id": "TRADE-04",
+      "name": "Type filter (buy/sell) works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list", "timeout": 8000 },
+        {
+          "action": "click",
+          "selector": "[data-testid=type-filter-buy], button[value=buy], [aria-label*=buy i], [data-value=buy]"
+        },
+        { "action": "wait", "selector": "[data-testid=trade-list], .trade-list", "timeout": 3000 },
+        { "action": "screenshot", "name": "trade-04-type-filter-buy" },
+        {
+          "action": "click",
+          "selector": "[data-testid=type-filter-sell], button[value=sell], [aria-label*=sell i], [data-value=sell]"
+        },
+        { "action": "wait", "selector": "[data-testid=trade-list], .trade-list", "timeout": 3000 },
+        { "action": "screenshot", "name": "trade-04-type-filter-sell" }
+      ]
+    },
+    {
+      "id": "TRADE-05",
+      "name": "Status filter works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list", "timeout": 8000 },
+        {
+          "action": "click",
+          "selector": "[data-testid=status-filter], select[name=status], [aria-label*=status i]"
+        },
+        {
+          "action": "select_option",
+          "selector": "select[name=status], [data-testid=status-filter] select",
+          "value": "filled"
+        },
+        { "action": "wait", "selector": "[data-testid=trade-list], .trade-list", "timeout": 3000 },
+        { "action": "screenshot", "name": "trade-05-status-filter-filled" }
+      ]
+    },
+    {
+      "id": "TRADE-06",
+      "name": "Sort by time works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list", "timeout": 8000 },
+        {
+          "action": "click",
+          "selector": "[data-testid=sort-time], th[data-sort=time], button[aria-label*=sort by time i], [data-testid=col-time]"
+        },
+        { "action": "wait", "selector": "[data-testid=trade-list], .trade-list", "timeout": 3000 },
+        { "action": "screenshot", "name": "trade-06-sorted-by-time-asc" },
+        {
+          "action": "click",
+          "selector": "[data-testid=sort-time], th[data-sort=time], button[aria-label*=sort by time i], [data-testid=col-time]"
+        },
+        { "action": "wait", "selector": "[data-testid=trade-list], .trade-list", "timeout": 3000 },
+        { "action": "screenshot", "name": "trade-06-sorted-by-time-desc" }
+      ]
+    },
+    {
+      "id": "TRADE-07",
+      "name": "Export CSV button works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list", "timeout": 8000 },
+        {
+          "action": "assert",
+          "check": "element_exists",
+          "selector": "[data-testid=export-csv-btn], button[aria-label*=export i], button[aria-label*=匯出], a[download]"
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=export-csv-btn], button[aria-label*=export i], button[aria-label*=匯出]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=export-success], [data-testid=download-started], .toast",
+          "timeout": 5000,
+          "optional": true
+        },
+        { "action": "screenshot", "name": "trade-07-export-csv-clicked" }
+      ]
+    },
+    {
+      "id": "TRADE-08",
+      "name": "Trade causal chain viewer opens",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trade-card], [data-testid=trade-row], .trade-card, .trade-row", "timeout": 8000 },
+        {
+          "action": "click",
+          "selector": "[data-testid=trade-card]:first-child [data-testid=causal-chain-btn], [data-testid=trade-row]:first-child [data-testid=causal-chain-btn], button[aria-label*=causal i], button[aria-label*=決策鏈]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=causal-chain-viewer], [data-testid=decision-chain], .causal-chain, [role=dialog]",
+          "timeout": 5000
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=causal-chain-viewer]",
+            "[data-testid=decision-chain]",
+            ".causal-chain"
+          ]
+        },
+        { "action": "screenshot", "name": "trade-08-causal-chain-viewer-open" }
+      ]
+    },
+    {
+      "id": "TRADE-09",
+      "name": "Daily P&L summary bar displays",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list", "timeout": 8000 },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=daily-pnl-bar]",
+            "[data-testid=daily-pnl-summary]",
+            ".daily-pnl",
+            ".pnl-summary-bar"
+          ]
+        },
+        { "action": "screenshot", "name": "trade-09-daily-pnl-summary-bar" }
+      ]
+    },
+    {
+      "id": "TRADE-10",
+      "name": "Order stats panel shows fills, volume, and win rate",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/trades" },
+        { "action": "wait", "selector": "[data-testid=trades-page], [data-testid=trade-list], .trade-list", "timeout": 8000 },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=order-stats-panel]",
+            "[data-testid=stats-fills]",
+            "[data-testid=stats-volume]",
+            "[data-testid=stats-win-rate]",
+            ".order-stats",
+            ".stats-panel"
+          ]
+        },
+        { "action": "screenshot", "name": "trade-10-order-stats-panel" }
+      ]
+    }
+  ]
+}

--- a/docs/test-journeys/03-strategy.json
+++ b/docs/test-journeys/03-strategy.json
@@ -1,0 +1,246 @@
+{
+  "journey": "strategy-proposals",
+  "version": "1.0.0",
+  "description": "Strategy page: war room layout, proposal lifecycle (approve/reject/batch), committee debate, LLM traces, semantic memory, market debates, filtering, and Bull vs Bear split view.",
+  "baseUrl": "http://localhost:3012",
+  "credentials": {
+    "ADMIN": {
+      "username": "admin",
+      "password": "test-password",
+      "role": "ADMIN"
+    }
+  },
+  "setup": {
+    "login": {
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/login"},
+        {"action": "fill", "selector": "input[name=username]", "value": "{{username}}"},
+        {"action": "fill", "selector": "input[name=password]", "value": "{{password}}"},
+        {"action": "click", "selector": "button[type=submit]"},
+        {"action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000}
+      ]
+    }
+  },
+  "testCases": [
+    {
+      "id": "STRAT-01",
+      "name": "Strategy page loads with war room layout",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=strategy-page], .strategy-page, main[class*='strategy']", "timeout": 5000},
+        {"action": "assert", "check": "url contains /ai-trader/strategy"},
+        {"action": "assert", "check": "element visible: [data-testid=strategy-page], .strategy-page, h1"},
+        {"action": "assert", "check": "element visible: nav, [data-testid=sidebar]"},
+        {"action": "screenshot", "name": "strategy-page-war-room-layout"}
+      ]
+    },
+    {
+      "id": "STRAT-02",
+      "name": "Market rating hero displays (A/B/C rating)",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=market-rating], .market-rating, [class*='rating']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=market-rating], .market-rating"},
+        {"action": "assert", "check": "element text matches pattern: [A-C][+-]?|中性|偏多|偏空"},
+        {"action": "screenshot", "name": "strategy-market-rating-hero"}
+      ]
+    },
+    {
+      "id": "STRAT-03",
+      "name": "Active proposal queue renders at top",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=proposal-queue], .proposal-queue, [class*='proposal']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=proposal-queue], [class*='proposal-list'], [class*='proposals']"},
+        {"action": "screenshot", "name": "strategy-active-proposal-queue"}
+      ]
+    },
+    {
+      "id": "STRAT-04",
+      "name": "Proposal cards show status dots (pending/approved/rejected/executed)",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=proposal-card], .proposal-card, [class*='proposal-item']", "timeout": 5000},
+        {"action": "assert", "check": "element count >= 1: [data-testid=proposal-card], .proposal-card, [class*='proposal-item']"},
+        {"action": "assert", "check": "element visible: [data-testid=status-dot], .status-dot, [class*='status'], [class*='badge']"},
+        {"action": "screenshot", "name": "strategy-proposal-cards-status-dots"}
+      ]
+    },
+    {
+      "id": "STRAT-05",
+      "name": "Click approve on a pending proposal",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=proposal-card], .proposal-card", "timeout": 5000},
+        {"action": "assert", "check": "element visible: button[data-action='approve'], button[class*='approve'], button:has-text('核准'), button:has-text('Approve')"},
+        {"action": "click", "selector": "[data-status='pending'] button[data-action='approve'], [data-status='pending'] button[class*='approve'], .proposal-card:first-child button[class*='approve'], .proposal-card:first-child button:has-text('核准')"},
+        {"action": "wait", "selector": "[data-testid=toast], [class*='toast'], [class*='notification'], [role='alert']", "timeout": 3000},
+        {"action": "screenshot", "name": "strategy-approve-pending-proposal"}
+      ]
+    },
+    {
+      "id": "STRAT-06",
+      "name": "Click reject on a pending proposal with reason",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=proposal-card], .proposal-card", "timeout": 5000},
+        {"action": "click", "selector": "[data-status='pending'] button[data-action='reject'], .proposal-card button[class*='reject'], .proposal-card button:has-text('拒絕'), .proposal-card button:has-text('Reject')"},
+        {"action": "wait", "selector": "[data-testid=reject-modal], [class*='modal'], dialog, [role='dialog']", "timeout": 3000},
+        {"action": "fill", "selector": "textarea[name=reason], input[name=reason], [data-testid=reject-reason]", "value": "風險過高，市場不利"},
+        {"action": "click", "selector": "button[data-testid=confirm-reject], button[class*='confirm'], dialog button[class*='reject'], [role='dialog'] button:last-child"},
+        {"action": "wait", "selector": "[data-testid=toast], [class*='toast'], [role='alert']", "timeout": 3000},
+        {"action": "screenshot", "name": "strategy-reject-pending-proposal-with-reason"}
+      ]
+    },
+    {
+      "id": "STRAT-07",
+      "name": "Batch approve multiple proposals (checkbox select + batch action)",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=proposal-card], .proposal-card", "timeout": 5000},
+        {"action": "click", "selector": "[data-testid=proposal-card]:nth-child(1) input[type='checkbox'], .proposal-card:nth-child(1) input[type='checkbox']"},
+        {"action": "click", "selector": "[data-testid=proposal-card]:nth-child(2) input[type='checkbox'], .proposal-card:nth-child(2) input[type='checkbox']"},
+        {"action": "assert", "check": "element visible: [data-testid=batch-actions], .batch-actions, [class*='batch']"},
+        {"action": "click", "selector": "button[data-testid=batch-approve], button[class*='batch-approve'], [class*='batch'] button:has-text('核准'), [class*='batch'] button:has-text('Approve All')"},
+        {"action": "wait", "selector": "[data-testid=toast], [class*='toast'], [role='alert']", "timeout": 3000},
+        {"action": "screenshot", "name": "strategy-batch-approve-proposals"}
+      ]
+    },
+    {
+      "id": "STRAT-08",
+      "name": "Batch reject multiple proposals",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=proposal-card], .proposal-card", "timeout": 5000},
+        {"action": "click", "selector": "[data-testid=proposal-card]:nth-child(1) input[type='checkbox'], .proposal-card:nth-child(1) input[type='checkbox']"},
+        {"action": "click", "selector": "[data-testid=proposal-card]:nth-child(2) input[type='checkbox'], .proposal-card:nth-child(2) input[type='checkbox']"},
+        {"action": "assert", "check": "element visible: [data-testid=batch-actions], .batch-actions, [class*='batch']"},
+        {"action": "click", "selector": "button[data-testid=batch-reject], button[class*='batch-reject'], [class*='batch'] button:has-text('拒絕'), [class*='batch'] button:has-text('Reject All')"},
+        {"action": "wait", "selector": "[data-testid=toast], [class*='toast'], [role='alert']", "timeout": 3000},
+        {"action": "screenshot", "name": "strategy-batch-reject-proposals"}
+      ]
+    },
+    {
+      "id": "STRAT-09",
+      "name": "Committee debate section renders chat bubbles",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=committee-debate], [class*='committee'], [class*='debate']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=committee-debate], [class*='committee-debate'], [class*='debate']"},
+        {"action": "assert", "check": "element count >= 1: [data-testid=chat-bubble], [class*='chat-bubble'], [class*='message-bubble'], [class*='debate-message']"},
+        {"action": "screenshot", "name": "strategy-committee-debate-chat-bubbles"}
+      ]
+    },
+    {
+      "id": "STRAT-10",
+      "name": "LLM trace terminal expands/collapses",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=llm-trace], [class*='llm-trace'], [class*='trace-terminal']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=llm-trace], [class*='llm-trace']"},
+        {"action": "click", "selector": "[data-testid=llm-trace-toggle], [class*='llm-trace'] button[class*='toggle'], [class*='llm-trace'] [class*='expand'], [class*='trace-terminal'] button"},
+        {"action": "wait", "timeout": 500},
+        {"action": "assert", "check": "element visible: [data-testid=llm-trace-content], [class*='trace-content'], [class*='trace-body']"},
+        {"action": "click", "selector": "[data-testid=llm-trace-toggle], [class*='llm-trace'] button[class*='toggle'], [class*='llm-trace'] [class*='expand'], [class*='trace-terminal'] button"},
+        {"action": "wait", "timeout": 500},
+        {"action": "screenshot", "name": "strategy-llm-trace-expand-collapse"}
+      ]
+    },
+    {
+      "id": "STRAT-11",
+      "name": "Semantic memory section displays with confidence scores",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=semantic-memory], [class*='semantic-memory'], [class*='memory']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=semantic-memory], [class*='semantic-memory']"},
+        {"action": "assert", "check": "element visible: [data-testid=confidence-score], [class*='confidence'], [class*='score']"},
+        {"action": "screenshot", "name": "strategy-semantic-memory-confidence-scores"}
+      ]
+    },
+    {
+      "id": "STRAT-12",
+      "name": "Market debates timeline renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=market-debates], [class*='market-debates'], [class*='debates-timeline']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=market-debates], [class*='market-debates'], [class*='debate-timeline']"},
+        {"action": "assert", "check": "element count >= 1: [data-testid=debate-item], [class*='debate-item'], [class*='timeline-item']"},
+        {"action": "screenshot", "name": "strategy-market-debates-timeline"}
+      ]
+    },
+    {
+      "id": "STRAT-13",
+      "name": "Proposal status filter works (pending/approved/rejected)",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=proposal-filter], [class*='filter'], select[name='status']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=proposal-filter], [class*='filter-bar'], [class*='status-filter']"},
+        {"action": "click", "selector": "button[data-filter='pending'], [data-testid=filter-pending], button:has-text('待審'), button:has-text('Pending')"},
+        {"action": "wait", "timeout": 500},
+        {"action": "assert", "check": "element attribute: [data-testid=proposal-card], [data-status='pending']"},
+        {"action": "click", "selector": "button[data-filter='approved'], [data-testid=filter-approved], button:has-text('已核准'), button:has-text('Approved')"},
+        {"action": "wait", "timeout": 500},
+        {"action": "click", "selector": "button[data-filter='rejected'], [data-testid=filter-rejected], button:has-text('已拒絕'), button:has-text('Rejected')"},
+        {"action": "wait", "timeout": 500},
+        {"action": "screenshot", "name": "strategy-proposal-status-filter"}
+      ]
+    },
+    {
+      "id": "STRAT-14",
+      "name": "Proposal pagination works (load more)",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=proposal-card], .proposal-card", "timeout": 5000},
+        {"action": "assert", "check": "element visible: button[data-testid=load-more], button[class*='load-more'], button:has-text('載入更多'), button:has-text('Load More')"},
+        {"action": "evaluate", "script": "document.querySelectorAll('[data-testid=proposal-card], .proposal-card').length", "storeAs": "initialCount"},
+        {"action": "click", "selector": "button[data-testid=load-more], button[class*='load-more'], button:has-text('載入更多'), button:has-text('Load More')"},
+        {"action": "wait", "timeout": 1000},
+        {"action": "assert", "check": "element count increased: [data-testid=proposal-card], .proposal-card"},
+        {"action": "screenshot", "name": "strategy-proposal-pagination-load-more"}
+      ]
+    },
+    {
+      "id": "STRAT-15",
+      "name": "Bull vs Bear split view renders correctly",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/strategy"},
+        {"action": "wait", "selector": "[data-testid=bull-bear-split], [class*='bull-bear'], [class*='split-view']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=bull-panel], [class*='bull-panel'], [class*='bull-side']"},
+        {"action": "assert", "check": "element visible: [data-testid=bear-panel], [class*='bear-panel'], [class*='bear-side']"},
+        {"action": "assert", "check": "element text contains: 多方|Bull|看多"},
+        {"action": "assert", "check": "element text contains: 空方|Bear|看空"},
+        {"action": "screenshot", "name": "strategy-bull-vs-bear-split-view"}
+      ]
+    }
+  ]
+}

--- a/docs/test-journeys/04-system-settings.json
+++ b/docs/test-journeys/04-system-settings.json
@@ -1,0 +1,259 @@
+{
+  "journey": "system-settings",
+  "version": "1.0.0",
+  "description": "System page: service status, health metrics, quota monitoring, risk assessment, events log, incident cluster, quarantine actions, remediation history. Settings page: danger zone, emergency stop, trading mode toggle, capital/position fields, save/persist.",
+  "baseUrl": "http://localhost:3012",
+  "credentials": {
+    "ADMIN": {
+      "username": "admin",
+      "password": "test-password",
+      "role": "ADMIN"
+    }
+  },
+  "setup": {
+    "login": {
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/login"},
+        {"action": "fill", "selector": "input[name=username]", "value": "{{username}}"},
+        {"action": "fill", "selector": "input[name=password]", "value": "{{password}}"},
+        {"action": "click", "selector": "button[type=submit]"},
+        {"action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000}
+      ]
+    }
+  },
+  "testCases": [
+    {
+      "id": "SYS-01",
+      "name": "System page loads with service status panel",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=system-page], .system-page, [class*='system']", "timeout": 5000},
+        {"action": "assert", "check": "url contains /ai-trader/system"},
+        {"action": "assert", "check": "element visible: [data-testid=service-status], [class*='service-status'], [class*='services-panel']"},
+        {"action": "assert", "check": "element count >= 1: [data-testid=service-item], [class*='service-item'], [class*='service-row']"},
+        {"action": "screenshot", "name": "system-page-service-status-panel"}
+      ]
+    },
+    {
+      "id": "SYS-02",
+      "name": "Health metrics display (CPU, memory, disk)",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=health-metrics], [class*='health-metrics'], [class*='metrics']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=health-metrics], [class*='health-metrics']"},
+        {"action": "assert", "check": "element text contains: CPU, cpu, 處理器"},
+        {"action": "assert", "check": "element text contains: Memory, memory, 記憶體"},
+        {"action": "assert", "check": "element text contains: Disk, disk, 磁碟"},
+        {"action": "screenshot", "name": "system-health-metrics-cpu-memory-disk"}
+      ]
+    },
+    {
+      "id": "SYS-03",
+      "name": "Quota monitoring shows API usage",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=quota-monitor], [class*='quota'], [class*='api-usage']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=quota-monitor], [class*='quota-monitor'], [class*='api-quota']"},
+        {"action": "assert", "check": "element visible: [class*='usage-bar'], [class*='progress'], [role='progressbar']"},
+        {"action": "screenshot", "name": "system-quota-monitoring-api-usage"}
+      ]
+    },
+    {
+      "id": "SYS-04",
+      "name": "Risk assessment section renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=risk-assessment], [class*='risk-assessment'], [class*='risk']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=risk-assessment], [class*='risk-assessment']"},
+        {"action": "screenshot", "name": "system-risk-assessment-section"}
+      ]
+    },
+    {
+      "id": "SYS-05",
+      "name": "System events log displays",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=system-events], [class*='system-events'], [class*='event-log']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=system-events], [class*='system-events'], [class*='events-log']"},
+        {"action": "assert", "check": "element count >= 1: [data-testid=event-item], [class*='event-item'], [class*='log-entry']"},
+        {"action": "screenshot", "name": "system-events-log"}
+      ]
+    },
+    {
+      "id": "SYS-06",
+      "name": "Incident cluster section renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=incident-cluster], [class*='incident-cluster'], [class*='incidents']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=incident-cluster], [class*='incident-cluster'], [class*='incident']"},
+        {"action": "screenshot", "name": "system-incident-cluster-section"}
+      ]
+    },
+    {
+      "id": "SYS-07",
+      "name": "Quarantine status displays",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=quarantine-status], [class*='quarantine'], [class*='quarantine-panel']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=quarantine-status], [class*='quarantine-status'], [class*='quarantine']"},
+        {"action": "screenshot", "name": "system-quarantine-status"}
+      ]
+    },
+    {
+      "id": "SYS-08",
+      "name": "Quarantine apply action works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=quarantine-status], [class*='quarantine']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: button[data-testid=quarantine-apply], button[class*='quarantine-apply'], button:has-text('隔離'), button:has-text('Quarantine'), button:has-text('Apply')"},
+        {"action": "click", "selector": "button[data-testid=quarantine-apply], button[class*='quarantine-apply'], [class*='quarantine'] button:has-text('Apply'), [class*='quarantine'] button:has-text('隔離')"},
+        {"action": "wait", "selector": "[data-testid=toast], [class*='toast'], [role='alert'], [class*='confirm-modal']", "timeout": 3000},
+        {"action": "screenshot", "name": "system-quarantine-apply-action"}
+      ]
+    },
+    {
+      "id": "SYS-09",
+      "name": "Quarantine clear action works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=quarantine-status], [class*='quarantine']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: button[data-testid=quarantine-clear], button[class*='quarantine-clear'], button:has-text('清除隔離'), button:has-text('Clear'), button:has-text('解除')"},
+        {"action": "click", "selector": "button[data-testid=quarantine-clear], button[class*='quarantine-clear'], [class*='quarantine'] button:has-text('Clear'), [class*='quarantine'] button:has-text('清除')"},
+        {"action": "wait", "selector": "[data-testid=toast], [class*='toast'], [role='alert']", "timeout": 3000},
+        {"action": "screenshot", "name": "system-quarantine-clear-action"}
+      ]
+    },
+    {
+      "id": "SYS-10",
+      "name": "Remediation history shows",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=remediation-history], [class*='remediation'], [class*='history']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=remediation-history], [class*='remediation-history']"},
+        {"action": "screenshot", "name": "system-remediation-history"}
+      ]
+    },
+    {
+      "id": "SET-01",
+      "name": "Settings page loads with danger zone",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=settings-page], [data-testid=system-page], [class*='settings'], [class*='system-page']", "timeout": 5000},
+        {"action": "assert", "check": "url contains /ai-trader/system"},
+        {"action": "assert", "check": "element visible: [data-testid=danger-zone], [class*='danger-zone'], section:has(h2:has-text('危險')), section:has(h2:has-text('Danger'))"},
+        {"action": "screenshot", "name": "settings-page-with-danger-zone"}
+      ]
+    },
+    {
+      "id": "SET-02",
+      "name": "Emergency stop toggle visible",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=emergency-stop], [class*='emergency-stop'], button[class*='emergency']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=emergency-stop], [class*='emergency-stop'], button:has-text('緊急停止'), button:has-text('Emergency Stop')"},
+        {"action": "screenshot", "name": "settings-emergency-stop-toggle"}
+      ]
+    },
+    {
+      "id": "SET-03",
+      "name": "Trading mode toggle (paper/live) visible",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=trading-mode], [class*='trading-mode'], [class*='simulation']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=trading-mode-toggle], [class*='trading-mode'], [class*='simulation-toggle']"},
+        {"action": "assert", "check": "element text contains: 模擬|Paper|Simulation|實盤|Live"},
+        {"action": "screenshot", "name": "settings-trading-mode-toggle-visible"}
+      ]
+    },
+    {
+      "id": "SET-04",
+      "name": "Capital/initial balance field editable",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=capital-field], input[name='capital'], input[name='initial_balance'], input[placeholder*='資本'], input[placeholder*='capital']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=capital-field], input[name='capital'], input[name='initial_balance']"},
+        {"action": "triple-click", "selector": "[data-testid=capital-field], input[name='capital'], input[name='initial_balance']"},
+        {"action": "fill", "selector": "[data-testid=capital-field], input[name='capital'], input[name='initial_balance']", "value": "1000000"},
+        {"action": "assert", "check": "element value: 1000000"},
+        {"action": "screenshot", "name": "settings-capital-field-editable"}
+      ]
+    },
+    {
+      "id": "SET-05",
+      "name": "Max position size field editable",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "[data-testid=max-position-size], input[name='max_position_size'], input[name='position_size']", "timeout": 5000},
+        {"action": "assert", "check": "element visible: [data-testid=max-position-size], input[name='max_position_size'], input[name='position_size']"},
+        {"action": "triple-click", "selector": "[data-testid=max-position-size], input[name='max_position_size'], input[name='position_size']"},
+        {"action": "fill", "selector": "[data-testid=max-position-size], input[name='max_position_size'], input[name='position_size']", "value": "50000"},
+        {"action": "assert", "check": "element value: 50000"},
+        {"action": "screenshot", "name": "settings-max-position-size-editable"}
+      ]
+    },
+    {
+      "id": "SET-06",
+      "name": "Save settings button works (dirty tracking)",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "input[name='capital'], input[name='max_position_size'], [data-testid=capital-field]", "timeout": 5000},
+        {"action": "triple-click", "selector": "input[name='capital'], input[name='initial_balance'], [data-testid=capital-field]"},
+        {"action": "fill", "selector": "input[name='capital'], input[name='initial_balance'], [data-testid=capital-field]", "value": "2000000"},
+        {"action": "assert", "check": "element visible: button[data-testid=save-settings]:not([disabled]), button[class*='save']:not([disabled]), button:has-text('儲存'), button:has-text('Save')"},
+        {"action": "click", "selector": "button[data-testid=save-settings], button[class*='save-settings'], button:has-text('儲存設定'), button:has-text('Save Settings'), button:has-text('Save')"},
+        {"action": "wait", "selector": "[data-testid=toast], [class*='toast'], [role='alert']", "timeout": 3000},
+        {"action": "screenshot", "name": "settings-save-button-dirty-tracking"}
+      ]
+    },
+    {
+      "id": "SET-07",
+      "name": "Settings persist after page reload",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "input[name='capital'], [data-testid=capital-field]", "timeout": 5000},
+        {"action": "triple-click", "selector": "input[name='capital'], input[name='initial_balance'], [data-testid=capital-field]"},
+        {"action": "fill", "selector": "input[name='capital'], input[name='initial_balance'], [data-testid=capital-field]", "value": "3000000"},
+        {"action": "click", "selector": "button[data-testid=save-settings], button[class*='save-settings'], button:has-text('儲存設定'), button:has-text('Save Settings'), button:has-text('Save')"},
+        {"action": "wait", "selector": "[data-testid=toast], [class*='toast'], [role='alert']", "timeout": 3000},
+        {"action": "navigate", "url": "/ai-trader/system"},
+        {"action": "wait", "selector": "input[name='capital'], [data-testid=capital-field]", "timeout": 5000},
+        {"action": "assert", "check": "element value equals: 3000000"},
+        {"action": "screenshot", "name": "settings-persist-after-reload"}
+      ]
+    }
+  ]
+}

--- a/docs/test-journeys/05-analysis-research.json
+++ b/docs/test-journeys/05-analysis-research.json
@@ -1,0 +1,494 @@
+{
+  "journey": "analysis-research",
+  "version": "1.0.0",
+  "description": "Analysis and Research module journeys for ai-trader frontend. Covers K-line charts, technical indicators, AI strategy recommendations, institutional flow, and the Research sub-pages (stock, macro, screener, sector).",
+  "baseUrl": "http://localhost:3012",
+  "credentials": {
+    "ADMIN": {
+      "username": "admin",
+      "password": "test-password",
+      "role": "ADMIN"
+    }
+  },
+  "setup": {
+    "login": {
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "fill", "selector": "input[name=username]", "value": "{{username}}" },
+        { "action": "fill", "selector": "input[name=password]", "value": "{{password}}" },
+        { "action": "click", "selector": "button[type=submit]" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 }
+      ]
+    }
+  },
+  "testCases": [
+    {
+      "id": "ANA-01",
+      "name": "Analysis page loads",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/analysis" },
+        { "action": "wait", "selector": "[data-testid=analysis-page], .analysis-page, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/analysis" },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=analysis-page], .analysis-page, main" },
+        { "action": "screenshot", "name": "ana-01-analysis-page-loads" }
+      ]
+    },
+    {
+      "id": "ANA-02",
+      "name": "K-line candlestick chart renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/analysis" },
+        { "action": "wait", "selector": "[data-testid=analysis-page], .analysis-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=kline-chart], .kline-chart, svg.candlestick, canvas[data-chart=kline]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=kline-chart], .kline-chart, svg.candlestick, canvas[data-chart=kline]"
+        },
+        { "action": "screenshot", "name": "ana-02-kline-candlestick-chart-renders" }
+      ]
+    },
+    {
+      "id": "ANA-03",
+      "name": "Technical indicators section displays RSI, MACD, Bollinger",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/analysis" },
+        { "action": "wait", "selector": "[data-testid=analysis-page], .analysis-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=technical-indicators], .technical-indicators, .indicators-section",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=rsi-indicator]",
+            ".rsi-value",
+            "[data-label=RSI]",
+            "text=RSI"
+          ]
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=macd-indicator]",
+            ".macd-value",
+            "[data-label=MACD]",
+            "text=MACD"
+          ]
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=bollinger-indicator]",
+            ".bollinger-value",
+            "[data-label=Bollinger]",
+            "text=布林"
+          ]
+        },
+        { "action": "screenshot", "name": "ana-03-technical-indicators-rsi-macd-bollinger" }
+      ]
+    },
+    {
+      "id": "ANA-04",
+      "name": "AI strategy recommendation section renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/analysis" },
+        { "action": "wait", "selector": "[data-testid=analysis-page], .analysis-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=ai-strategy], .ai-strategy-section, .strategy-recommendation, [data-testid=ai-recommendation]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=ai-strategy], .ai-strategy-section, .strategy-recommendation, [data-testid=ai-recommendation]"
+        },
+        { "action": "screenshot", "name": "ana-04-ai-strategy-recommendation-renders" }
+      ]
+    },
+    {
+      "id": "ANA-05",
+      "name": "Sentiment badge shows Bullish/Bearish/Neutral",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/analysis" },
+        { "action": "wait", "selector": "[data-testid=analysis-page], .analysis-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=sentiment-badge], .sentiment-badge, .sentiment-indicator",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=sentiment-badge]",
+            ".sentiment-badge",
+            "[data-sentiment=bullish]",
+            "[data-sentiment=bearish]",
+            "[data-sentiment=neutral]",
+            "text=Bullish",
+            "text=Bearish",
+            "text=Neutral",
+            "text=多頭",
+            "text=空頭",
+            "text=中立"
+          ]
+        },
+        { "action": "screenshot", "name": "ana-05-sentiment-badge-displays" }
+      ]
+    },
+    {
+      "id": "ANA-06",
+      "name": "Institutional flow heatmap renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/analysis" },
+        { "action": "wait", "selector": "[data-testid=analysis-page], .analysis-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=institution-heatmap], .institution-heatmap, .chips-heatmap, [data-testid=institutional-flow]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=institution-heatmap], .institution-heatmap, .chips-heatmap, [data-testid=institutional-flow]"
+        },
+        { "action": "screenshot", "name": "ana-06-institutional-flow-heatmap-renders" }
+      ]
+    },
+    {
+      "id": "ANA-07",
+      "name": "Historical analysis comparison works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/analysis" },
+        { "action": "wait", "selector": "[data-testid=analysis-page], .analysis-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=date-picker], .date-picker, input[type=date], [data-testid=history-selector], select[name=date]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=date-picker], .date-picker, input[type=date], [data-testid=history-selector], select[name=date]"
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=date-picker], .date-picker, [data-testid=history-selector]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=analysis-content], .analysis-content, [data-testid=analysis-result]",
+          "timeout": 6000
+        },
+        { "action": "screenshot", "name": "ana-07-historical-analysis-comparison" }
+      ]
+    },
+    {
+      "id": "RES-01",
+      "name": "Research dashboard loads with overview",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research" },
+        { "action": "wait", "selector": "[data-testid=research-page], .research-page, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/research" },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=research-page], .research-page, main" },
+        { "action": "screenshot", "name": "res-01-research-dashboard-loads" }
+      ]
+    },
+    {
+      "id": "RES-02",
+      "name": "Stock research tab navigates correctly",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research" },
+        { "action": "wait", "selector": "[data-testid=research-page], .research-page, main", "timeout": 5000 },
+        {
+          "action": "click",
+          "selector": "[data-testid=tab-stock], a[href*=stock], button[data-tab=stock], [role=tab][data-value=stock]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=stock-research], .stock-research-tab, [data-panel=stock]",
+          "timeout": 5000
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=stock-research]",
+            ".stock-research-tab",
+            "[data-panel=stock]"
+          ]
+        },
+        { "action": "screenshot", "name": "res-02-stock-research-tab-navigates" }
+      ]
+    },
+    {
+      "id": "RES-03",
+      "name": "Stock research shows financial data",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research/stock" },
+        { "action": "wait", "selector": "[data-testid=stock-research], .stock-research-tab, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=financial-data], .financial-data, .stock-financials, table",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=financial-data], .financial-data, .stock-financials, table"
+        },
+        { "action": "screenshot", "name": "res-03-stock-research-financial-data" }
+      ]
+    },
+    {
+      "id": "RES-04",
+      "name": "Macro analysis tab loads economic indicators",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research/macro" },
+        { "action": "wait", "selector": "[data-testid=macro-page], .macro-analysis, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/research" },
+        {
+          "action": "wait",
+          "selector": "[data-testid=economic-indicators], .economic-indicators, .macro-indicators",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=economic-indicators], .economic-indicators, .macro-indicators"
+        },
+        { "action": "screenshot", "name": "res-04-macro-analysis-economic-indicators" }
+      ]
+    },
+    {
+      "id": "RES-05",
+      "name": "Screener tab loads with filter controls",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research/screener" },
+        { "action": "wait", "selector": "[data-testid=screener-page], .screener-page, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/research" },
+        {
+          "action": "wait",
+          "selector": "[data-testid=screener-filters], .screener-filters, .filter-panel, form.filters",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=screener-filters], .screener-filters, .filter-panel, form.filters"
+        },
+        { "action": "screenshot", "name": "res-05-screener-tab-filter-controls" }
+      ]
+    },
+    {
+      "id": "RES-06",
+      "name": "Screener filter by RSI works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research/screener" },
+        { "action": "wait", "selector": "[data-testid=screener-filters], .screener-filters, .filter-panel", "timeout": 5000 },
+        {
+          "action": "fill",
+          "selector": "[data-testid=rsi-min], input[name=rsi_min], input[placeholder*=RSI]",
+          "value": "30"
+        },
+        {
+          "action": "fill",
+          "selector": "[data-testid=rsi-max], input[name=rsi_max]",
+          "value": "70"
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=apply-filters], button[type=submit], button[data-action=screen]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=screener-results], .screener-results, table tbody tr",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=screener-results], .screener-results, table tbody"
+        },
+        { "action": "screenshot", "name": "res-06-screener-filter-rsi" }
+      ]
+    },
+    {
+      "id": "RES-07",
+      "name": "Screener filter by P/E works",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research/screener" },
+        { "action": "wait", "selector": "[data-testid=screener-filters], .screener-filters, .filter-panel", "timeout": 5000 },
+        {
+          "action": "fill",
+          "selector": "[data-testid=pe-max], input[name=pe_max], input[placeholder*=P/E], input[placeholder*=本益比]",
+          "value": "20"
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=apply-filters], button[type=submit], button[data-action=screen]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=screener-results], .screener-results, table tbody tr",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=screener-results], .screener-results, table tbody"
+        },
+        { "action": "screenshot", "name": "res-07-screener-filter-pe" }
+      ]
+    },
+    {
+      "id": "RES-08",
+      "name": "Screener results table renders with sorting",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research/screener" },
+        { "action": "wait", "selector": "[data-testid=screener-page], .screener-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=screener-results] table, .screener-results table, table.screener-table",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=screener-results] table, .screener-results table, table.screener-table"
+        },
+        {
+          "action": "click",
+          "selector": "th[data-sortable=true], th[role=columnheader], th.sortable, th[aria-sort]"
+        },
+        {
+          "action": "wait",
+          "selector": "th[aria-sort=ascending], th[aria-sort=descending], th.sorted-asc, th.sorted-desc",
+          "timeout": 3000
+        },
+        { "action": "screenshot", "name": "res-08-screener-results-table-sorting" }
+      ]
+    },
+    {
+      "id": "RES-09",
+      "name": "Sector analysis tab loads",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research/sector" },
+        { "action": "wait", "selector": "[data-testid=sector-page], .sector-analysis, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/research" },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=sector-page], .sector-analysis, main"
+        },
+        { "action": "screenshot", "name": "res-09-sector-analysis-tab-loads" }
+      ]
+    },
+    {
+      "id": "RES-10",
+      "name": "Sector performance comparison chart renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research/sector" },
+        { "action": "wait", "selector": "[data-testid=sector-page], .sector-analysis, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=sector-chart], .sector-performance-chart, svg.sector-chart, canvas[data-chart=sector]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=sector-chart], .sector-performance-chart, svg.sector-chart, canvas[data-chart=sector]"
+        },
+        { "action": "screenshot", "name": "res-10-sector-performance-chart-renders" }
+      ]
+    },
+    {
+      "id": "RES-11",
+      "name": "Research sub-navigation tabs work correctly",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/research" },
+        { "action": "wait", "selector": "[data-testid=research-page], .research-page, main", "timeout": 5000 },
+        {
+          "action": "assert",
+          "check": "element_exists",
+          "selector": "[data-testid=research-tabs], .research-tabs, nav[aria-label*=research i], [role=tablist]"
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=tab-macro], a[href*=macro], button[data-tab=macro], [role=tab][data-value=macro]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=macro-page], .macro-analysis, [data-panel=macro]",
+          "timeout": 5000
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=tab-screener], a[href*=screener], button[data-tab=screener], [role=tab][data-value=screener]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=screener-page], .screener-page, [data-panel=screener]",
+          "timeout": 5000
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=tab-sector], a[href*=sector], button[data-tab=sector], [role=tab][data-value=sector]"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=sector-page], .sector-analysis, [data-panel=sector]",
+          "timeout": 5000
+        },
+        { "action": "screenshot", "name": "res-11-research-sub-navigation-tabs" }
+      ]
+    }
+  ]
+}

--- a/docs/test-journeys/06-dashboard-agents.json
+++ b/docs/test-journeys/06-dashboard-agents.json
@@ -1,0 +1,620 @@
+{
+  "journey": "dashboard-agents",
+  "version": "1.0.0",
+  "description": "Dashboard, Agents, Risk, and Geopolitical module journeys for ai-trader frontend. Covers indices snapshot, portfolio KPIs, action queue, agent mission control, execution timeline, risk KPI cards, sector treemap, stress tests, and geopolitical globe.",
+  "baseUrl": "http://localhost:3012",
+  "credentials": {
+    "ADMIN": {
+      "username": "admin",
+      "password": "test-password",
+      "role": "ADMIN"
+    }
+  },
+  "setup": {
+    "login": {
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/login" },
+        { "action": "fill", "selector": "input[name=username]", "value": "{{username}}" },
+        { "action": "fill", "selector": "input[name=password]", "value": "{{password}}" },
+        { "action": "click", "selector": "button[type=submit]" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 }
+      ]
+    }
+  },
+  "testCases": [
+    {
+      "id": "DASH-01",
+      "name": "Dashboard page loads",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=dashboard]" },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=dashboard]",
+            ".dashboard-page",
+            "main[data-page=dashboard]"
+          ]
+        },
+        { "action": "screenshot", "name": "dash-01-dashboard-page-loads" }
+      ]
+    },
+    {
+      "id": "DASH-02",
+      "name": "Indices snapshot renders with TWII, VIX etc.",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=indices-snapshot], .indices-snapshot, .market-indices, [data-testid=market-overview]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=indices-snapshot], .indices-snapshot, .market-indices, [data-testid=market-overview]"
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=twii-index]",
+            ".twii-value",
+            "text=TWII",
+            "text=加權指數",
+            "text=TAIEX"
+          ]
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=vix-index]",
+            ".vix-value",
+            "text=VIX"
+          ]
+        },
+        { "action": "screenshot", "name": "dash-02-indices-snapshot-twii-vix" }
+      ]
+    },
+    {
+      "id": "DASH-03",
+      "name": "Portfolio summary KPIs display",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=portfolio-summary], .portfolio-summary, .portfolio-kpi",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=portfolio-summary], .portfolio-summary, .portfolio-kpi"
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=total-pnl]",
+            ".total-pnl",
+            "[data-kpi=unrealized_pnl]",
+            "text=未實現損益",
+            "text=Total P&L"
+          ]
+        },
+        { "action": "screenshot", "name": "dash-03-portfolio-summary-kpis" }
+      ]
+    },
+    {
+      "id": "DASH-04",
+      "name": "Latest analysis snapshot section renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=analysis-snapshot], .analysis-snapshot, .latest-analysis, [data-testid=eod-analysis]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=analysis-snapshot], .analysis-snapshot, .latest-analysis, [data-testid=eod-analysis]"
+        },
+        { "action": "screenshot", "name": "dash-04-latest-analysis-snapshot" }
+      ]
+    },
+    {
+      "id": "DASH-05",
+      "name": "Risk snapshot section renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=risk-snapshot], .risk-snapshot, .risk-summary, [data-testid=risk-overview]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=risk-snapshot], .risk-snapshot, .risk-summary, [data-testid=risk-overview]"
+        },
+        { "action": "screenshot", "name": "dash-05-risk-snapshot-renders" }
+      ]
+    },
+    {
+      "id": "DASH-06",
+      "name": "Action queue displays AI suggestions",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=action-queue], .action-queue, .ai-suggestions, [data-testid=proposals-feed]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=action-queue], .action-queue, .ai-suggestions, [data-testid=proposals-feed]"
+        },
+        { "action": "screenshot", "name": "dash-06-action-queue-ai-suggestions" }
+      ]
+    },
+    {
+      "id": "DASH-07",
+      "name": "Top gainers/losers section renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=gainers-losers], .top-gainers, .top-losers, .gainers-losers-section",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=gainers-losers], .top-gainers, .top-losers, .gainers-losers-section"
+        },
+        { "action": "screenshot", "name": "dash-07-top-gainers-losers" }
+      ]
+    },
+    {
+      "id": "DASH-08",
+      "name": "Navigation links to detail pages work",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "click",
+          "selector": "a[href*=/ai-trader/portfolio], [data-testid=nav-portfolio], nav a[href*=portfolio]"
+        },
+        { "action": "wait", "selector": "[data-testid=portfolio-page], .portfolio-page, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/portfolio" },
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "click",
+          "selector": "a[href*=/ai-trader/strategy], [data-testid=nav-strategy], nav a[href*=strategy]"
+        },
+        { "action": "wait", "selector": "[data-testid=strategy-page], .strategy-page, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/strategy" },
+        { "action": "screenshot", "name": "dash-08-navigation-links-detail-pages" }
+      ]
+    },
+    {
+      "id": "DASH-09",
+      "name": "Dashboard auto-refreshes data",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/" },
+        { "action": "wait", "selector": "[data-testid=dashboard]", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=last-updated], .last-updated, [data-testid=refresh-indicator], .refresh-indicator, time[data-auto-refresh]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-testid=last-updated]",
+            ".last-updated",
+            "[data-testid=refresh-indicator]",
+            "text=最後更新",
+            "text=Last updated"
+          ]
+        },
+        { "action": "wait", "timeout": 6000 },
+        { "action": "screenshot", "name": "dash-09-dashboard-auto-refresh" }
+      ]
+    },
+    {
+      "id": "AGT-01",
+      "name": "Agents page loads with mission control layout",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/agents" },
+        { "action": "assert", "check": "element_visible", "selector": "[data-testid=agents-page], .agents-page, main" },
+        { "action": "screenshot", "name": "agt-01-agents-page-mission-control" }
+      ]
+    },
+    {
+      "id": "AGT-02",
+      "name": "Agent status bar shows total, running, errors, uptime",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=agent-status-bar], .agent-status-bar, .agent-stats-header",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=agent-status-bar], .agent-status-bar, .agent-stats-header"
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-stat=total]",
+            "[data-testid=agent-total]",
+            "text=Total",
+            "text=總計"
+          ]
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-stat=running]",
+            "[data-testid=agent-running]",
+            "text=Running",
+            "text=執行中"
+          ]
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-stat=errors]",
+            "[data-testid=agent-errors]",
+            "text=Errors",
+            "text=錯誤"
+          ]
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-stat=uptime]",
+            "[data-testid=agent-uptime]",
+            "text=Uptime",
+            "text=運行時間"
+          ]
+        },
+        { "action": "screenshot", "name": "agt-02-agent-status-bar" }
+      ]
+    },
+    {
+      "id": "AGT-03",
+      "name": "Active agents display as large cards",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=active-agents], .active-agents, [data-status=active], .agent-card--active",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=active-agents], .active-agents, [data-status=active], .agent-card--active"
+        },
+        { "action": "screenshot", "name": "agt-03-active-agents-large-cards" }
+      ]
+    },
+    {
+      "id": "AGT-04",
+      "name": "Idle agents display as small cards",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=idle-agents], .idle-agents, [data-status=idle], .agent-card--idle",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=idle-agents], .idle-agents, [data-status=idle], .agent-card--idle"
+        },
+        { "action": "screenshot", "name": "agt-04-idle-agents-small-cards" }
+      ]
+    },
+    {
+      "id": "AGT-05",
+      "name": "Error agents pulse red",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=agents-page], .agents-page, main",
+          "timeout": 5000
+        },
+        {
+          "action": "assert",
+          "check": "any_element_exists",
+          "selectors": [
+            "[data-status=error]",
+            ".agent-card--error",
+            "[data-testid=agent-error]",
+            ".agent-error-pulse",
+            ".pulse-red"
+          ]
+        },
+        { "action": "screenshot", "name": "agt-05-error-agents-pulse-red" }
+      ]
+    },
+    {
+      "id": "AGT-06",
+      "name": "Execution timeline renders in sidebar",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=execution-timeline], .execution-timeline, .timeline-sidebar, aside .timeline",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=execution-timeline], .execution-timeline, .timeline-sidebar, aside .timeline"
+        },
+        { "action": "screenshot", "name": "agt-06-execution-timeline-sidebar" }
+      ]
+    },
+    {
+      "id": "AGT-07",
+      "name": "Run agent button triggers confirmation",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=run-agent-btn], button[data-action=run-agent], .run-agent-button",
+          "timeout": 8000
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=run-agent-btn]:first-of-type, button[data-action=run-agent]:first-of-type, .run-agent-button:first-of-type"
+        },
+        {
+          "action": "wait",
+          "selector": "[data-testid=confirm-dialog], [role=dialog], .confirm-modal, .modal",
+          "timeout": 5000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=confirm-dialog], [role=dialog], .confirm-modal, .modal"
+        },
+        {
+          "action": "click",
+          "selector": "[data-testid=cancel-btn], button[data-action=cancel], .modal button:last-of-type, [role=dialog] button:last-of-type"
+        },
+        { "action": "screenshot", "name": "agt-07-run-agent-confirmation-dialog" }
+      ]
+    },
+    {
+      "id": "AGT-08",
+      "name": "Agent history panel shows last runs",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=agent-history], .agent-history, .agent-run-history, [data-testid=last-runs]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=agent-history], .agent-history, .agent-run-history, [data-testid=last-runs]"
+        },
+        { "action": "screenshot", "name": "agt-08-agent-history-last-runs" }
+      ]
+    },
+    {
+      "id": "AGT-09",
+      "name": "Confidence badge displays percentage",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=confidence-badge], .confidence-badge, [data-label=confidence], .agent-confidence",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=confidence-badge], .confidence-badge, [data-label=confidence], .agent-confidence"
+        },
+        { "action": "screenshot", "name": "agt-09-confidence-badge-percentage" }
+      ]
+    },
+    {
+      "id": "AGT-10",
+      "name": "Agent latency metrics display",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/agents" },
+        { "action": "wait", "selector": "[data-testid=agents-page], .agents-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=agent-latency], .agent-latency, [data-metric=latency], .latency-badge",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=agent-latency], .agent-latency, [data-metric=latency], .latency-badge"
+        },
+        { "action": "screenshot", "name": "agt-10-agent-latency-metrics" }
+      ]
+    },
+    {
+      "id": "RISK-01",
+      "name": "Risk page loads with KPI cards",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/risk" },
+        { "action": "wait", "selector": "[data-testid=risk-page], .risk-page, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/risk" },
+        {
+          "action": "wait",
+          "selector": "[data-testid=risk-kpi], .risk-kpi-cards, .kpi-card, [data-testid=risk-metrics]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=risk-kpi], .risk-kpi-cards, .kpi-card, [data-testid=risk-metrics]"
+        },
+        { "action": "screenshot", "name": "risk-01-risk-page-kpi-cards" }
+      ]
+    },
+    {
+      "id": "RISK-02",
+      "name": "Sector concentration treemap renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/risk" },
+        { "action": "wait", "selector": "[data-testid=risk-page], .risk-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=sector-treemap], .sector-treemap, svg.treemap, [data-chart=treemap]",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=sector-treemap], .sector-treemap, svg.treemap, [data-chart=treemap]"
+        },
+        { "action": "screenshot", "name": "risk-02-sector-concentration-treemap" }
+      ]
+    },
+    {
+      "id": "RISK-03",
+      "name": "Stress test results display",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/risk" },
+        { "action": "wait", "selector": "[data-testid=risk-page], .risk-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=stress-test], .stress-test-results, [data-testid=scenario-results], .scenario-card",
+          "timeout": 8000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=stress-test], .stress-test-results, [data-testid=scenario-results], .scenario-card"
+        },
+        { "action": "screenshot", "name": "risk-03-stress-test-results" }
+      ]
+    },
+    {
+      "id": "GEO-01",
+      "name": "Geopolitical page loads",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/geopolitical" },
+        { "action": "wait", "selector": "[data-testid=geopolitical-page], .geopolitical-page, main", "timeout": 5000 },
+        { "action": "assert", "check": "url_contains", "value": "/ai-trader/geopolitical" },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=geopolitical-page], .geopolitical-page, main"
+        },
+        { "action": "screenshot", "name": "geo-01-geopolitical-page-loads" }
+      ]
+    },
+    {
+      "id": "GEO-02",
+      "name": "Globe visualization renders",
+      "role": "ADMIN",
+      "setup": "login",
+      "steps": [
+        { "action": "navigate", "url": "/ai-trader/geopolitical" },
+        { "action": "wait", "selector": "[data-testid=geopolitical-page], .geopolitical-page, main", "timeout": 5000 },
+        {
+          "action": "wait",
+          "selector": "[data-testid=globe-viz], .globe-visualization, canvas.globe, svg.globe, [data-component=globe]",
+          "timeout": 10000
+        },
+        {
+          "action": "assert",
+          "check": "element_visible",
+          "selector": "[data-testid=globe-viz], .globe-visualization, canvas.globe, svg.globe, [data-component=globe]"
+        },
+        { "action": "screenshot", "name": "geo-02-globe-visualization-renders" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- 新增 6 個 E2E 測試旅程 JSON 檔案，共 106 個 test cases
- 涵蓋所有前端頁面：Auth、Portfolio、Trades、Strategy、System、Settings、Analysis、Research、Dashboard、Agents、Risk、Geopolitical

Closes #609

## Test plan
- [x] 所有 JSON 檔案格式驗證通過
- [x] 每個 test case 包含 screenshot 收尾步驟

🤖 Generated with [Claude Code](https://claude.com/claude-code)