### PR TITLE
chore: add E2E journey execution isolation (#617)

### DIFF
--- a/docs/test-journeys/01-auth.json
+++ b/docs/test-journeys/01-auth.json
@@ -233,6 +233,10 @@
       "setup": null,
       "steps": [
         {
+          "action": "navigate",
+          "url": "/ai-trader/login"
+        },
+        {
           "action": "clear_storage",
           "keys": [
             "token",
@@ -266,6 +270,10 @@
       "role": "ADMIN",
       "setup": "login",
       "steps": [
+        {
+          "action": "navigate",
+          "url": "/ai-trader/login"
+        },
         {
           "action": "wait",
           "selector": "nav, [class*='sidebar']",
@@ -304,6 +312,10 @@
       "note": "BLOCKED — requires network interception (Playwright route or similar). Cannot be tested with basic navigate/click actions. Skip or implement with a dedicated E2E framework that supports request interception.",
       "steps": [
         {
+          "action": "navigate",
+          "url": "/ai-trader/login"
+        },
+        {
           "action": "screenshot",
           "name": "auth-07-blocked-requires-route-interception"
         }
@@ -315,6 +327,10 @@
       "role": "ADMIN",
       "setup": "login",
       "steps": [
+        {
+          "action": "navigate",
+          "url": "/ai-trader/login"
+        },
         {
           "action": "wait",
           "selector": "nav, [class*='sidebar']",
@@ -355,6 +371,10 @@
       "role": "ADMIN",
       "setup": "login",
       "steps": [
+        {
+          "action": "navigate",
+          "url": "/ai-trader/login"
+        },
         {
           "action": "wait",
           "selector": "nav, [class*='sidebar']",
@@ -435,5 +455,10 @@
         }
       ]
     }
-  ]
+  ],
+  "execution": {
+    "mode": "sequential",
+    "isolation": "context",
+    "notes": "Each journey MUST run in its own browser context. Do NOT share browser tabs across journeys."
+  }
 }

--- a/docs/test-journeys/02-portfolio-trades.json
+++ b/docs/test-journeys/02-portfolio-trades.json
@@ -702,5 +702,10 @@
         }
       ]
     }
-  ]
+  ],
+  "execution": {
+    "mode": "sequential",
+    "isolation": "context",
+    "notes": "Each journey MUST run in its own browser context. Do NOT share browser tabs across journeys."
+  }
 }

--- a/docs/test-journeys/03-strategy.json
+++ b/docs/test-journeys/03-strategy.json
@@ -551,5 +551,10 @@
         }
       ]
     }
-  ]
+  ],
+  "execution": {
+    "mode": "sequential",
+    "isolation": "context",
+    "notes": "Each journey MUST run in its own browser context. Do NOT share browser tabs across journeys."
+  }
 }

--- a/docs/test-journeys/04-system-settings.json
+++ b/docs/test-journeys/04-system-settings.json
@@ -413,5 +413,10 @@
         }
       ]
     }
-  ]
+  ],
+  "execution": {
+    "mode": "sequential",
+    "isolation": "context",
+    "notes": "Each journey MUST run in its own browser context. Do NOT share browser tabs across journeys."
+  }
 }

--- a/docs/test-journeys/05-analysis-research.json
+++ b/docs/test-journeys/05-analysis-research.json
@@ -663,5 +663,10 @@
         }
       ]
     }
-  ]
+  ],
+  "execution": {
+    "mode": "sequential",
+    "isolation": "context",
+    "notes": "Each journey MUST run in its own browser context. Do NOT share browser tabs across journeys."
+  }
 }

--- a/docs/test-journeys/06-dashboard-agents.json
+++ b/docs/test-journeys/06-dashboard-agents.json
@@ -971,5 +971,10 @@
         }
       ]
     }
-  ]
+  ],
+  "execution": {
+    "mode": "sequential",
+    "isolation": "context",
+    "notes": "Each journey MUST run in its own browser context. Do NOT share browser tabs across journeys."
+  }
 }


### PR DESCRIPTION
## Summary
- 6 個 journey 檔案加入 `execution.mode=sequential` + `isolation=context`
- 97 test cases 全部第一步強制 navigate（自包含）

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)