### PR TITLE
fix: dashboard 404 + CORS (#619)

### DIFF
--- a/frontend/web/src/components/GlobalTicker.jsx
+++ b/frontend/web/src/components/GlobalTicker.jsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 // API fetch
 // ---------------------------------------------------------------------------
 
-const API_BASE = (import.meta?.env?.VITE_API_BASE ?? 'http://localhost:8080').replace(/\/$/, '')
+const API_BASE = (import.meta?.env?.VITE_API_BASE || (import.meta?.env?.BASE_URL || '/').replace(/\/$/, '')).replace(/\/$/, '')
 
 async function fetchLatestIndices() {
   const res = await fetch(`${API_BASE}/api/indices/latest`, {

--- a/frontend/web/src/components/LogTerminal.jsx
+++ b/frontend/web/src/components/LogTerminal.jsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 
-const DEFAULT_API_BASE = (typeof window !== 'undefined' && window.location.hostname.includes('tail'))
-  ? `https://${window.location.hostname}:8080`
-  : 'http://localhost:8080'
+const DEFAULT_API_BASE = (import.meta?.env?.VITE_API_BASE || (import.meta?.env?.BASE_URL || '/').replace(/\/$/, '')).replace(/\/$/, '')
 
 import { getToken } from '../lib/auth'
 

--- a/frontend/web/src/layouts/DashboardLayout.jsx
+++ b/frontend/web/src/layouts/DashboardLayout.jsx
@@ -121,7 +121,7 @@ export default function DashboardLayout({ variantSwitcher }) {
           <footer className="mt-10 border-t border-[rgb(var(--border))] pt-6 text-xs text-[rgb(var(--muted))]">
             Sprint 1 · API:{' '}
             <code className="text-[rgb(var(--text))]">
-              {(import.meta?.env?.VITE_API_BASE || 'http://localhost:8080').replace(/\/$/, '')}/api/portfolio/positions
+              {(import.meta?.env?.VITE_API_BASE || (import.meta?.env?.BASE_URL || '/')).replace(/\/$/, '')}/api/portfolio/positions
             </code>
           </footer>
         </main>

--- a/frontend/web/src/pages/Dashboard.jsx
+++ b/frontend/web/src/pages/Dashboard.jsx
@@ -18,7 +18,7 @@ async function fetchIndices() {
 }
 
 async function fetchPortfolioSummary() {
-  const res = await authFetch(`${getApiBase()}/api/portfolio/summary`)
+  const res = await authFetch(`${getApiBase()}/api/portfolio/kpis`)
   if (!res.ok) throw new Error(`投組摘要載入失敗 (${res.status})`)
   return res.json()
 }

--- a/frontend/web/vite.config.js
+++ b/frontend/web/vite.config.js
@@ -12,10 +12,23 @@ const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 const BACKEND = 'https://127.0.0.1:8080'
 
 const proxyConfig = {
+  '/ai-trader/api': {
+    target: BACKEND,
+    changeOrigin: true,
+    secure: false,
+    rewrite: (path) => path.replace(/^\/ai-trader/, ''),
+  },
   '/api': {
     target: BACKEND,
     changeOrigin: true,
     secure: false,          // accept self-signed cert on loopback
+  },
+  '/ai-trader/ws': {
+    target: BACKEND.replace('https', 'wss'),
+    changeOrigin: true,
+    secure: false,
+    ws: true,
+    rewrite: (path) => path.replace(/^\/ai-trader/, ''),
   },
   '/ws': {
     target: BACKEND.replace('https', 'wss'),


### PR DESCRIPTION
## Summary
- `/api/portfolio/summary` (404) → `/api/portfolio/kpis`
- GlobalTicker/LogTerminal: 移除 hardcoded `localhost:8080`，改用 `BASE_URL` proxy
- vite.config.js: 新增 `/ai-trader/api` proxy rewrite

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)